### PR TITLE
feat: implement list_threads and fetch_messages via GraphQL messaging API

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -126,32 +126,32 @@ def sync_account(body: SyncIn):
         proxy = storage.get_account_proxy(body.account_id)
     except KeyError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    provider = LinkedInProvider(auth=auth, proxy=proxy)
-    try:
-        result: SyncResult = run_sync(
-            account_id=body.account_id,
-            storage=storage,
-            provider=provider,
-            limit_per_thread=body.limit_per_thread,
-            max_pages_per_thread=body.max_pages_per_thread,
-        )
-        return {
-            "ok": True,
-            "synced_threads": result.synced_threads,
-            "messages_inserted": result.messages_inserted,
-            "messages_skipped_duplicate": result.messages_skipped_duplicate,
-            "pages_fetched": result.pages_fetched,
-        }
-    except NotImplementedError:
-        raise HTTPException(
-            status_code=501,
-            detail="Provider not implemented. Implement libs/providers/linkedin/provider.py",
-        ) from None
-    except httpx.HTTPStatusError as exc:
-        code = exc.response.status_code
-        if code in (301, 302, 303, 307, 308):
-            raise HTTPException(status_code=401, detail=str(exc)) from None
-        raise HTTPException(status_code=502, detail=str(exc)) from None
+    with LinkedInProvider(auth=auth, proxy=proxy) as provider:
+        try:
+            result: SyncResult = run_sync(
+                account_id=body.account_id,
+                storage=storage,
+                provider=provider,
+                limit_per_thread=body.limit_per_thread,
+                max_pages_per_thread=body.max_pages_per_thread,
+            )
+            return {
+                "ok": True,
+                "synced_threads": result.synced_threads,
+                "messages_inserted": result.messages_inserted,
+                "messages_skipped_duplicate": result.messages_skipped_duplicate,
+                "pages_fetched": result.pages_fetched,
+            }
+        except NotImplementedError:
+            raise HTTPException(
+                status_code=501,
+                detail="Provider not implemented. Implement libs/providers/linkedin/provider.py",
+            ) from None
+        except httpx.HTTPStatusError as exc:
+            code = exc.response.status_code
+            if code in (301, 302, 303, 307, 308):
+                raise HTTPException(status_code=401, detail=str(exc)) from None
+            raise HTTPException(status_code=502, detail=str(exc)) from None
 
 
 @app.post("/send")
@@ -161,19 +161,19 @@ def send_message(body: SendIn):
         proxy = storage.get_account_proxy(body.account_id)
     except KeyError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    provider = LinkedInProvider(auth=auth, proxy=proxy)
-    try:
-        platform_message_id = run_send(
-            account_id=body.account_id,
-            storage=storage,
-            provider=provider,
-            recipient=body.recipient,
-            text=body.text,
-            idempotency_key=body.idempotency_key,
-        )
-        return {"ok": True, "platform_message_id": platform_message_id}
-    except NotImplementedError:
-        raise HTTPException(
-            status_code=501,
-            detail="Provider not implemented. Implement libs/providers/linkedin/provider.py",
-        ) from None
+    with LinkedInProvider(auth=auth, proxy=proxy) as provider:
+        try:
+            platform_message_id = run_send(
+                account_id=body.account_id,
+                storage=storage,
+                provider=provider,
+                recipient=body.recipient,
+                text=body.text,
+                idempotency_key=body.idempotency_key,
+            )
+            return {"ok": True, "platform_message_id": platform_message_id}
+        except NotImplementedError:
+            raise HTTPException(
+                status_code=501,
+                detail="Provider not implemented. Implement libs/providers/linkedin/provider.py",
+            ) from None

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
 from libs.core.cookies import cookies_to_account_auth, validate_li_at
-from libs.core.job_runner import run_send, run_sync, SyncResult
+from libs.core.job_runner import SyncResult, run_send, run_sync
 from libs.core.models import AccountAuth, ProxyConfig
 from libs.core.redaction import configure_logging, redact_for_log
 from libs.core.storage import Storage
@@ -30,7 +30,10 @@ class AuthCheckResponse(BaseModel):
 
 class AccountCreateIn(BaseModel):
     label: str = Field(..., description="Human label, e.g. 'sales-1'")
-    li_at: str | None = Field(None, description="LinkedIn li_at cookie value (required if cookies not provided)")
+    li_at: str | None = Field(
+        None,
+        description="LinkedIn li_at cookie value (required if cookies not provided)",
+    )
     jsessionid: str | None = Field(None, description="Optional JSESSIONID cookie value")
     cookies: str | None = Field(
         None,
@@ -47,12 +50,16 @@ class AccountCreateIn(BaseModel):
     def to_account_auth(self) -> AccountAuth:
         if self.cookies:
             return cookies_to_account_auth(self.cookies)
-        return AccountAuth(li_at=validate_li_at(self.li_at or ""), jsessionid=self.jsessionid)
+        return AccountAuth(
+            li_at=validate_li_at(self.li_at or ""), jsessionid=self.jsessionid
+        )
 
 
 class SendIn(BaseModel):
     account_id: int
-    recipient: str = Field(..., min_length=1, description="Recipient id (profile URN or conversation id)")
+    recipient: str = Field(
+        ..., min_length=1, description="Recipient id (profile URN or conversation id)"
+    )
     text: str = Field(..., min_length=1, max_length=8000, description="Message body")
     idempotency_key: str | None = None
 
@@ -81,7 +88,10 @@ def create_account(body: AccountCreateIn):
         raise HTTPException(status_code=422, detail=str(exc))
     proxy = ProxyConfig(url=body.proxy_url) if body.proxy_url else None
     account_id = storage.create_account(label=body.label, auth=auth, proxy=proxy)
-    logger.info("Account created: %s", redact_for_log({"account_id": account_id, "label": body.label}))
+    logger.info(
+        "Account created: %s",
+        redact_for_log({"account_id": account_id, "label": body.label}),
+    )
     return {"account_id": account_id}
 
 
@@ -136,6 +146,15 @@ def sync_account(body: SyncIn):
             status_code=501,
             detail="Provider not implemented. Implement libs/providers/linkedin/provider.py",
         ) from None
+    except Exception as exc:
+        import httpx as _httpx
+
+        if isinstance(exc, _httpx.HTTPStatusError):
+            code = exc.response.status_code
+            if code in (301, 302, 303, 307, 308):
+                raise HTTPException(status_code=401, detail=str(exc)) from None
+            raise HTTPException(status_code=502, detail=str(exc)) from None
+        raise
 
 
 @app.post("/send")

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
+import httpx
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
@@ -146,15 +147,11 @@ def sync_account(body: SyncIn):
             status_code=501,
             detail="Provider not implemented. Implement libs/providers/linkedin/provider.py",
         ) from None
-    except Exception as exc:
-        import httpx as _httpx
-
-        if isinstance(exc, _httpx.HTTPStatusError):
-            code = exc.response.status_code
-            if code in (301, 302, 303, 307, 308):
-                raise HTTPException(status_code=401, detail=str(exc)) from None
-            raise HTTPException(status_code=502, detail=str(exc)) from None
-        raise
+    except httpx.HTTPStatusError as exc:
+        code = exc.response.status_code
+        if code in (301, 302, 303, 307, 308):
+            raise HTTPException(status_code=401, detail=str(exc)) from None
+        raise HTTPException(status_code=502, detail=str(exc)) from None
 
 
 @app.post("/send")

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -67,7 +67,7 @@ class SendIn(BaseModel):
 
 class SyncIn(BaseModel):
     account_id: int
-    limit_per_thread: int = Field(50, ge=1, le=500, description="Messages per page")
+    limit_per_thread: int = Field(50, ge=1, le=200, description="Messages per page")
     max_pages_per_thread: int | None = Field(
         1,
         ge=1,

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -82,6 +82,14 @@ _DEFAULT_COUNT = 20
 # Safety limit to prevent runaway pagination on very large inboxes
 _MAX_PAGES = 50  # 50 * 20 = 1000 threads max
 
+# Retry configuration for transient errors (429 rate-limit, 5xx server errors)
+_RETRY_MAX_ATTEMPTS = 3
+_RETRY_BASE_DELAY_S = 2.0
+_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+# Rate limiting: pause between pagination requests to avoid triggering LinkedIn's limiter
+_DELAY_BETWEEN_PAGES_S = 1.5
+
 
 def _discover_query_ids(
     cookies: dict[str, str],
@@ -483,6 +491,33 @@ class LinkedInProvider:
     def __init__(self, *, auth: AccountAuth, proxy: Optional[ProxyConfig] = None):
         self.auth = auth
         self.proxy = proxy
+        self._client: Optional[httpx.Client] = None
+
+    # -- lifecycle ------------------------------------------------------------
+
+    def _get_client(self) -> httpx.Client:
+        """Return a reusable httpx.Client (lazy-initialized)."""
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.Client(
+                proxy=self._get_proxy_url(),
+                timeout=30.0,
+                follow_redirects=False,
+            )
+        return self._client
+
+    def close(self) -> None:
+        """Close the underlying HTTP client. Safe to call multiple times."""
+        if self._client is not None and not self._client.is_closed:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> LinkedInProvider:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    # -- header / cookie builders --------------------------------------------
 
     def _build_headers(
         self, *, accept: str = "application/vnd.linkedin.normalized+json+2.1"
@@ -532,6 +567,45 @@ class LinkedInProvider:
                 body_preview,
             )
             resp.raise_for_status()
+
+    def _get_with_retry(
+        self, client: httpx.Client, url: str, **kwargs: Any
+    ) -> httpx.Response:
+        """GET with retry on transient errors (429, 5xx).
+
+        Exponential backoff: 2s, 4s, 8s.  Honours Retry-After on 429.
+        Non-retryable status codes are returned immediately for the caller
+        to handle via _check_response().
+        """
+        last_exc: Optional[httpx.HTTPStatusError] = None
+        for attempt in range(_RETRY_MAX_ATTEMPTS):
+            resp = client.get(url, **kwargs)
+            if resp.status_code not in _RETRYABLE_STATUS_CODES:
+                return resp
+            last_exc = httpx.HTTPStatusError(
+                str(resp.status_code),
+                request=resp.request,
+                response=resp,
+            )
+            if attempt == _RETRY_MAX_ATTEMPTS - 1:
+                break
+            delay = _RETRY_BASE_DELAY_S * (2 ** attempt)
+            if resp.status_code == 429:
+                retry_after = resp.headers.get("Retry-After")
+                if retry_after:
+                    try:
+                        delay = max(delay, float(retry_after))
+                    except (TypeError, ValueError):
+                        pass
+            logger.debug(
+                "Retrying: %d from LinkedIn, attempt %d/%d, waiting %.1fs",
+                resp.status_code,
+                attempt + 1,
+                _RETRY_MAX_ATTEMPTS,
+                delay,
+            )
+            time.sleep(delay)
+        raise last_exc  # type: ignore[misc]
 
     def _resolve_profile_urn(
         self, client: httpx.Client, cookies: dict[str, str]
@@ -593,7 +667,9 @@ class LinkedInProvider:
         """Fetch all DM conversation threads via LinkedIn's GraphQL messaging API.
 
         Uses the voyagerMessagingGraphQL endpoint with cursor-based pagination
-        (lastUpdatedBefore timestamp).
+        (lastUpdatedBefore timestamp).  Deduplicates threads across pages.
+        Retries transient errors (429, 5xx) with exponential backoff.
+        Sleeps between pages to avoid triggering LinkedIn's rate limiter.
         """
         if not self.auth.jsessionid:
             raise ValueError(
@@ -603,56 +679,56 @@ class LinkedInProvider:
 
         headers = self._build_headers(accept="application/graphql")
         cookies = self._build_cookies()
-        proxy_url = self._get_proxy_url()
 
-        conv_query_id, _ = _discover_query_ids(cookies, headers, proxy_url)
+        conv_query_id, _ = _discover_query_ids(
+            cookies, headers, self._get_proxy_url()
+        )
+
+        client = self._get_client()
+        mailbox_urn = self._resolve_profile_urn(client, cookies)
+        logger.info("Resolved mailbox URN: %s", mailbox_urn)
 
         all_threads: list[LinkedInThread] = []
+        seen_urns: set[str] = set()
+        encoded_urn = quote(mailbox_urn, safe="")
+        last_activity_before = int(time.time() * 1000)
         page = 0
 
-        with httpx.Client(
-            proxy=proxy_url,
-            timeout=30.0,
-            follow_redirects=False,
-        ) as client:
-            mailbox_urn = self._resolve_profile_urn(client, cookies)
-            logger.info("Resolved mailbox URN: %s", mailbox_urn)
+        while page < _MAX_PAGES:
+            variables = (
+                f"(query:(predicateUnions:List("
+                f"(conversationCategoryPredicate:(category:PRIMARY_INBOX)))),"
+                f"count:{_DEFAULT_COUNT},"
+                f"mailboxUrn:{encoded_urn},"
+                f"lastUpdatedBefore:{last_activity_before})"
+            )
+            full_url = (
+                f"{_GRAPHQL_MSG_URL}?queryId={conv_query_id}&variables={variables}"
+            )
+            resp = self._get_with_retry(
+                client, full_url, headers=headers, cookies=cookies
+            )
+            self._check_response(resp)
+            data = resp.json()
+            page_threads = _parse_graphql_threads(data)
+            if not page_threads:
+                break
 
-            encoded_urn = quote(mailbox_urn, safe="")
-            last_activity_before = int(time.time() * 1000)
+            for t in page_threads:
+                if t.platform_thread_id not in seen_urns:
+                    seen_urns.add(t.platform_thread_id)
+                    all_threads.append(t)
 
-            while page < _MAX_PAGES:
-                variables = (
-                    f"(query:(predicateUnions:List("
-                    f"(conversationCategoryPredicate:(category:PRIMARY_INBOX)))),"
-                    f"count:{_DEFAULT_COUNT},"
-                    f"mailboxUrn:{encoded_urn},"
-                    f"lastUpdatedBefore:{last_activity_before})"
-                )
-                full_url = (
-                    f"{_GRAPHQL_MSG_URL}?queryId={conv_query_id}&variables={variables}"
-                )
-                resp = client.get(
-                    full_url,
-                    headers=headers,
-                    cookies=cookies,
-                )
-                self._check_response(resp)
-                data = resp.json()
-                page_threads = _parse_graphql_threads(data)
-                if not page_threads:
-                    break
-                all_threads.extend(page_threads)
+            if len(page_threads) < _DEFAULT_COUNT:
+                break
 
-                if len(page_threads) < _DEFAULT_COUNT:
-                    break
+            oldest_ts = _get_oldest_timestamp(data)
+            if oldest_ts is None or oldest_ts >= last_activity_before:
+                break
+            last_activity_before = oldest_ts
 
-                oldest_ts = _get_oldest_timestamp(data)
-                if oldest_ts is None or oldest_ts >= last_activity_before:
-                    break
-                last_activity_before = oldest_ts
-
-                page += 1
+            time.sleep(_DELAY_BETWEEN_PAGES_S)
+            page += 1
 
         if page >= _MAX_PAGES:
             logger.warning(
@@ -675,19 +751,25 @@ class LinkedInProvider:
         Args:
           platform_thread_id: conversation URN from list_threads
           cursor: opaque syncToken from a previous call (None = initial fetch)
-          limit: unused for this endpoint (LinkedIn controls page size)
+          limit: maximum number of messages to request (1–200)
 
         Returns:
           (messages, next_cursor) where next_cursor is a syncToken or None.
+
+        Raises:
+          ValueError: If JSESSIONID is missing or limit is out of range.
         """
         if not self.auth.jsessionid:
             raise ValueError("JSESSIONID is required for LinkedIn API requests.")
+        if limit < 1 or limit > 200:
+            raise ValueError(f"limit must be between 1 and 200, got {limit}")
 
         headers = self._build_headers(accept="application/graphql")
         cookies = self._build_cookies()
-        proxy_url = self._get_proxy_url()
 
-        _, msg_query_id = _discover_query_ids(cookies, headers, proxy_url)
+        _, msg_query_id = _discover_query_ids(
+            cookies, headers, self._get_proxy_url()
+        )
 
         encoded_conv = quote(platform_thread_id, safe="")
 
@@ -699,14 +781,12 @@ class LinkedInProvider:
 
         full_url = f"{_GRAPHQL_MSG_URL}?queryId={msg_query_id}&variables={variables}"
 
-        with httpx.Client(
-            proxy=proxy_url,
-            timeout=30.0,
-            follow_redirects=False,
-        ) as client:
-            resp = client.get(full_url, headers=headers, cookies=cookies)
-            self._check_response(resp)
-            data = resp.json()
+        client = self._get_client()
+        resp = self._get_with_retry(
+            client, full_url, headers=headers, cookies=cookies
+        )
+        self._check_response(resp)
+        data = resp.json()
 
         messages, next_cursor = _parse_graphql_messages(data, platform_thread_id)
         return messages, next_cursor

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -415,10 +415,12 @@ def _parse_graphql_messages(
         next_cursor = sync_token
 
     messages: list[LinkedInMessage] = []
+    seen_ids: set[str] = set()
     for elem in elements:
         msg_urn = elem.get("entityUrn", elem.get("backendUrn", ""))
-        if not msg_urn:
+        if not msg_urn or msg_urn in seen_ids:
             continue
+        seen_ids.add(msg_urn)
 
         body = elem.get("body", {})
         text = (
@@ -709,7 +711,11 @@ class LinkedInProvider:
                 client, full_url, headers=headers, cookies=cookies
             )
             self._check_response(resp)
-            data = resp.json()
+            try:
+                data = resp.json()
+            except (json.JSONDecodeError, ValueError):
+                logger.debug("list_threads: non-JSON response on page %d", page)
+                break
             page_threads = _parse_graphql_threads(data)
             if not page_threads:
                 break
@@ -786,7 +792,13 @@ class LinkedInProvider:
             client, full_url, headers=headers, cookies=cookies
         )
         self._check_response(resp)
-        data = resp.json()
+        try:
+            data = resp.json()
+        except (json.JSONDecodeError, ValueError):
+            logger.debug(
+                "fetch_messages: non-JSON response for %s", platform_thread_id
+            )
+            return [], None
 
         messages, next_cursor = _parse_graphql_messages(data, platform_thread_id)
         return messages, next_cursor

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
+from urllib.parse import quote
 
 import httpx
 
@@ -15,22 +17,45 @@ logger = logging.getLogger(__name__)
 # LinkedIn internal API base
 _VOYAGER_BASE = "https://www.linkedin.com/voyager/api"
 
-# Headers that LinkedIn requires on every Voyager request.
-# Without these you get 403 or status 999.
+# GraphQL messaging endpoint (separate from the REST-li /graphql path)
+_GRAPHQL_MSG_URL = f"{_VOYAGER_BASE}/voyagerMessagingGraphQL/graphql"
+
+# queryId used by the LinkedIn web-app for listing conversations
+_CONVERSATIONS_QUERY_ID = "messengerConversations.9501074288a12f3ae9e3c7ea243bccbf"
+
+# queryId for fetching messages within a conversation
+_MESSAGES_QUERY_ID = "messengerMessages.5846eeb71c981f11e0134cb6626cc314"
+
 _STATIC_HEADERS = {
     "user-agent": (
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/145.0.0.0 Safari/537.36"
     ),
-    "accept": "application/vnd.linkedin.normalized+json+2.1",
+    "accept-language": "en-US,en;q=0.9",
     "x-restli-protocol-version": "2.0.0",
-    "x-li-track": json.dumps({
-        "clientVersion": "1.13.8953",
-        "osName": "web",
-        "timezoneOffset": 4,
-        "deviceFormFactor": "DESKTOP",
-    }),
+    "x-li-lang": "en_US",
+    "x-li-track": json.dumps(
+        {
+            "clientVersion": "1.13.42849",
+            "mpVersion": "1.13.42849",
+            "osName": "web",
+            "timezoneOffset": -4,
+            "timezone": "America/New_York",
+            "deviceFormFactor": "DESKTOP",
+            "mpName": "voyager-web",
+            "displayDensity": 1.25,
+            "displayWidth": 1920,
+            "displayHeight": 1080,
+        }
+    ),
     "x-li-page-instance": "urn:li:page:d_flagship3_messaging",
+    "sec-ch-ua": '"Not:A-Brand";v="99", "Google Chrome";v="145", "Chromium";v="145"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"Windows"',
+    "sec-fetch-dest": "empty",
+    "sec-fetch-mode": "cors",
+    "sec-fetch-site": "same-origin",
 }
 
 # Default page size for conversation listing
@@ -63,14 +88,15 @@ class AuthCheckResult:
     error: Optional[str] = None
 
 
-def _extract_thread_title(element: dict[str, Any], included: list[dict[str, Any]]) -> Optional[str]:
+def _extract_thread_title(
+    element: dict[str, Any], included: list[dict[str, Any]]
+) -> Optional[str]:
     """Try to build a human-readable title from conversation participants.
 
     LinkedIn stores participant references in the conversation element and
     resolves them in the top-level 'included' array. We look for miniProfile
     entities that match this conversation's participants.
     """
-    # Collect participant URNs from the conversation element
     participant_urns: list[str] = []
     for p in element.get("participants", []):
         urn = (
@@ -84,7 +110,6 @@ def _extract_thread_title(element: dict[str, Any], included: list[dict[str, Any]
     if not participant_urns:
         return None
 
-    # Match against included miniProfile entities
     names: list[str] = []
     for inc in included:
         entity_urn = inc.get("entityUrn", "")
@@ -100,7 +125,7 @@ def _extract_thread_title(element: dict[str, Any], included: list[dict[str, Any]
 
 
 def _parse_threads(data: dict[str, Any]) -> list[LinkedInThread]:
-    """Parse the Voyager conversations response into LinkedInThread objects."""
+    """Parse the legacy Voyager conversations response into LinkedInThread objects."""
     elements = data.get("elements", [])
     included = data.get("included", [])
     threads: list[LinkedInThread] = []
@@ -109,12 +134,191 @@ def _parse_threads(data: dict[str, Any]) -> list[LinkedInThread]:
         if not entity_urn:
             continue
         title = _extract_thread_title(elem, included)
-        threads.append(LinkedInThread(
-            platform_thread_id=entity_urn,
-            title=title,
-            raw=elem,
-        ))
+        threads.append(
+            LinkedInThread(
+                platform_thread_id=entity_urn,
+                title=title,
+                raw=elem,
+            )
+        )
     return threads
+
+
+_CONVERSATIONS_RESPONSE_KEYS = (
+    "messengerConversationsByCategoryQuery",
+    "messengerConversationsByCriteria",
+    "messengerConversationsByLastActivity",
+    "messengerConversations",
+)
+
+
+def _find_elements(data: dict[str, Any]) -> tuple[list[Any], dict[str, Any]]:
+    """Locate the elements list and metadata from a GraphQL conversations response."""
+    result = data
+    if "data" in result and isinstance(result["data"], dict):
+        result = result["data"]
+
+    for key in _CONVERSATIONS_RESPONSE_KEYS:
+        if key in result and isinstance(result[key], dict):
+            container = result[key]
+            return container.get("elements", []), container.get("metadata", {})
+
+    return result.get("elements", []), {}
+
+
+def _parse_graphql_threads(data: dict[str, Any]) -> list[LinkedInThread]:
+    """Parse the GraphQL messengerConversations response.
+
+    The response shape:
+      data.messengerConversationsByCategoryQuery.elements[]
+    Each element contains conversationParticipants, entityUrn, lastActivityAt, etc.
+    """
+    threads: list[LinkedInThread] = []
+    elements, _ = _find_elements(data)
+
+    for elem in elements:
+        conv = elem if "entityUrn" in elem else elem.get("conversation", elem)
+        entity_urn = conv.get("entityUrn", conv.get("conversationUrn", ""))
+        if not entity_urn:
+            continue
+
+        title = _extract_graphql_title(conv)
+        threads.append(
+            LinkedInThread(
+                platform_thread_id=entity_urn,
+                title=title,
+                raw=elem,
+            )
+        )
+    return threads
+
+
+def _extract_graphql_title(conv: dict[str, Any]) -> Optional[str]:
+    """Extract participant names from a GraphQL conversation object."""
+    names: list[str] = []
+
+    participants = conv.get("conversationParticipants", conv.get("participants", []))
+    for p in participants:
+        profile = p.get("participantProfile", p.get("profile", p))
+        first = profile.get("firstName", "")
+        last = profile.get("lastName", "")
+        full = f"{first} {last}".strip()
+        if full:
+            names.append(full)
+
+    if not names:
+        title = conv.get("title", None)
+        if title:
+            return title
+
+    return ", ".join(names) if names else None
+
+
+def _get_oldest_timestamp(data: dict[str, Any]) -> Optional[int]:
+    """Extract the oldest lastActivityAt timestamp for cursor-based pagination."""
+    elements, _ = _find_elements(data)
+    if not elements:
+        return None
+
+    oldest = None
+    for elem in elements:
+        conv = elem if "lastActivityAt" in elem else elem.get("conversation", elem)
+        ts = conv.get("lastActivityAt")
+        if ts is not None:
+            if oldest is None or ts < oldest:
+                oldest = ts
+    return oldest
+
+
+def _parse_graphql_messages(
+    data: dict[str, Any], conversation_urn: str
+) -> tuple[list[LinkedInMessage], Optional[str]]:
+    """Parse the GraphQL messengerMessages response into LinkedInMessage objects.
+
+    Returns (messages_list, next_sync_token).
+    """
+    result = data
+    if "data" in result and isinstance(result["data"], dict):
+        result = result["data"]
+
+    container: dict[str, Any] = {}
+    for key in (
+        "messengerMessagesBySyncToken",
+        "messengerMessages",
+        "messengerMessagesByConversation",
+    ):
+        if key in result and isinstance(result[key], dict):
+            container = result[key]
+            break
+    if not container:
+        container = result
+
+    elements = container.get("elements", [])
+
+    next_cursor: Optional[str] = None
+    metadata = container.get("metadata", {})
+    sync_token = metadata.get("syncToken")
+    if sync_token:
+        next_cursor = sync_token
+
+    messages: list[LinkedInMessage] = []
+    for elem in elements:
+        msg_urn = elem.get("entityUrn", elem.get("backendUrn", ""))
+        if not msg_urn:
+            continue
+
+        body = elem.get("body", {})
+        text = (
+            body.get("text", "")
+            if isinstance(body, dict)
+            else str(body)
+            if body
+            else ""
+        )
+
+        sender_profile = elem.get("sender", {})
+        sender_urn = ""
+        if isinstance(sender_profile, dict):
+            sender_urn = sender_profile.get("entityUrn", "")
+            if not sender_urn:
+                member = sender_profile.get(
+                    "member", sender_profile.get("participantProfile", {})
+                )
+                if isinstance(member, dict):
+                    sender_urn = member.get("entityUrn", "")
+                elif isinstance(member, str):
+                    sender_urn = member
+
+        delivered_at = elem.get("deliveredAt", 0)
+        if delivered_at:
+            sent_at = datetime.fromtimestamp(delivered_at / 1000, tz=timezone.utc)
+        else:
+            sent_at = datetime.now(timezone.utc)
+
+        direction = "in"
+        if sender_urn and conversation_urn:
+            conv_profile = ""
+            if "fsd_profile:" in conversation_urn:
+                parts = conversation_urn.split("fsd_profile:")
+                if len(parts) >= 2:
+                    conv_profile = parts[1].split(",")[0].rstrip(")")
+            sender_id = sender_urn.split(":")[-1] if ":" in sender_urn else sender_urn
+            if conv_profile and sender_id == conv_profile:
+                direction = "out"
+
+        messages.append(
+            LinkedInMessage(
+                platform_message_id=msg_urn,
+                direction=direction,
+                sender=sender_urn or None,
+                text=text or None,
+                sent_at=sent_at,
+                raw=elem,
+            )
+        )
+
+    messages.sort(key=lambda m: m.sent_at)
+    return messages, next_cursor
 
 
 class LinkedInProvider:
@@ -135,12 +339,13 @@ class LinkedInProvider:
         self.auth = auth
         self.proxy = proxy
 
-    def _build_headers(self) -> dict[str, str]:
+    def _build_headers(
+        self, *, accept: str = "application/vnd.linkedin.normalized+json+2.1"
+    ) -> dict[str, str]:
         """Build request headers including the CSRF token from JSESSIONID."""
         headers = dict(_STATIC_HEADERS)
+        headers["accept"] = accept
         if self.auth.jsessionid:
-            # LinkedIn expects csrf-token WITHOUT surrounding quotes,
-            # even though the JSESSIONID cookie value includes them.
             headers["csrf-token"] = self.auth.jsessionid.strip('"')
         return headers
 
@@ -154,11 +359,96 @@ class LinkedInProvider:
     def _get_proxy_url(self) -> Optional[str]:
         return self.proxy.url if self.proxy else None
 
-    def list_threads(self) -> list[LinkedInThread]:
-        """Fetch all DM conversation threads with pagination.
+    @staticmethod
+    def _check_response(resp: httpx.Response) -> None:
+        """Inspect a Voyager response and raise a clear error on failure.
 
-        Calls the Voyager conversations endpoint, page by page, until
-        LinkedIn returns fewer results than the requested count.
+        LinkedIn returns different status codes depending on the failure mode:
+          302 — session expired / cookies invalid (redirect to login)
+          401/403 — auth rejected
+          500 — can indicate downstream auth-verification failure, or
+                a genuine server bug.  Log the body so we can diagnose.
+        """
+        if resp.is_redirect:
+            location = resp.headers.get("location", "")
+            raise httpx.HTTPStatusError(
+                f"LinkedIn returned {resp.status_code} redirect to {location!r}. "
+                "Session cookies are expired or invalid — log in again and "
+                "re-create the account with fresh li_at / JSESSIONID values.",
+                request=resp.request,
+                response=resp,
+            )
+        if resp.status_code >= 400:
+            body_preview = resp.text[:500] if resp.text else "<empty>"
+            logger.error(
+                "LinkedIn API error %d on %s — body: %s",
+                resp.status_code,
+                resp.request.url,
+                body_preview,
+            )
+            resp.raise_for_status()
+
+    def _resolve_profile_urn(
+        self, client: httpx.Client, cookies: dict[str, str]
+    ) -> str:
+        """Call /me to get the logged-in user's fsd_profile URN (mailboxUrn).
+
+        The /me endpoint returns a normalized JSON response with shape:
+            {"data": {"*miniProfile": "urn:li:fs_miniProfile:...", ...}, "included": [...]}
+        The included array contains the full miniProfile object with entityUrn
+        and dashEntityUrn fields.
+        """
+        headers = self._build_headers()
+        resp = client.get(
+            f"{_VOYAGER_BASE}/me",
+            headers=headers,
+            cookies=cookies,
+        )
+        self._check_response(resp)
+        body = resp.json()
+
+        urn = ""
+
+        top_data = body if "entityUrn" in body else body.get("data", {})
+        if isinstance(top_data, dict):
+            urn = top_data.get("entityUrn", "")
+            if not urn:
+                mini_ref = top_data.get("*miniProfile", "")
+                if mini_ref:
+                    urn = mini_ref
+
+        if not urn:
+            for inc in body.get("included", []):
+                candidate = inc.get("dashEntityUrn", "") or inc.get("entityUrn", "")
+                if "fsd_profile" in candidate:
+                    urn = candidate
+                    break
+                if "fs_miniProfile" in candidate or "member" in candidate:
+                    urn = candidate
+
+        for prefix in (
+            "urn:li:fs_miniProfile:",
+            "urn:li:fsd_profile:",
+            "urn:li:member:",
+        ):
+            if urn.startswith(prefix):
+                member_id = urn[len(prefix) :]
+                return f"urn:li:fsd_profile:{member_id}"
+
+        if urn:
+            logger.warning("Unexpected URN format from /me: %r", urn)
+            return urn
+
+        raise ValueError(
+            "Could not extract profile URN from /me response. "
+            f"Top-level keys: {list(body.keys())}"
+        )
+
+    def list_threads(self) -> list[LinkedInThread]:
+        """Fetch all DM conversation threads via LinkedIn's GraphQL messaging API.
+
+        Uses the voyagerMessagingGraphQL endpoint with cursor-based pagination
+        (lastUpdatedBefore timestamp).
         """
         if not self.auth.jsessionid:
             raise ValueError(
@@ -166,52 +456,66 @@ class LinkedInProvider:
                 "Re-create the account with both li_at and JSESSIONID cookies."
             )
 
-        headers = self._build_headers()
+        headers = self._build_headers(accept="application/graphql")
         cookies = self._build_cookies()
         proxy_url = self._get_proxy_url()
 
         all_threads: list[LinkedInThread] = []
-        start = 0
         page = 0
 
-        with httpx.Client(proxy=proxy_url, timeout=30.0) as client:
+        with httpx.Client(
+            proxy=proxy_url,
+            timeout=30.0,
+            follow_redirects=False,
+        ) as client:
+            mailbox_urn = self._resolve_profile_urn(client, cookies)
+            logger.info("Resolved mailbox URN: %s", mailbox_urn)
+
+            last_activity_before = int(time.time() * 1000)
+
             while page < _MAX_PAGES:
+                encoded_urn = quote(mailbox_urn, safe="")
+                variables = (
+                    f"(query:(predicateUnions:List("
+                    f"(conversationCategoryPredicate:(category:PRIMARY_INBOX)))),"
+                    f"count:{_DEFAULT_COUNT},"
+                    f"mailboxUrn:{encoded_urn},"
+                    f"lastUpdatedBefore:{last_activity_before})"
+                )
+                full_url = (
+                    f"{_GRAPHQL_MSG_URL}"
+                    f"?queryId={_CONVERSATIONS_QUERY_ID}"
+                    f"&variables={variables}"
+                )
                 resp = client.get(
-                    f"{_VOYAGER_BASE}/messaging/conversations",
-                    params={
-                        "keyVersion": "LEGACY_INBOX",
-                        "q": "participants",
-                        "start": start,
-                        "count": _DEFAULT_COUNT,
-                    },
+                    full_url,
                     headers=headers,
                     cookies=cookies,
                 )
-                resp.raise_for_status()
+                self._check_response(resp)
                 data = resp.json()
-                page_threads = _parse_threads(data)
+                page_threads = _parse_graphql_threads(data)
+                if not page_threads:
+                    break
                 all_threads.extend(page_threads)
 
-                # Stop when we got fewer than a full page (last page)
-                paging = data.get("paging", {})
-                returned = len(data.get("elements", []))
-                total = paging.get("total")
-
-                if returned < _DEFAULT_COUNT:
-                    break
-                # If LinkedIn tells us the total, stop when we've seen them all
-                if total is not None and start + returned >= total:
+                if len(page_threads) < _DEFAULT_COUNT:
                     break
 
-                start += _DEFAULT_COUNT
+                oldest_ts = _get_oldest_timestamp(data)
+                if oldest_ts is None or oldest_ts >= last_activity_before:
+                    break
+                last_activity_before = oldest_ts
+
                 page += 1
 
         if page >= _MAX_PAGES:
             logger.warning(
                 "Reached max page limit (%d); %d threads fetched — some threads may be missing",
-                _MAX_PAGES, len(all_threads),
+                _MAX_PAGES,
+                len(all_threads),
             )
-        logger.info("Fetched %d threads across %d pages", len(all_threads), page)
+        logger.info("Fetched %d threads across %d pages", len(all_threads), page + 1)
         return all_threads
 
     def fetch_messages(
@@ -221,19 +525,46 @@ class LinkedInProvider:
         cursor: Optional[str],
         limit: int = 50,
     ) -> tuple[list[LinkedInMessage], Optional[str]]:
-        """Fetch messages for a thread incrementally.
+        """Fetch messages for a conversation via the GraphQL messengerMessages endpoint.
 
         Args:
-          platform_thread_id: stable thread id
-          cursor: opaque provider cursor (None = start)
-          limit: max messages per call
+          platform_thread_id: conversation URN from list_threads
+          cursor: opaque syncToken from a previous call (None = initial fetch)
+          limit: unused for this endpoint (LinkedIn controls page size)
 
-        TODO (contributors):
-        - Decide cursor semantics (e.g. newest timestamp, message id, pagination token)
-        - Return messages in chronological order (oldest -> newest) if possible
-        - Return next_cursor to continue, or None if fully synced
+        Returns:
+          (messages, next_cursor) where next_cursor is a syncToken or None.
         """
-        raise NotImplementedError
+        if not self.auth.jsessionid:
+            raise ValueError("JSESSIONID is required for LinkedIn API requests.")
+
+        headers = self._build_headers(accept="application/graphql")
+        cookies = self._build_cookies()
+        proxy_url = self._get_proxy_url()
+
+        encoded_conv = quote(platform_thread_id, safe="")
+
+        if cursor:
+            encoded_cursor = quote(cursor, safe="")
+            variables = f"(conversationUrn:{encoded_conv},syncToken:{encoded_cursor})"
+        else:
+            variables = f"(conversationUrn:{encoded_conv})"
+
+        full_url = (
+            f"{_GRAPHQL_MSG_URL}?queryId={_MESSAGES_QUERY_ID}&variables={variables}"
+        )
+
+        with httpx.Client(
+            proxy=proxy_url,
+            timeout=30.0,
+            follow_redirects=False,
+        ) as client:
+            resp = client.get(full_url, headers=headers, cookies=cookies)
+            self._check_response(resp)
+            data = resp.json()
+
+        messages, next_cursor = _parse_graphql_messages(data, platform_thread_id)
+        return messages, next_cursor
 
     def send_message(
         self,

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -20,11 +22,27 @@ _VOYAGER_BASE = "https://www.linkedin.com/voyager/api"
 # GraphQL messaging endpoint (separate from the REST-li /graphql path)
 _GRAPHQL_MSG_URL = f"{_VOYAGER_BASE}/voyagerMessagingGraphQL/graphql"
 
-# queryId used by the LinkedIn web-app for listing conversations
-_CONVERSATIONS_QUERY_ID = "messengerConversations.9501074288a12f3ae9e3c7ea243bccbf"
+# Fallback queryIds — used when auto-detection from LinkedIn's JS bundles fails.
+# These are tied to a specific LinkedIn frontend build and will eventually go stale.
+_FALLBACK_CONVERSATIONS_QUERY_ID = (
+    "messengerConversations.9501074288a12f3ae9e3c7ea243bccbf"
+)
+_FALLBACK_MESSAGES_QUERY_ID = "messengerMessages.5846eeb71c981f11e0134cb6626cc314"
+# Regex patterns to extract queryId hashes from LinkedIn's compiled JS bundles.
+# The bundles contain entries like: queryId:"messengerConversations.<32-hex-hash>"
+_CONVERSATIONS_QID_RE = re.compile(
+    r'queryId:\s*["\']?(messengerConversations\.[a-f0-9]{20,})["\']?'
+)
+_MESSAGES_QID_RE = re.compile(
+    r'queryId:\s*["\']?(messengerMessages\.[a-f0-9]{20,})["\']?'
+)
 
-# queryId for fetching messages within a conversation
-_MESSAGES_QUERY_ID = "messengerMessages.5846eeb71c981f11e0134cb6626cc314"
+# Pattern to find JS bundle URLs in LinkedIn's HTML page source
+_SCRIPT_SRC_RE = re.compile(r'<script[^>]+src="([^"]+)"', re.IGNORECASE)
+
+# Cache for discovered queryIds (thread-safe)
+_query_id_cache: dict[str, str] = {}
+_query_id_lock = threading.Lock()
 
 _STATIC_HEADERS = {
     "user-agent": (
@@ -63,6 +81,131 @@ _DEFAULT_COUNT = 20
 
 # Safety limit to prevent runaway pagination on very large inboxes
 _MAX_PAGES = 50  # 50 * 20 = 1000 threads max
+
+
+def _discover_query_ids(
+    cookies: dict[str, str],
+    headers: dict[str, str],
+    proxy_url: Optional[str] = None,
+) -> tuple[str, str]:
+    """Auto-detect current GraphQL queryIds from LinkedIn's JS bundles.
+
+    LinkedIn embeds queryId strings (e.g. ``messengerConversations.<hash>``)
+    in its compiled JavaScript bundles. This function:
+
+    1. Fetches the ``/messaging`` page HTML.
+    2. Extracts ``<script src="...">`` URLs pointing to JS bundles.
+    3. Fetches each bundle and scans for the queryId patterns.
+    4. Returns ``(conversations_query_id, messages_query_id)``.
+
+    Falls back to the hardcoded ``_FALLBACK_*`` values if discovery fails.
+    Results are cached in ``_query_id_cache`` for the process lifetime.
+    """
+    with _query_id_lock:
+        cached_conv = _query_id_cache.get("conversations")
+        cached_msg = _query_id_cache.get("messages")
+        if cached_conv and cached_msg:
+            return cached_conv, cached_msg
+
+    conv_qid: Optional[str] = None
+    msg_qid: Optional[str] = None
+
+    try:
+        with httpx.Client(
+            proxy=proxy_url,
+            timeout=20.0,
+            follow_redirects=True,
+        ) as client:
+            page_headers = {
+                "user-agent": headers.get("user-agent", _STATIC_HEADERS["user-agent"]),
+                "accept": "text/html,application/xhtml+xml",
+                "accept-language": "en-US,en;q=0.9",
+            }
+            resp = client.get(
+                "https://www.linkedin.com/messaging/",
+                headers=page_headers,
+                cookies=cookies,
+            )
+            if resp.status_code != 200:
+                logger.debug(
+                    "queryId discovery: /messaging returned %d, using fallbacks",
+                    resp.status_code,
+                )
+                return _use_fallback_query_ids()
+
+            html = resp.text
+            script_urls = _SCRIPT_SRC_RE.findall(html)
+            logger.debug("queryId discovery: found %d script tags", len(script_urls))
+
+            # Filter to likely messaging-related bundles; fall back to all if none match
+            messaging_urls = [
+                u
+                for u in script_urls
+                if "messaging" in u.lower() or "voyager" in u.lower()
+            ]
+            candidate_urls = messaging_urls or script_urls
+
+            for url in candidate_urls:
+                if url.startswith("//"):
+                    url = "https:" + url
+                elif url.startswith("/"):
+                    url = "https://www.linkedin.com" + url
+
+                try:
+                    js_resp = client.get(url, headers=page_headers, timeout=15.0)
+                    if js_resp.status_code != 200:
+                        continue
+                    js_text = js_resp.text
+                except httpx.HTTPError:
+                    continue
+
+                if not conv_qid:
+                    match = _CONVERSATIONS_QID_RE.search(js_text)
+                    if match:
+                        conv_qid = match.group(1)
+                        logger.info("Discovered conversations queryId: %s", conv_qid)
+
+                if not msg_qid:
+                    match = _MESSAGES_QID_RE.search(js_text)
+                    if match:
+                        msg_qid = match.group(1)
+                        logger.info("Discovered messages queryId: %s", msg_qid)
+
+                if conv_qid and msg_qid:
+                    break
+
+    except httpx.HTTPError as exc:
+        logger.debug("queryId discovery failed with HTTP error: %s", exc)
+    except Exception:
+        logger.debug("queryId discovery failed unexpectedly", exc_info=True)
+
+    conv_qid = conv_qid or _FALLBACK_CONVERSATIONS_QUERY_ID
+    msg_qid = msg_qid or _FALLBACK_MESSAGES_QUERY_ID
+
+    with _query_id_lock:
+        _query_id_cache["conversations"] = conv_qid
+        _query_id_cache["messages"] = msg_qid
+
+    return conv_qid, msg_qid
+
+
+def _use_fallback_query_ids() -> tuple[str, str]:
+    """Return hardcoded fallback queryIds and cache them."""
+    with _query_id_lock:
+        _query_id_cache["conversations"] = _FALLBACK_CONVERSATIONS_QUERY_ID
+        _query_id_cache["messages"] = _FALLBACK_MESSAGES_QUERY_ID
+    logger.debug(
+        "Using fallback queryIds: conversations=%s, messages=%s",
+        _FALLBACK_CONVERSATIONS_QUERY_ID,
+        _FALLBACK_MESSAGES_QUERY_ID,
+    )
+    return _FALLBACK_CONVERSATIONS_QUERY_ID, _FALLBACK_MESSAGES_QUERY_ID
+
+
+def _reset_query_id_cache() -> None:
+    """Clear the cached queryIds. Useful for testing or when IDs go stale."""
+    with _query_id_lock:
+        _query_id_cache.clear()
 
 
 @dataclass(frozen=True)
@@ -149,6 +292,12 @@ _CONVERSATIONS_RESPONSE_KEYS = (
     "messengerConversationsByCriteria",
     "messengerConversationsByLastActivity",
     "messengerConversations",
+)
+
+_MESSAGES_RESPONSE_KEYS = (
+    "messengerMessagesBySyncToken",
+    "messengerMessages",
+    "messengerMessagesByConversation",
 )
 
 
@@ -242,11 +391,7 @@ def _parse_graphql_messages(
         result = result["data"]
 
     container: dict[str, Any] = {}
-    for key in (
-        "messengerMessagesBySyncToken",
-        "messengerMessages",
-        "messengerMessagesByConversation",
-    ):
+    for key in _MESSAGES_RESPONSE_KEYS:
         if key in result and isinstance(result[key], dict):
             container = result[key]
             break
@@ -460,6 +605,8 @@ class LinkedInProvider:
         cookies = self._build_cookies()
         proxy_url = self._get_proxy_url()
 
+        conv_query_id, _ = _discover_query_ids(cookies, headers, proxy_url)
+
         all_threads: list[LinkedInThread] = []
         page = 0
 
@@ -471,10 +618,10 @@ class LinkedInProvider:
             mailbox_urn = self._resolve_profile_urn(client, cookies)
             logger.info("Resolved mailbox URN: %s", mailbox_urn)
 
+            encoded_urn = quote(mailbox_urn, safe="")
             last_activity_before = int(time.time() * 1000)
 
             while page < _MAX_PAGES:
-                encoded_urn = quote(mailbox_urn, safe="")
                 variables = (
                     f"(query:(predicateUnions:List("
                     f"(conversationCategoryPredicate:(category:PRIMARY_INBOX)))),"
@@ -483,9 +630,7 @@ class LinkedInProvider:
                     f"lastUpdatedBefore:{last_activity_before})"
                 )
                 full_url = (
-                    f"{_GRAPHQL_MSG_URL}"
-                    f"?queryId={_CONVERSATIONS_QUERY_ID}"
-                    f"&variables={variables}"
+                    f"{_GRAPHQL_MSG_URL}?queryId={conv_query_id}&variables={variables}"
                 )
                 resp = client.get(
                     full_url,
@@ -542,6 +687,8 @@ class LinkedInProvider:
         cookies = self._build_cookies()
         proxy_url = self._get_proxy_url()
 
+        _, msg_query_id = _discover_query_ids(cookies, headers, proxy_url)
+
         encoded_conv = quote(platform_thread_id, safe="")
 
         if cursor:
@@ -550,9 +697,7 @@ class LinkedInProvider:
         else:
             variables = f"(conversationUrn:{encoded_conv})"
 
-        full_url = (
-            f"{_GRAPHQL_MSG_URL}?queryId={_MESSAGES_QUERY_ID}&variables={variables}"
-        )
+        full_url = f"{_GRAPHQL_MSG_URL}?queryId={msg_query_id}&variables={variables}"
 
         with httpx.Client(
             proxy=proxy_url,

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -1,10 +1,43 @@
 from __future__ import annotations
 
+import json
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
 
+import httpx
+
 from libs.core.models import AccountAuth, ProxyConfig
+
+logger = logging.getLogger(__name__)
+
+# LinkedIn internal API base
+_VOYAGER_BASE = "https://www.linkedin.com/voyager/api"
+
+# Headers that LinkedIn requires on every Voyager request.
+# Without these you get 403 or status 999.
+_STATIC_HEADERS = {
+    "user-agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+    ),
+    "accept": "application/vnd.linkedin.normalized+json+2.1",
+    "x-restli-protocol-version": "2.0.0",
+    "x-li-track": json.dumps({
+        "clientVersion": "1.13.8953",
+        "osName": "web",
+        "timezoneOffset": 4,
+        "deviceFormFactor": "DESKTOP",
+    }),
+    "x-li-page-instance": "urn:li:page:d_flagship3_messaging",
+}
+
+# Default page size for conversation listing
+_DEFAULT_COUNT = 20
+
+# Safety limit to prevent runaway pagination on very large inboxes
+_MAX_PAGES = 50  # 50 * 20 = 1000 threads max
 
 
 @dataclass(frozen=True)
@@ -23,10 +56,66 @@ class LinkedInMessage:
     sent_at: datetime
     raw: Optional[dict[str, Any]] = None
 
+
 @dataclass(frozen=True)
 class AuthCheckResult:
     ok: bool
     error: Optional[str] = None
+
+
+def _extract_thread_title(element: dict[str, Any], included: list[dict[str, Any]]) -> Optional[str]:
+    """Try to build a human-readable title from conversation participants.
+
+    LinkedIn stores participant references in the conversation element and
+    resolves them in the top-level 'included' array. We look for miniProfile
+    entities that match this conversation's participants.
+    """
+    # Collect participant URNs from the conversation element
+    participant_urns: list[str] = []
+    for p in element.get("participants", []):
+        urn = (
+            p.get("*com.linkedin.voyager.messaging.MessagingMember")
+            or p.get("participantUrn")
+            or p.get("entityUrn", "")
+        )
+        if urn:
+            participant_urns.append(urn)
+
+    if not participant_urns:
+        return None
+
+    # Match against included miniProfile entities
+    names: list[str] = []
+    for inc in included:
+        entity_urn = inc.get("entityUrn", "")
+        if entity_urn not in participant_urns:
+            continue
+        first = inc.get("firstName", "")
+        last = inc.get("lastName", "")
+        full = f"{first} {last}".strip()
+        if full:
+            names.append(full)
+
+    return ", ".join(names) if names else None
+
+
+def _parse_threads(data: dict[str, Any]) -> list[LinkedInThread]:
+    """Parse the Voyager conversations response into LinkedInThread objects."""
+    elements = data.get("elements", [])
+    included = data.get("included", [])
+    threads: list[LinkedInThread] = []
+    for elem in elements:
+        entity_urn = elem.get("entityUrn", "")
+        if not entity_urn:
+            continue
+        title = _extract_thread_title(elem, included)
+        threads.append(LinkedInThread(
+            platform_thread_id=entity_urn,
+            title=title,
+            raw=elem,
+        ))
+    return threads
+
 
 class LinkedInProvider:
     """LinkedIn DM provider.
@@ -46,18 +135,82 @@ class LinkedInProvider:
         self.auth = auth
         self.proxy = proxy
 
+    def _build_headers(self) -> dict[str, str]:
+        """Build request headers including the CSRF token from JSESSIONID."""
+        headers = dict(_STATIC_HEADERS)
+        if self.auth.jsessionid:
+            headers["csrf-token"] = self.auth.jsessionid
+        return headers
+
+    def _build_cookies(self) -> dict[str, str]:
+        """Build the cookie dict for requests. Never log the return value."""
+        cookies: dict[str, str] = {"li_at": self.auth.li_at}
+        if self.auth.jsessionid:
+            cookies["JSESSIONID"] = self.auth.jsessionid
+        return cookies
+
+    def _get_proxy_url(self) -> Optional[str]:
+        return self.proxy.url if self.proxy else None
+
     def list_threads(self) -> list[LinkedInThread]:
-        """Return list of DM threads for this account.
+        """Fetch all DM conversation threads with pagination.
 
-        TODO (contributors):
-        - Fetch threads from LinkedIn messaging
-        - Provide stable `platform_thread_id`
-        - Optional: thread title (participant names)
-
-        Return examples:
-        - platform_thread_id could be a LinkedIn conversation URN
+        Calls the Voyager conversations endpoint, page by page, until
+        LinkedIn returns fewer results than the requested count.
         """
-        raise NotImplementedError
+        if not self.auth.jsessionid:
+            raise ValueError(
+                "JSESSIONID is required for LinkedIn API requests (used as CSRF token). "
+                "Re-create the account with both li_at and JSESSIONID cookies."
+            )
+
+        headers = self._build_headers()
+        cookies = self._build_cookies()
+        proxy_url = self._get_proxy_url()
+
+        all_threads: list[LinkedInThread] = []
+        start = 0
+        page = 0
+
+        with httpx.Client(proxy=proxy_url, timeout=30.0) as client:
+            while page < _MAX_PAGES:
+                resp = client.get(
+                    f"{_VOYAGER_BASE}/messaging/conversations",
+                    params={
+                        "keyVersion": "LEGACY_INBOX",
+                        "q": "participants",
+                        "start": start,
+                        "count": _DEFAULT_COUNT,
+                    },
+                    headers=headers,
+                    cookies=cookies,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                page_threads = _parse_threads(data)
+                all_threads.extend(page_threads)
+
+                # Stop when we got fewer than a full page (last page)
+                paging = data.get("paging", {})
+                returned = len(data.get("elements", []))
+                total = paging.get("total")
+
+                if returned < _DEFAULT_COUNT:
+                    break
+                # If LinkedIn tells us the total, stop when we've seen them all
+                if total is not None and start + returned >= total:
+                    break
+
+                start += _DEFAULT_COUNT
+                page += 1
+
+        if page >= _MAX_PAGES:
+            logger.warning(
+                "Reached max page limit (%d); %d threads fetched — some threads may be missing",
+                _MAX_PAGES, len(all_threads),
+            )
+        logger.info("Fetched %d threads across %d pages", len(all_threads), page)
+        return all_threads
 
     def fetch_messages(
         self,

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -139,7 +139,9 @@ class LinkedInProvider:
         """Build request headers including the CSRF token from JSESSIONID."""
         headers = dict(_STATIC_HEADERS)
         if self.auth.jsessionid:
-            headers["csrf-token"] = self.auth.jsessionid
+            # LinkedIn expects csrf-token WITHOUT surrounding quotes,
+            # even though the JSESSIONID cookie value includes them.
+            headers["csrf-token"] = self.auth.jsessionid.strip('"')
         return headers
 
     def _build_cookies(self) -> dict[str, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "uvicorn[standard]>=0.27",
   "pydantic>=2.6",
   "cryptography>=42.0",
+  "httpx>=0.27",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_fetch_messages.py
+++ b/tests/test_fetch_messages.py
@@ -1,0 +1,430 @@
+"""Tests for LinkedInProvider.fetch_messages() — GraphQL messaging API."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from libs.core.models import AccountAuth, ProxyConfig
+from libs.providers.linkedin.provider import (
+    _FALLBACK_CONVERSATIONS_QUERY_ID,
+    _FALLBACK_MESSAGES_QUERY_ID,
+    _RETRY_MAX_ATTEMPTS,
+    LinkedInMessage,
+    LinkedInProvider,
+    _parse_graphql_messages,
+    _reset_query_id_cache,
+)
+
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def auth():
+    return AccountAuth(li_at="fake-li-at-cookie-value", jsessionid="ajax:9999999999")
+
+
+@pytest.fixture
+def provider(auth):
+    return LinkedInProvider(auth=auth)
+
+
+@pytest.fixture
+def mock_client():
+    """A mock httpx.Client for injection into provider._client."""
+    client = MagicMock(spec=httpx.Client)
+    client.is_closed = False
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _prefill_query_id_cache():
+    """Pre-fill the queryId cache so tests don't trigger discovery HTTP calls."""
+    from libs.providers.linkedin.provider import _query_id_cache, _query_id_lock
+
+    with _query_id_lock:
+        _query_id_cache["conversations"] = _FALLBACK_CONVERSATIONS_QUERY_ID
+        _query_id_cache["messages"] = _FALLBACK_MESSAGES_QUERY_ID
+    yield
+    _reset_query_id_cache()
+
+
+# -- Response builders -------------------------------------------------------
+
+
+def _ok_response(json_data):
+    """Build a MagicMock that passes LinkedInProvider._check_response."""
+    mock = MagicMock(spec=httpx.Response)
+    mock.status_code = 200
+    mock.is_redirect = False
+    mock.headers = {}
+    mock.text = ""
+    mock.json.return_value = json_data
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+def _graphql_messages(elements, sync_token=None):
+    """Build a GraphQL messengerMessages response."""
+    metadata = {}
+    if sync_token:
+        metadata["syncToken"] = sync_token
+    return {
+        "data": {
+            "messengerMessagesBySyncToken": {
+                "elements": elements,
+                "metadata": metadata,
+            }
+        }
+    }
+
+
+def _msg_element(
+    urn,
+    delivered_at=1700000000000,
+    sender_urn=None,
+    text="Hello",
+):
+    """Build a single message element for GraphQL responses."""
+    elem = {
+        "entityUrn": urn,
+        "deliveredAt": delivered_at,
+        "body": {"text": text},
+    }
+    if sender_urn:
+        elem["sender"] = {
+            "participantProfile": {"entityUrn": sender_urn},
+        }
+    return elem
+
+
+# -- Unit tests: _parse_graphql_messages -------------------------------------
+
+
+class TestParseGraphqlMessages:
+    def test_single_message(self):
+        data = _graphql_messages([_msg_element("urn:msg:1", text="Hi")])
+        msgs, cursor = _parse_graphql_messages(data, "urn:conv:1")
+        assert len(msgs) == 1
+        assert msgs[0].platform_message_id == "urn:msg:1"
+        assert msgs[0].text == "Hi"
+
+    def test_returns_sync_token_as_cursor(self):
+        data = _graphql_messages(
+            [_msg_element("urn:msg:1")], sync_token="abc-sync-123"
+        )
+        msgs, cursor = _parse_graphql_messages(data, "urn:conv:1")
+        assert cursor == "abc-sync-123"
+
+    def test_no_cursor_without_sync_token(self):
+        data = _graphql_messages([_msg_element("urn:msg:1")])
+        _, cursor = _parse_graphql_messages(data, "urn:conv:1")
+        assert cursor is None
+
+    def test_empty_elements(self):
+        data = _graphql_messages([])
+        msgs, cursor = _parse_graphql_messages(data, "urn:conv:1")
+        assert msgs == []
+        assert cursor is None
+
+    def test_sorted_oldest_first(self):
+        elems = [
+            _msg_element("urn:msg:new", delivered_at=1700000003000),
+            _msg_element("urn:msg:old", delivered_at=1700000001000),
+            _msg_element("urn:msg:mid", delivered_at=1700000002000),
+        ]
+        data = _graphql_messages(elems)
+        msgs, _ = _parse_graphql_messages(data, "urn:conv:1")
+        assert [m.platform_message_id for m in msgs] == [
+            "urn:msg:old",
+            "urn:msg:mid",
+            "urn:msg:new",
+        ]
+
+    def test_timestamp_parsed_correctly(self):
+        ts = 1700000000000  # 2023-11-14T22:13:20Z
+        data = _graphql_messages([_msg_element("urn:msg:1", delivered_at=ts)])
+        msgs, _ = _parse_graphql_messages(data, "urn:conv:1")
+        assert msgs[0].sent_at == datetime.fromtimestamp(ts / 1000, tz=timezone.utc)
+
+    def test_skips_elements_without_urn(self):
+        data = _graphql_messages([{"deliveredAt": 1700000000000, "body": {"text": "x"}}])
+        msgs, _ = _parse_graphql_messages(data, "urn:conv:1")
+        assert msgs == []
+
+    def test_backend_urn_fallback(self):
+        elem = {"backendUrn": "urn:msg:backend:1", "deliveredAt": 1700000000000}
+        data = _graphql_messages([elem])
+        msgs, _ = _parse_graphql_messages(data, "urn:conv:1")
+        assert msgs[0].platform_message_id == "urn:msg:backend:1"
+
+    def test_text_from_string_body(self):
+        elem = {"entityUrn": "urn:msg:1", "deliveredAt": 1700000000000, "body": "string"}
+        data = _graphql_messages([elem])
+        msgs, _ = _parse_graphql_messages(data, "urn:conv:1")
+        assert msgs[0].text == "string"
+
+    def test_text_none_when_empty_body(self):
+        elem = {"entityUrn": "urn:msg:1", "deliveredAt": 1700000000000, "body": {}}
+        data = _graphql_messages([elem])
+        msgs, _ = _parse_graphql_messages(data, "urn:conv:1")
+        assert msgs[0].text is None
+
+    def test_raw_preserved(self):
+        elem = _msg_element("urn:msg:1")
+        data = _graphql_messages([elem])
+        msgs, _ = _parse_graphql_messages(data, "urn:conv:1")
+        assert msgs[0].raw == elem
+
+    def test_sender_urn_extracted(self):
+        elem = _msg_element("urn:msg:1", sender_urn="urn:li:fsd_profile:SENDER")
+        data = _graphql_messages([elem])
+        msgs, _ = _parse_graphql_messages(data, "urn:conv:1")
+        assert msgs[0].sender == "urn:li:fsd_profile:SENDER"
+
+    def test_sender_none_without_sender_field(self):
+        elem = _msg_element("urn:msg:1")
+        data = _graphql_messages([elem])
+        msgs, _ = _parse_graphql_messages(data, "urn:conv:1")
+        assert msgs[0].sender is None
+
+
+# -- Integration: fetch_messages with mocked HTTP ----------------------------
+
+
+class TestFetchMessages:
+    def test_basic_fetch(self, provider, mock_client):
+        provider._client = mock_client
+        data = _graphql_messages([_msg_element("urn:msg:1", text="Hello")])
+        mock_client.get.return_value = _ok_response(data)
+
+        msgs, cursor = provider.fetch_messages(
+            platform_thread_id="urn:li:conv:1",
+            cursor=None,
+        )
+
+        assert len(msgs) == 1
+        assert msgs[0].text == "Hello"
+        assert isinstance(msgs[0], LinkedInMessage)
+
+    def test_empty_response(self, provider, mock_client):
+        provider._client = mock_client
+        data = _graphql_messages([])
+        mock_client.get.return_value = _ok_response(data)
+
+        msgs, cursor = provider.fetch_messages(
+            platform_thread_id="urn:li:conv:1",
+            cursor=None,
+        )
+
+        assert msgs == []
+        assert cursor is None
+
+    def test_returns_sync_token_cursor(self, provider, mock_client):
+        provider._client = mock_client
+        data = _graphql_messages(
+            [_msg_element("urn:msg:1")], sync_token="next-sync-abc"
+        )
+        mock_client.get.return_value = _ok_response(data)
+
+        msgs, cursor = provider.fetch_messages(
+            platform_thread_id="urn:li:conv:1",
+            cursor=None,
+        )
+
+        assert cursor == "next-sync-abc"
+
+    def test_cursor_passed_in_url(self, provider, mock_client):
+        provider._client = mock_client
+        data = _graphql_messages([])
+        mock_client.get.return_value = _ok_response(data)
+
+        provider.fetch_messages(
+            platform_thread_id="urn:li:conv:1",
+            cursor="prev-sync-token",
+        )
+
+        url = mock_client.get.call_args[0][0]
+        assert "syncToken" in url
+
+    def test_conversation_urn_in_url(self, provider, mock_client):
+        provider._client = mock_client
+        data = _graphql_messages([])
+        mock_client.get.return_value = _ok_response(data)
+
+        provider.fetch_messages(
+            platform_thread_id="urn:li:msg_conversation:ABC",
+            cursor=None,
+        )
+
+        url = mock_client.get.call_args[0][0]
+        assert "conversationUrn" in url
+        assert "messengerMessages" in url
+
+    def test_messages_sorted_chronologically(self, provider, mock_client):
+        provider._client = mock_client
+        data = _graphql_messages([
+            _msg_element("urn:msg:new", delivered_at=1700000002000),
+            _msg_element("urn:msg:old", delivered_at=1700000001000),
+        ])
+        mock_client.get.return_value = _ok_response(data)
+
+        msgs, _ = provider.fetch_messages(
+            platform_thread_id="urn:li:conv:1",
+            cursor=None,
+        )
+
+        assert msgs[0].platform_message_id == "urn:msg:old"
+        assert msgs[1].platform_message_id == "urn:msg:new"
+
+    def test_http_error_propagates(self, provider, mock_client):
+        provider._client = mock_client
+        resp_403 = MagicMock(spec=httpx.Response)
+        resp_403.status_code = 403
+        resp_403.is_redirect = False
+        resp_403.headers = {}
+        resp_403.text = "Forbidden"
+        resp_403.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "403", request=MagicMock(), response=resp_403
+        )
+        mock_client.get.return_value = resp_403
+
+        with pytest.raises(httpx.HTTPStatusError):
+            provider.fetch_messages(
+                platform_thread_id="urn:li:conv:1",
+                cursor=None,
+            )
+
+    def test_requires_jsessionid(self):
+        auth = AccountAuth(li_at="fake", jsessionid=None)
+        p = LinkedInProvider(auth=auth)
+        with pytest.raises(ValueError, match="JSESSIONID"):
+            p.fetch_messages(
+                platform_thread_id="urn:li:conv:1",
+                cursor=None,
+            )
+
+    def test_invalid_limit_too_low(self, provider):
+        with pytest.raises(ValueError, match="limit"):
+            provider.fetch_messages(
+                platform_thread_id="urn:li:conv:1",
+                cursor=None,
+                limit=0,
+            )
+
+    def test_invalid_limit_too_high(self, provider):
+        with pytest.raises(ValueError, match="limit"):
+            provider.fetch_messages(
+                platform_thread_id="urn:li:conv:1",
+                cursor=None,
+                limit=201,
+            )
+
+    def test_valid_limit_boundaries(self, provider, mock_client):
+        """Limits 1 and 200 should be accepted without error."""
+        provider._client = mock_client
+        data = _graphql_messages([])
+        mock_client.get.return_value = _ok_response(data)
+
+        # Should not raise
+        provider.fetch_messages(
+            platform_thread_id="urn:li:conv:1", cursor=None, limit=1
+        )
+        provider.fetch_messages(
+            platform_thread_id="urn:li:conv:1", cursor=None, limit=200
+        )
+
+    def test_retries_on_429(self, provider, mock_client):
+        provider._client = mock_client
+        resp_429 = MagicMock(spec=httpx.Response)
+        resp_429.status_code = 429
+        resp_429.headers = {}
+        resp_429.request = MagicMock()
+
+        data = _graphql_messages([_msg_element("urn:msg:1")])
+        mock_client.get.side_effect = [resp_429, _ok_response(data)]
+
+        with patch("libs.providers.linkedin.provider.time.sleep"):
+            msgs, _ = provider.fetch_messages(
+                platform_thread_id="urn:li:conv:1",
+                cursor=None,
+            )
+
+        assert len(msgs) == 1
+
+    def test_exhausts_retries_on_502(self, provider, mock_client):
+        provider._client = mock_client
+        resp_502 = MagicMock(spec=httpx.Response)
+        resp_502.status_code = 502
+        resp_502.headers = {}
+        resp_502.request = MagicMock()
+
+        mock_client.get.return_value = resp_502
+
+        with patch("libs.providers.linkedin.provider.time.sleep"):
+            with pytest.raises(httpx.HTTPStatusError):
+                provider.fetch_messages(
+                    platform_thread_id="urn:li:conv:1",
+                    cursor=None,
+                )
+
+        # Should have attempted _RETRY_MAX_ATTEMPTS times
+        assert mock_client.get.call_count == _RETRY_MAX_ATTEMPTS
+
+    def test_uses_proxy(self):
+        """Proxy URL is passed through to httpx.Client."""
+        auth = AccountAuth(li_at="fake-li-at", jsessionid="ajax:123")
+        proxy = ProxyConfig(url="http://proxy:8080")
+        p = LinkedInProvider(auth=auth, proxy=proxy)
+
+        data = _graphql_messages([])
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value
+            client_instance.is_closed = False
+            client_instance.get.return_value = _ok_response(data)
+
+            p.fetch_messages(
+                platform_thread_id="urn:li:conv:1",
+                cursor=None,
+            )
+
+        MockClient.assert_called_once_with(
+            proxy="http://proxy:8080",
+            timeout=30.0,
+            follow_redirects=False,
+        )
+
+    def test_cookies_not_leaked_into_headers(self, provider, mock_client):
+        provider._client = mock_client
+        data = _graphql_messages([])
+        mock_client.get.return_value = _ok_response(data)
+
+        provider.fetch_messages(
+            platform_thread_id="urn:li:conv:1",
+            cursor=None,
+        )
+
+        call_kwargs = mock_client.get.call_args.kwargs
+        headers_str = str(call_kwargs["headers"])
+        assert "fake-li-at-cookie-value" not in headers_str
+        assert call_kwargs["cookies"]["li_at"] == "fake-li-at-cookie-value"
+
+    def test_client_reused_across_calls(self, provider, mock_client):
+        """Multiple fetch_messages calls reuse the same httpx client."""
+        provider._client = mock_client
+        data = _graphql_messages([])
+        mock_client.get.return_value = _ok_response(data)
+
+        provider.fetch_messages(
+            platform_thread_id="urn:li:conv:1", cursor=None
+        )
+        provider.fetch_messages(
+            platform_thread_id="urn:li:conv:2", cursor=None
+        )
+
+        # No new httpx.Client was created — both calls used the injected mock
+        assert provider._client is mock_client

--- a/tests/test_fetch_messages.py
+++ b/tests/test_fetch_messages.py
@@ -192,6 +192,18 @@ class TestParseGraphqlMessages:
         msgs, _ = _parse_graphql_messages(data, "urn:conv:1")
         assert msgs[0].sender is None
 
+    def test_deduplicates_by_message_id(self):
+        """Duplicate message IDs within a page are returned only once."""
+        dup = _msg_element("urn:msg:dup", text="first")
+        dup2 = _msg_element("urn:msg:dup", text="second")
+        unique = _msg_element("urn:msg:unique")
+        data = _graphql_messages([dup, dup2, unique])
+        msgs, _ = _parse_graphql_messages(data, "urn:conv:1")
+        assert len(msgs) == 2
+        ids = [m.platform_message_id for m in msgs]
+        assert ids.count("urn:msg:dup") == 1
+        assert "urn:msg:unique" in ids
+
 
 # -- Integration: fetch_messages with mocked HTTP ----------------------------
 
@@ -428,3 +440,25 @@ class TestFetchMessages:
 
         # No new httpx.Client was created — both calls used the injected mock
         assert provider._client is mock_client
+
+    def test_handles_non_json_response(self, provider, mock_client):
+        """HTML error page (non-JSON) doesn't crash — returns empty."""
+        provider._client = mock_client
+
+        html_resp = MagicMock(spec=httpx.Response)
+        html_resp.status_code = 200
+        html_resp.is_redirect = False
+        html_resp.headers = {}
+        html_resp.text = "<html>Cloudflare error</html>"
+        html_resp.json.side_effect = ValueError("No JSON")
+        html_resp.raise_for_status = MagicMock()
+
+        mock_client.get.return_value = html_resp
+
+        msgs, cursor = provider.fetch_messages(
+            platform_thread_id="urn:li:conv:1",
+            cursor=None,
+        )
+
+        assert msgs == []
+        assert cursor is None

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -1,23 +1,26 @@
 """Tests for LinkedInProvider.list_threads() — HTTP calls, pagination, parsing."""
+
 from __future__ import annotations
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
 from libs.core.models import AccountAuth, ProxyConfig
 from libs.providers.linkedin.provider import (
-    LinkedInProvider,
-    LinkedInThread,
-    _parse_threads,
-    _extract_thread_title,
     _DEFAULT_COUNT,
     _MAX_PAGES,
+    LinkedInProvider,
+    LinkedInThread,
+    _extract_thread_title,
+    _get_oldest_timestamp,
+    _parse_graphql_threads,
+    _parse_threads,
 )
 
-
 # -- Fixtures ----------------------------------------------------------------
+
 
 @pytest.fixture
 def auth():
@@ -34,7 +37,9 @@ def provider_with_proxy(auth):
     return LinkedInProvider(auth=auth, proxy=ProxyConfig(url="http://proxy:8080"))
 
 
-def _voyager_response(elements, total=None, start=0, count=_DEFAULT_COUNT, included=None):
+def _voyager_response(
+    elements, total=None, start=0, count=_DEFAULT_COUNT, included=None
+):
     """Build a realistic Voyager conversations response."""
     body = {
         "elements": elements,
@@ -55,7 +60,55 @@ def _make_element(urn, participants=None):
     return elem
 
 
+def _ok_response(json_data):
+    """Build a MagicMock that passes LinkedInProvider._check_response."""
+    mock = MagicMock(spec=httpx.Response)
+    mock.status_code = 200
+    mock.is_redirect = False
+    mock.headers = {}
+    mock.text = ""
+    mock.json.return_value = json_data
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+def _me_response(profile_urn="urn:li:fsd_profile:ACoAATest123"):
+    """Build a /me response mock."""
+    return _ok_response({"entityUrn": profile_urn})
+
+
+def _graphql_conversations(elements, has_more=False):
+    """Build a GraphQL messengerConversations response."""
+    return {
+        "data": {
+            "messengerConversationsByCriteria": {
+                "elements": elements,
+            }
+        }
+    }
+
+
+def _graphql_conv_element(urn, last_activity_at=None, participant_names=None):
+    """Build a single GraphQL conversation element."""
+    elem = {
+        "entityUrn": urn,
+        "lastActivityAt": last_activity_at or 1700000000000,
+    }
+    if participant_names:
+        elem["conversationParticipants"] = [
+            {
+                "participantProfile": {
+                    "firstName": n.split()[0],
+                    "lastName": n.split()[-1] if len(n.split()) > 1 else "",
+                }
+            }
+            for n in participant_names
+        ]
+    return elem
+
+
 # -- Unit tests: response parsing --------------------------------------------
+
 
 class TestParseThreads:
     def test_empty_elements(self):
@@ -90,7 +143,9 @@ class TestParseThreads:
             "urn:li:fs_conversation:2-abc",
             participants=[{"participantUrn": participant_urn}],
         )
-        included = [{"entityUrn": participant_urn, "firstName": "Alice", "lastName": "Smith"}]
+        included = [
+            {"entityUrn": participant_urn, "firstName": "Alice", "lastName": "Smith"}
+        ]
         data = _voyager_response(elements=[elem], included=included)
         threads = _parse_threads(data)
         assert threads[0].title == "Alice Smith"
@@ -126,7 +181,68 @@ class TestParseThreads:
         assert threads[0].title is None
 
 
+# -- Unit tests: GraphQL response parsing ------------------------------------
+
+
+class TestParseGraphqlThreads:
+    def test_empty_elements(self):
+        data = _graphql_conversations(elements=[])
+        assert _parse_graphql_threads(data) == []
+
+    def test_single_conversation(self):
+        elems = [_graphql_conv_element("urn:li:msg_conversation:abc123")]
+        data = _graphql_conversations(elems)
+        threads = _parse_graphql_threads(data)
+        assert len(threads) == 1
+        assert threads[0].platform_thread_id == "urn:li:msg_conversation:abc123"
+
+    def test_multiple_conversations(self):
+        elems = [
+            _graphql_conv_element(f"urn:li:msg_conversation:{i}") for i in range(5)
+        ]
+        data = _graphql_conversations(elems)
+        threads = _parse_graphql_threads(data)
+        assert len(threads) == 5
+
+    def test_title_from_participants(self):
+        elems = [
+            _graphql_conv_element(
+                "urn:li:msg_conversation:1", participant_names=["Alice Smith"]
+            )
+        ]
+        data = _graphql_conversations(elems)
+        threads = _parse_graphql_threads(data)
+        assert threads[0].title == "Alice Smith"
+
+    def test_title_multiple_participants(self):
+        elems = [
+            _graphql_conv_element(
+                "urn:li:msg_conversation:1",
+                participant_names=["Alice A", "Bob B"],
+            )
+        ]
+        data = _graphql_conversations(elems)
+        threads = _parse_graphql_threads(data)
+        assert threads[0].title == "Alice A, Bob B"
+
+
+class TestGetOldestTimestamp:
+    def test_returns_oldest(self):
+        elems = [
+            _graphql_conv_element("urn:1", last_activity_at=3000),
+            _graphql_conv_element("urn:2", last_activity_at=1000),
+            _graphql_conv_element("urn:3", last_activity_at=2000),
+        ]
+        data = _graphql_conversations(elems)
+        assert _get_oldest_timestamp(data) == 1000
+
+    def test_returns_none_for_empty(self):
+        data = _graphql_conversations([])
+        assert _get_oldest_timestamp(data) is None
+
+
 # -- Unit tests: header and cookie building ----------------------------------
+
 
 class TestBuildHeaders:
     def test_includes_csrf_token(self, provider):
@@ -168,83 +284,59 @@ class TestBuildHeaders:
 
 # -- Integration-style tests: list_threads with mocked HTTP ------------------
 
+
 class TestListThreads:
     def test_single_page(self, provider):
         """When LinkedIn returns fewer than DEFAULT_COUNT, no second request."""
-        elems = [_make_element(f"urn:li:fs_conversation:{i}") for i in range(3)]
-        response_data = _voyager_response(elements=elems, total=3)
-
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.json.return_value = response_data
-        mock_resp.raise_for_status = MagicMock()
+        elems = [
+            _graphql_conv_element(f"urn:li:msg_conversation:{i}") for i in range(3)
+        ]
+        me_resp = _me_response()
+        graphql_resp = _ok_response(_graphql_conversations(elems))
 
         with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
             client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.return_value = mock_resp
+            client_instance.get.side_effect = [me_resp, graphql_resp]
 
             threads = provider.list_threads()
 
         assert len(threads) == 3
         assert all(isinstance(t, LinkedInThread) for t in threads)
-        client_instance.get.assert_called_once()
+        assert client_instance.get.call_count == 2  # /me + 1 graphql page
 
     def test_pagination_two_pages(self, provider):
         """When first page is full, fetches second page."""
-        page1_elems = [_make_element(f"urn:conv:{i}") for i in range(_DEFAULT_COUNT)]
-        page2_elems = [_make_element(f"urn:conv:{_DEFAULT_COUNT + i}") for i in range(5)]
+        page1_elems = [
+            _graphql_conv_element(f"urn:conv:{i}", last_activity_at=2000 - i)
+            for i in range(_DEFAULT_COUNT)
+        ]
+        page2_elems = [
+            _graphql_conv_element(
+                f"urn:conv:{_DEFAULT_COUNT + i}", last_activity_at=1000 - i
+            )
+            for i in range(5)
+        ]
 
-        resp1 = MagicMock(spec=httpx.Response)
-        resp1.json.return_value = _voyager_response(
-            elements=page1_elems, total=_DEFAULT_COUNT + 5,
-        )
-        resp1.raise_for_status = MagicMock()
-
-        resp2 = MagicMock(spec=httpx.Response)
-        resp2.json.return_value = _voyager_response(
-            elements=page2_elems, start=_DEFAULT_COUNT, total=_DEFAULT_COUNT + 5,
-        )
-        resp2.raise_for_status = MagicMock()
+        me_resp = _me_response()
+        resp1 = _ok_response(_graphql_conversations(page1_elems))
+        resp2 = _ok_response(_graphql_conversations(page2_elems))
 
         with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
             client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.side_effect = [resp1, resp2]
+            client_instance.get.side_effect = [me_resp, resp1, resp2]
 
             threads = provider.list_threads()
 
         assert len(threads) == _DEFAULT_COUNT + 5
-        assert client_instance.get.call_count == 2
-
-        # Verify start param incremented on second call
-        second_call_params = client_instance.get.call_args_list[1]
-        assert second_call_params.kwargs["params"]["start"] == _DEFAULT_COUNT
-
-    def test_pagination_stops_at_total(self, provider):
-        """Even if a full page is returned, stops when start+returned >= total."""
-        elems = [_make_element(f"urn:conv:{i}") for i in range(_DEFAULT_COUNT)]
-
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.json.return_value = _voyager_response(
-            elements=elems, total=_DEFAULT_COUNT,
-        )
-        mock_resp.raise_for_status = MagicMock()
-
-        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
-            client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.return_value = mock_resp
-
-            threads = provider.list_threads()
-
-        assert len(threads) == _DEFAULT_COUNT
-        client_instance.get.assert_called_once()
+        assert client_instance.get.call_count == 3  # /me + 2 graphql pages
 
     def test_empty_inbox(self, provider):
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.json.return_value = _voyager_response(elements=[], total=0)
-        mock_resp.raise_for_status = MagicMock()
+        me_resp = _me_response()
+        graphql_resp = _ok_response(_graphql_conversations([]))
 
         with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
             client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.return_value = mock_resp
+            client_instance.get.side_effect = [me_resp, graphql_resp]
 
             threads = provider.list_threads()
 
@@ -253,12 +345,19 @@ class TestListThreads:
     def test_http_error_propagates(self, provider):
         """HTTP errors from LinkedIn should bubble up, not be swallowed."""
         mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 403
+        mock_resp.is_redirect = False
+        mock_resp.headers = {}
+        mock_resp.text = "Forbidden"
         mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
-            "403 Forbidden", request=MagicMock(), response=mock_resp,
+            "403 Forbidden",
+            request=MagicMock(),
+            response=mock_resp,
         )
 
         with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
             client_instance = MockClient.return_value.__enter__.return_value
+            # /me fails with 403
             client_instance.get.return_value = mock_resp
 
             with pytest.raises(httpx.HTTPStatusError):
@@ -273,60 +372,70 @@ class TestListThreads:
 
     def test_uses_proxy(self, provider_with_proxy):
         """Proxy URL is passed through to httpx.Client."""
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.json.return_value = _voyager_response(elements=[], total=0)
-        mock_resp.raise_for_status = MagicMock()
+        me_resp = _me_response()
+        graphql_resp = _ok_response(_graphql_conversations([]))
 
         with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
             client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.return_value = mock_resp
+            client_instance.get.side_effect = [me_resp, graphql_resp]
 
             provider_with_proxy.list_threads()
 
-        MockClient.assert_called_once_with(proxy="http://proxy:8080", timeout=30.0)
+        MockClient.assert_called_once_with(
+            proxy="http://proxy:8080",
+            timeout=30.0,
+            follow_redirects=False,
+        )
 
     def test_cookies_not_in_headers(self, provider):
         """Cookies are passed via the cookies param, not leaked into headers."""
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.json.return_value = _voyager_response(elements=[], total=0)
-        mock_resp.raise_for_status = MagicMock()
+        me_resp = _me_response()
+        graphql_resp = _ok_response(_graphql_conversations([]))
 
         with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
             client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.return_value = mock_resp
+            client_instance.get.side_effect = [me_resp, graphql_resp]
 
             provider.list_threads()
 
+        # Check the last call (graphql) — cookies should be in the cookies param
         call_kwargs = client_instance.get.call_args.kwargs
         headers = call_kwargs["headers"]
-        # Headers should not contain raw cookie values
         assert "li_at" not in str(headers.get("cookie", ""))
         assert "fake-li-at-cookie-value" not in str(headers)
-        # Cookies should be passed separately
         assert call_kwargs["cookies"]["li_at"] == "fake-li-at-cookie-value"
 
     def test_max_pages_safety_limit(self, provider):
         """Pagination stops after _MAX_PAGES even if more data exists."""
-        # Every page returns a full batch, so pagination would continue forever
-        # without the safety limit.
-        full_page = [_make_element(f"urn:conv:{i}") for i in range(_DEFAULT_COUNT)]
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.json.return_value = _voyager_response(
-            elements=full_page, total=_MAX_PAGES * _DEFAULT_COUNT + 100,
-        )
-        mock_resp.raise_for_status = MagicMock()
+
+        def make_full_page(base_ts):
+            return [
+                _graphql_conv_element(
+                    f"urn:conv:{base_ts - i}", last_activity_at=base_ts - i
+                )
+                for i in range(_DEFAULT_COUNT)
+            ]
+
+        me_resp = _me_response()
+        pages = []
+        base = 100000
+        for p in range(_MAX_PAGES + 1):
+            ts = base - (p * _DEFAULT_COUNT)
+            pages.append(_ok_response(_graphql_conversations(make_full_page(ts))))
 
         with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
             client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.return_value = mock_resp
+            client_instance.get.side_effect = [me_resp] + pages
 
             threads = provider.list_threads()
 
-        assert client_instance.get.call_count == _MAX_PAGES
+        # /me + _MAX_PAGES graphql calls
+        assert client_instance.get.call_count == 1 + _MAX_PAGES
         assert len(threads) == _MAX_PAGES * _DEFAULT_COUNT
 
 
 # -- Edge case: _extract_thread_title variations -----------------------------
+
 
 class TestExtractThreadTitle:
     def test_voyager_messaging_member_key(self):

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -135,6 +135,13 @@ class TestBuildHeaders:
         assert "user-agent" in headers
         assert "x-restli-protocol-version" in headers
 
+    def test_csrf_token_strips_quotes(self):
+        """JSESSIONID cookie value has surrounding quotes; csrf-token must not."""
+        auth = AccountAuth(li_at="fake", jsessionid='"ajax:1234567890"')
+        p = LinkedInProvider(auth=auth)
+        headers = p._build_headers()
+        assert headers["csrf-token"] == "ajax:1234567890"
+
     def test_no_csrf_without_jsessionid(self):
         auth = AccountAuth(li_at="fake", jsessionid=None)
         p = LinkedInProvider(auth=auth)

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -602,6 +602,25 @@ class TestListThreads:
 
         mock_client.close.assert_called_once()
 
+    def test_handles_non_json_response(self, provider, mock_client):
+        """HTML error page (non-JSON) doesn't crash — treated as empty."""
+        provider._client = mock_client
+        me_resp = _me_response()
+
+        html_resp = MagicMock(spec=httpx.Response)
+        html_resp.status_code = 200
+        html_resp.is_redirect = False
+        html_resp.headers = {}
+        html_resp.text = "<html>Cloudflare error</html>"
+        html_resp.json.side_effect = ValueError("No JSON")
+        html_resp.raise_for_status = MagicMock()
+
+        mock_client.get.side_effect = [me_resp, html_resp]
+
+        threads = provider.list_threads()
+
+        assert threads == []
+
 
 # -- Edge case: _extract_thread_title variations -----------------------------
 

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -1,0 +1,353 @@
+"""Tests for LinkedInProvider.list_threads() — HTTP calls, pagination, parsing."""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import httpx
+import pytest
+
+from libs.core.models import AccountAuth, ProxyConfig
+from libs.providers.linkedin.provider import (
+    LinkedInProvider,
+    LinkedInThread,
+    _parse_threads,
+    _extract_thread_title,
+    _DEFAULT_COUNT,
+    _MAX_PAGES,
+)
+
+
+# -- Fixtures ----------------------------------------------------------------
+
+@pytest.fixture
+def auth():
+    return AccountAuth(li_at="fake-li-at-cookie-value", jsessionid="ajax:9999999999")
+
+
+@pytest.fixture
+def provider(auth):
+    return LinkedInProvider(auth=auth)
+
+
+@pytest.fixture
+def provider_with_proxy(auth):
+    return LinkedInProvider(auth=auth, proxy=ProxyConfig(url="http://proxy:8080"))
+
+
+def _voyager_response(elements, total=None, start=0, count=_DEFAULT_COUNT, included=None):
+    """Build a realistic Voyager conversations response."""
+    body = {
+        "elements": elements,
+        "paging": {"start": start, "count": count},
+    }
+    if total is not None:
+        body["paging"]["total"] = total
+    if included is not None:
+        body["included"] = included
+    return body
+
+
+def _make_element(urn, participants=None):
+    """Shorthand for a conversation element with an entityUrn."""
+    elem = {"entityUrn": urn}
+    if participants is not None:
+        elem["participants"] = participants
+    return elem
+
+
+# -- Unit tests: response parsing --------------------------------------------
+
+class TestParseThreads:
+    def test_empty_elements(self):
+        data = _voyager_response(elements=[])
+        assert _parse_threads(data) == []
+
+    def test_single_thread_with_urn(self):
+        elem = _make_element("urn:li:fs_conversation:2-abc123")
+        data = _voyager_response(elements=[elem])
+        threads = _parse_threads(data)
+        assert len(threads) == 1
+        assert threads[0].platform_thread_id == "urn:li:fs_conversation:2-abc123"
+        assert threads[0].raw == elem
+
+    def test_multiple_threads(self):
+        elems = [_make_element(f"urn:li:fs_conversation:{i}") for i in range(5)]
+        data = _voyager_response(elements=elems)
+        threads = _parse_threads(data)
+        assert len(threads) == 5
+        assert threads[2].platform_thread_id == "urn:li:fs_conversation:2"
+
+    def test_skips_elements_without_entity_urn(self):
+        elems = [{"someField": "value"}, _make_element("urn:li:fs_conversation:good")]
+        data = _voyager_response(elements=elems)
+        threads = _parse_threads(data)
+        assert len(threads) == 1
+        assert threads[0].platform_thread_id == "urn:li:fs_conversation:good"
+
+    def test_title_from_included_mini_profiles(self):
+        participant_urn = "urn:li:fs_miniProfile:alice123"
+        elem = _make_element(
+            "urn:li:fs_conversation:2-abc",
+            participants=[{"participantUrn": participant_urn}],
+        )
+        included = [{"entityUrn": participant_urn, "firstName": "Alice", "lastName": "Smith"}]
+        data = _voyager_response(elements=[elem], included=included)
+        threads = _parse_threads(data)
+        assert threads[0].title == "Alice Smith"
+
+    def test_title_multiple_participants(self):
+        urn_a = "urn:li:fs_miniProfile:alice"
+        urn_b = "urn:li:fs_miniProfile:bob"
+        elem = _make_element(
+            "urn:li:fs_conversation:group",
+            participants=[{"participantUrn": urn_a}, {"participantUrn": urn_b}],
+        )
+        included = [
+            {"entityUrn": urn_a, "firstName": "Alice", "lastName": "A"},
+            {"entityUrn": urn_b, "firstName": "Bob", "lastName": "B"},
+        ]
+        data = _voyager_response(elements=[elem], included=included)
+        threads = _parse_threads(data)
+        assert threads[0].title == "Alice A, Bob B"
+
+    def test_title_none_when_no_participants(self):
+        elem = _make_element("urn:li:fs_conversation:solo")
+        data = _voyager_response(elements=[elem])
+        threads = _parse_threads(data)
+        assert threads[0].title is None
+
+    def test_title_none_when_participant_not_in_included(self):
+        elem = _make_element(
+            "urn:li:fs_conversation:orphan",
+            participants=[{"participantUrn": "urn:li:fs_miniProfile:unknown"}],
+        )
+        data = _voyager_response(elements=[elem], included=[])
+        threads = _parse_threads(data)
+        assert threads[0].title is None
+
+
+# -- Unit tests: header and cookie building ----------------------------------
+
+class TestBuildHeaders:
+    def test_includes_csrf_token(self, provider):
+        headers = provider._build_headers()
+        assert headers["csrf-token"] == "ajax:9999999999"
+        assert "user-agent" in headers
+        assert "x-restli-protocol-version" in headers
+
+    def test_no_csrf_without_jsessionid(self):
+        auth = AccountAuth(li_at="fake", jsessionid=None)
+        p = LinkedInProvider(auth=auth)
+        headers = p._build_headers()
+        assert "csrf-token" not in headers
+
+    def test_build_cookies(self, provider):
+        cookies = provider._build_cookies()
+        assert cookies["li_at"] == "fake-li-at-cookie-value"
+        assert cookies["JSESSIONID"] == "ajax:9999999999"
+
+    def test_build_cookies_without_jsessionid(self):
+        auth = AccountAuth(li_at="fake", jsessionid=None)
+        p = LinkedInProvider(auth=auth)
+        cookies = p._build_cookies()
+        assert "JSESSIONID" not in cookies
+
+    def test_proxy_url(self, provider_with_proxy):
+        assert provider_with_proxy._get_proxy_url() == "http://proxy:8080"
+
+    def test_proxy_url_none(self, provider):
+        assert provider._get_proxy_url() is None
+
+
+# -- Integration-style tests: list_threads with mocked HTTP ------------------
+
+class TestListThreads:
+    def test_single_page(self, provider):
+        """When LinkedIn returns fewer than DEFAULT_COUNT, no second request."""
+        elems = [_make_element(f"urn:li:fs_conversation:{i}") for i in range(3)]
+        response_data = _voyager_response(elements=elems, total=3)
+
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.json.return_value = response_data
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.return_value = mock_resp
+
+            threads = provider.list_threads()
+
+        assert len(threads) == 3
+        assert all(isinstance(t, LinkedInThread) for t in threads)
+        client_instance.get.assert_called_once()
+
+    def test_pagination_two_pages(self, provider):
+        """When first page is full, fetches second page."""
+        page1_elems = [_make_element(f"urn:conv:{i}") for i in range(_DEFAULT_COUNT)]
+        page2_elems = [_make_element(f"urn:conv:{_DEFAULT_COUNT + i}") for i in range(5)]
+
+        resp1 = MagicMock(spec=httpx.Response)
+        resp1.json.return_value = _voyager_response(
+            elements=page1_elems, total=_DEFAULT_COUNT + 5,
+        )
+        resp1.raise_for_status = MagicMock()
+
+        resp2 = MagicMock(spec=httpx.Response)
+        resp2.json.return_value = _voyager_response(
+            elements=page2_elems, start=_DEFAULT_COUNT, total=_DEFAULT_COUNT + 5,
+        )
+        resp2.raise_for_status = MagicMock()
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.side_effect = [resp1, resp2]
+
+            threads = provider.list_threads()
+
+        assert len(threads) == _DEFAULT_COUNT + 5
+        assert client_instance.get.call_count == 2
+
+        # Verify start param incremented on second call
+        second_call_params = client_instance.get.call_args_list[1]
+        assert second_call_params.kwargs["params"]["start"] == _DEFAULT_COUNT
+
+    def test_pagination_stops_at_total(self, provider):
+        """Even if a full page is returned, stops when start+returned >= total."""
+        elems = [_make_element(f"urn:conv:{i}") for i in range(_DEFAULT_COUNT)]
+
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.json.return_value = _voyager_response(
+            elements=elems, total=_DEFAULT_COUNT,
+        )
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.return_value = mock_resp
+
+            threads = provider.list_threads()
+
+        assert len(threads) == _DEFAULT_COUNT
+        client_instance.get.assert_called_once()
+
+    def test_empty_inbox(self, provider):
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.json.return_value = _voyager_response(elements=[], total=0)
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.return_value = mock_resp
+
+            threads = provider.list_threads()
+
+        assert threads == []
+
+    def test_http_error_propagates(self, provider):
+        """HTTP errors from LinkedIn should bubble up, not be swallowed."""
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "403 Forbidden", request=MagicMock(), response=mock_resp,
+        )
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.return_value = mock_resp
+
+            with pytest.raises(httpx.HTTPStatusError):
+                provider.list_threads()
+
+    def test_requires_jsessionid(self):
+        """list_threads raises ValueError when JSESSIONID is missing."""
+        auth = AccountAuth(li_at="fake-cookie", jsessionid=None)
+        p = LinkedInProvider(auth=auth)
+        with pytest.raises(ValueError, match="JSESSIONID"):
+            p.list_threads()
+
+    def test_uses_proxy(self, provider_with_proxy):
+        """Proxy URL is passed through to httpx.Client."""
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.json.return_value = _voyager_response(elements=[], total=0)
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.return_value = mock_resp
+
+            provider_with_proxy.list_threads()
+
+        MockClient.assert_called_once_with(proxy="http://proxy:8080", timeout=30.0)
+
+    def test_cookies_not_in_headers(self, provider):
+        """Cookies are passed via the cookies param, not leaked into headers."""
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.json.return_value = _voyager_response(elements=[], total=0)
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.return_value = mock_resp
+
+            provider.list_threads()
+
+        call_kwargs = client_instance.get.call_args.kwargs
+        headers = call_kwargs["headers"]
+        # Headers should not contain raw cookie values
+        assert "li_at" not in str(headers.get("cookie", ""))
+        assert "fake-li-at-cookie-value" not in str(headers)
+        # Cookies should be passed separately
+        assert call_kwargs["cookies"]["li_at"] == "fake-li-at-cookie-value"
+
+    def test_max_pages_safety_limit(self, provider):
+        """Pagination stops after _MAX_PAGES even if more data exists."""
+        # Every page returns a full batch, so pagination would continue forever
+        # without the safety limit.
+        full_page = [_make_element(f"urn:conv:{i}") for i in range(_DEFAULT_COUNT)]
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.json.return_value = _voyager_response(
+            elements=full_page, total=_MAX_PAGES * _DEFAULT_COUNT + 100,
+        )
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.return_value = mock_resp
+
+            threads = provider.list_threads()
+
+        assert client_instance.get.call_count == _MAX_PAGES
+        assert len(threads) == _MAX_PAGES * _DEFAULT_COUNT
+
+
+# -- Edge case: _extract_thread_title variations -----------------------------
+
+class TestExtractThreadTitle:
+    def test_voyager_messaging_member_key(self):
+        """Handles the alternate participant key LinkedIn sometimes uses."""
+        urn = "urn:li:fs_miniProfile:alice"
+        element = {
+            "entityUrn": "urn:li:fs_conversation:1",
+            "participants": [{"*com.linkedin.voyager.messaging.MessagingMember": urn}],
+        }
+        included = [{"entityUrn": urn, "firstName": "Alice", "lastName": "W"}]
+        assert _extract_thread_title(element, included) == "Alice W"
+
+    def test_entity_urn_fallback(self):
+        """Falls back to entityUrn on participant when other keys are missing."""
+        urn = "urn:li:fs_miniProfile:bob"
+        element = {
+            "entityUrn": "urn:li:fs_conversation:1",
+            "participants": [{"entityUrn": urn}],
+        }
+        included = [{"entityUrn": urn, "firstName": "Bob", "lastName": ""}]
+        assert _extract_thread_title(element, included) == "Bob"
+
+    def test_empty_name_fields(self):
+        urn = "urn:li:fs_miniProfile:empty"
+        element = {
+            "entityUrn": "urn:li:fs_conversation:1",
+            "participants": [{"participantUrn": urn}],
+        }
+        included = [{"entityUrn": urn, "firstName": "", "lastName": ""}]
+        # Empty name → no title
+        assert _extract_thread_title(element, included) is None

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -9,14 +9,21 @@ import pytest
 
 from libs.core.models import AccountAuth, ProxyConfig
 from libs.providers.linkedin.provider import (
+    _CONVERSATIONS_QID_RE,
     _DEFAULT_COUNT,
+    _FALLBACK_CONVERSATIONS_QUERY_ID,
+    _FALLBACK_MESSAGES_QUERY_ID,
     _MAX_PAGES,
+    _MESSAGES_QID_RE,
+    _SCRIPT_SRC_RE,
     LinkedInProvider,
     LinkedInThread,
+    _discover_query_ids,
     _extract_thread_title,
     _get_oldest_timestamp,
     _parse_graphql_threads,
     _parse_threads,
+    _reset_query_id_cache,
 )
 
 # -- Fixtures ----------------------------------------------------------------
@@ -35,6 +42,18 @@ def provider(auth):
 @pytest.fixture
 def provider_with_proxy(auth):
     return LinkedInProvider(auth=auth, proxy=ProxyConfig(url="http://proxy:8080"))
+
+
+@pytest.fixture(autouse=True)
+def _prefill_query_id_cache():
+    """Pre-fill the queryId cache so tests don't trigger discovery HTTP calls."""
+    from libs.providers.linkedin.provider import _query_id_cache, _query_id_lock
+
+    with _query_id_lock:
+        _query_id_cache["conversations"] = _FALLBACK_CONVERSATIONS_QUERY_ID
+        _query_id_cache["messages"] = _FALLBACK_MESSAGES_QUERY_ID
+    yield
+    _reset_query_id_cache()
 
 
 def _voyager_response(
@@ -77,7 +96,7 @@ def _me_response(profile_urn="urn:li:fsd_profile:ACoAATest123"):
     return _ok_response({"entityUrn": profile_urn})
 
 
-def _graphql_conversations(elements, has_more=False):
+def _graphql_conversations(elements):
     """Build a GraphQL messengerConversations response."""
     return {
         "data": {
@@ -467,3 +486,185 @@ class TestExtractThreadTitle:
         included = [{"entityUrn": urn, "firstName": "", "lastName": ""}]
         # Empty name → no title
         assert _extract_thread_title(element, included) is None
+
+
+# -- Unit tests: queryId regex patterns ----------------------------------------
+
+
+class TestQueryIdRegex:
+    def test_conversations_pattern_double_quotes(self):
+        js = 'queryId:"messengerConversations.9501074288a12f3ae9e3c7ea243bccbf"'
+        match = _CONVERSATIONS_QID_RE.search(js)
+        assert match is not None
+        assert (
+            match.group(1) == "messengerConversations.9501074288a12f3ae9e3c7ea243bccbf"
+        )
+
+    def test_conversations_pattern_single_quotes(self):
+        js = "queryId:'messengerConversations.abcdef1234567890abcdef'"
+        match = _CONVERSATIONS_QID_RE.search(js)
+        assert match is not None
+        assert match.group(1) == "messengerConversations.abcdef1234567890abcdef"
+
+    def test_messages_pattern(self):
+        js = 'queryId:"messengerMessages.5846eeb71c981f11e0134cb6626cc314"'
+        match = _MESSAGES_QID_RE.search(js)
+        assert match is not None
+        assert match.group(1) == "messengerMessages.5846eeb71c981f11e0134cb6626cc314"
+
+    def test_no_match_on_unrelated(self):
+        js = 'queryId:"somethingElse.abc123"'
+        assert _CONVERSATIONS_QID_RE.search(js) is None
+        assert _MESSAGES_QID_RE.search(js) is None
+
+    def test_pattern_with_spaces(self):
+        js = 'queryId: "messengerConversations.aaaa1111bbbb2222cccc3333"'
+        match = _CONVERSATIONS_QID_RE.search(js)
+        assert match is not None
+
+    def test_script_src_extraction(self):
+        html = '<script src="https://static.licdn.com/aero-v1/sc/h/abc123"></script>'
+        urls = _SCRIPT_SRC_RE.findall(html)
+        assert len(urls) == 1
+        assert urls[0] == "https://static.licdn.com/aero-v1/sc/h/abc123"
+
+
+# -- Integration-style tests: queryId discovery --------------------------------
+
+
+class TestDiscoverQueryIds:
+    def setup_method(self):
+        _reset_query_id_cache()
+
+    def test_discovers_both_ids_from_bundle(self):
+        """Discovery finds both queryIds from JS bundle content."""
+        html = (
+            "<html><head>"
+            '<script src="https://static.licdn.com/bundle.js"></script>'
+            "</head></html>"
+        )
+        js_content = (
+            'var x=1;queryId:"messengerConversations.aaaa1111bbbb2222cccc3333dddd4444";'
+            'queryId:"messengerMessages.eeee5555ffff6666aaaa7777bbbb8888";'
+        )
+
+        html_resp = _ok_response(None)
+        html_resp.status_code = 200
+        html_resp.text = html
+
+        js_resp = _ok_response(None)
+        js_resp.status_code = 200
+        js_resp.text = js_content
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.side_effect = [html_resp, js_resp]
+
+            conv_id, msg_id = _discover_query_ids(
+                {"li_at": "fake", "JSESSIONID": "ajax:123"}, {}, None
+            )
+
+        assert conv_id == "messengerConversations.aaaa1111bbbb2222cccc3333dddd4444"
+        assert msg_id == "messengerMessages.eeee5555ffff6666aaaa7777bbbb8888"
+
+    def test_falls_back_when_page_returns_error(self):
+        """Falls back to hardcoded IDs when /messaging returns non-200."""
+        html_resp = _ok_response(None)
+        html_resp.status_code = 403
+        html_resp.text = "Forbidden"
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.return_value = html_resp
+
+            conv_id, msg_id = _discover_query_ids({"li_at": "fake"}, {}, None)
+
+        assert conv_id == _FALLBACK_CONVERSATIONS_QUERY_ID
+        assert msg_id == _FALLBACK_MESSAGES_QUERY_ID
+
+    def test_falls_back_when_no_ids_in_bundles(self):
+        """Falls back when JS bundles don't contain queryId patterns."""
+        html = '<html><script src="/bundle.js"></script></html>'
+        js_content = "var x = 1; // no queryIds here"
+
+        html_resp = _ok_response(None)
+        html_resp.status_code = 200
+        html_resp.text = html
+
+        js_resp = _ok_response(None)
+        js_resp.status_code = 200
+        js_resp.text = js_content
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.side_effect = [html_resp, js_resp]
+
+            conv_id, msg_id = _discover_query_ids({"li_at": "fake"}, {}, None)
+
+        assert conv_id == _FALLBACK_CONVERSATIONS_QUERY_ID
+        assert msg_id == _FALLBACK_MESSAGES_QUERY_ID
+
+    def test_caches_results(self):
+        """Second call returns cached result without HTTP requests."""
+        html = '<html><script src="/bundle.js"></script></html>'
+        js_content = (
+            'queryId:"messengerConversations.aabb11223344556677889900aabb1122";'
+            'queryId:"messengerMessages.ccdd33445566778899001122ccdd3344";'
+        )
+
+        html_resp = _ok_response(None)
+        html_resp.status_code = 200
+        html_resp.text = html
+
+        js_resp = _ok_response(None)
+        js_resp.status_code = 200
+        js_resp.text = js_content
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.side_effect = [html_resp, js_resp]
+
+            conv1, msg1 = _discover_query_ids({"li_at": "fake"}, {}, None)
+
+        # Second call — should use cache, no HTTP
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            conv2, msg2 = _discover_query_ids({"li_at": "fake"}, {}, None)
+            MockClient.assert_not_called()
+
+        assert conv1 == conv2
+        assert msg1 == msg2
+
+    def test_falls_back_on_http_error(self):
+        """Falls back gracefully when httpx raises an error."""
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.side_effect = httpx.ConnectError("Connection refused")
+
+            conv_id, msg_id = _discover_query_ids({"li_at": "fake"}, {}, None)
+
+        assert conv_id == _FALLBACK_CONVERSATIONS_QUERY_ID
+        assert msg_id == _FALLBACK_MESSAGES_QUERY_ID
+
+    def test_partial_discovery_uses_fallback_for_missing(self):
+        """If only one queryId is found, the other falls back."""
+        html = '<html><script src="/bundle.js"></script></html>'
+        js_content = (
+            'queryId:"messengerConversations.aabb11cc22dd33ee44ff5566aabb1122";'
+        )
+
+        html_resp = _ok_response(None)
+        html_resp.status_code = 200
+        html_resp.text = html
+
+        js_resp = _ok_response(None)
+        js_resp.status_code = 200
+        js_resp.text = js_content
+
+        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
+            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance.get.side_effect = [html_resp, js_resp]
+
+            conv_id, msg_id = _discover_query_ids({"li_at": "fake"}, {}, None)
+
+        assert conv_id == "messengerConversations.aabb11cc22dd33ee44ff5566aabb1122"
+        assert msg_id == _FALLBACK_MESSAGES_QUERY_ID

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -11,10 +11,13 @@ from libs.core.models import AccountAuth, ProxyConfig
 from libs.providers.linkedin.provider import (
     _CONVERSATIONS_QID_RE,
     _DEFAULT_COUNT,
+    _DELAY_BETWEEN_PAGES_S,
     _FALLBACK_CONVERSATIONS_QUERY_ID,
     _FALLBACK_MESSAGES_QUERY_ID,
     _MAX_PAGES,
     _MESSAGES_QID_RE,
+    _RETRY_MAX_ATTEMPTS,
+    _RETRYABLE_STATUS_CODES,
     _SCRIPT_SRC_RE,
     LinkedInProvider,
     LinkedInThread,
@@ -42,6 +45,14 @@ def provider(auth):
 @pytest.fixture
 def provider_with_proxy(auth):
     return LinkedInProvider(auth=auth, proxy=ProxyConfig(url="http://proxy:8080"))
+
+
+@pytest.fixture
+def mock_client():
+    """A mock httpx.Client for injection into provider._client."""
+    client = MagicMock(spec=httpx.Client)
+    client.is_closed = False
+    return client
 
 
 @pytest.fixture(autouse=True)
@@ -305,26 +316,25 @@ class TestBuildHeaders:
 
 
 class TestListThreads:
-    def test_single_page(self, provider):
+    def test_single_page(self, provider, mock_client):
         """When LinkedIn returns fewer than DEFAULT_COUNT, no second request."""
+        provider._client = mock_client
         elems = [
             _graphql_conv_element(f"urn:li:msg_conversation:{i}") for i in range(3)
         ]
         me_resp = _me_response()
         graphql_resp = _ok_response(_graphql_conversations(elems))
+        mock_client.get.side_effect = [me_resp, graphql_resp]
 
-        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
-            client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.side_effect = [me_resp, graphql_resp]
-
-            threads = provider.list_threads()
+        threads = provider.list_threads()
 
         assert len(threads) == 3
         assert all(isinstance(t, LinkedInThread) for t in threads)
-        assert client_instance.get.call_count == 2  # /me + 1 graphql page
+        assert mock_client.get.call_count == 2  # /me + 1 graphql page
 
-    def test_pagination_two_pages(self, provider):
+    def test_pagination_two_pages(self, provider, mock_client):
         """When first page is full, fetches second page."""
+        provider._client = mock_client
         page1_elems = [
             _graphql_conv_element(f"urn:conv:{i}", last_activity_at=2000 - i)
             for i in range(_DEFAULT_COUNT)
@@ -339,48 +349,42 @@ class TestListThreads:
         me_resp = _me_response()
         resp1 = _ok_response(_graphql_conversations(page1_elems))
         resp2 = _ok_response(_graphql_conversations(page2_elems))
+        mock_client.get.side_effect = [me_resp, resp1, resp2]
 
-        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
-            client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.side_effect = [me_resp, resp1, resp2]
-
+        with patch("libs.providers.linkedin.provider.time.sleep"):
             threads = provider.list_threads()
 
         assert len(threads) == _DEFAULT_COUNT + 5
-        assert client_instance.get.call_count == 3  # /me + 2 graphql pages
+        assert mock_client.get.call_count == 3  # /me + 2 graphql pages
 
-    def test_empty_inbox(self, provider):
+    def test_empty_inbox(self, provider, mock_client):
+        provider._client = mock_client
         me_resp = _me_response()
         graphql_resp = _ok_response(_graphql_conversations([]))
+        mock_client.get.side_effect = [me_resp, graphql_resp]
 
-        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
-            client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.side_effect = [me_resp, graphql_resp]
-
-            threads = provider.list_threads()
+        threads = provider.list_threads()
 
         assert threads == []
 
-    def test_http_error_propagates(self, provider):
+    def test_http_error_propagates(self, provider, mock_client):
         """HTTP errors from LinkedIn should bubble up, not be swallowed."""
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 403
-        mock_resp.is_redirect = False
-        mock_resp.headers = {}
-        mock_resp.text = "Forbidden"
-        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        provider._client = mock_client
+        error_resp = MagicMock(spec=httpx.Response)
+        error_resp.status_code = 403
+        error_resp.is_redirect = False
+        error_resp.headers = {}
+        error_resp.text = "Forbidden"
+        error_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
             "403 Forbidden",
             request=MagicMock(),
-            response=mock_resp,
+            response=error_resp,
         )
+        # /me fails with 403
+        mock_client.get.return_value = error_resp
 
-        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
-            client_instance = MockClient.return_value.__enter__.return_value
-            # /me fails with 403
-            client_instance.get.return_value = mock_resp
-
-            with pytest.raises(httpx.HTTPStatusError):
-                provider.list_threads()
+        with pytest.raises(httpx.HTTPStatusError):
+            provider.list_threads()
 
     def test_requires_jsessionid(self):
         """list_threads raises ValueError when JSESSIONID is missing."""
@@ -395,7 +399,8 @@ class TestListThreads:
         graphql_resp = _ok_response(_graphql_conversations([]))
 
         with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
-            client_instance = MockClient.return_value.__enter__.return_value
+            client_instance = MockClient.return_value
+            client_instance.is_closed = False
             client_instance.get.side_effect = [me_resp, graphql_resp]
 
             provider_with_proxy.list_threads()
@@ -406,26 +411,25 @@ class TestListThreads:
             follow_redirects=False,
         )
 
-    def test_cookies_not_in_headers(self, provider):
+    def test_cookies_not_in_headers(self, provider, mock_client):
         """Cookies are passed via the cookies param, not leaked into headers."""
+        provider._client = mock_client
         me_resp = _me_response()
         graphql_resp = _ok_response(_graphql_conversations([]))
+        mock_client.get.side_effect = [me_resp, graphql_resp]
 
-        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
-            client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.side_effect = [me_resp, graphql_resp]
-
-            provider.list_threads()
+        provider.list_threads()
 
         # Check the last call (graphql) — cookies should be in the cookies param
-        call_kwargs = client_instance.get.call_args.kwargs
+        call_kwargs = mock_client.get.call_args.kwargs
         headers = call_kwargs["headers"]
         assert "li_at" not in str(headers.get("cookie", ""))
         assert "fake-li-at-cookie-value" not in str(headers)
         assert call_kwargs["cookies"]["li_at"] == "fake-li-at-cookie-value"
 
-    def test_max_pages_safety_limit(self, provider):
+    def test_max_pages_safety_limit(self, provider, mock_client):
         """Pagination stops after _MAX_PAGES even if more data exists."""
+        provider._client = mock_client
 
         def make_full_page(base_ts):
             return [
@@ -442,15 +446,162 @@ class TestListThreads:
             ts = base - (p * _DEFAULT_COUNT)
             pages.append(_ok_response(_graphql_conversations(make_full_page(ts))))
 
-        with patch("libs.providers.linkedin.provider.httpx.Client") as MockClient:
-            client_instance = MockClient.return_value.__enter__.return_value
-            client_instance.get.side_effect = [me_resp] + pages
+        mock_client.get.side_effect = [me_resp] + pages
 
+        with patch("libs.providers.linkedin.provider.time.sleep"):
             threads = provider.list_threads()
 
         # /me + _MAX_PAGES graphql calls
-        assert client_instance.get.call_count == 1 + _MAX_PAGES
+        assert mock_client.get.call_count == 1 + _MAX_PAGES
         assert len(threads) == _MAX_PAGES * _DEFAULT_COUNT
+
+    def test_deduplicates_across_pages(self, provider, mock_client):
+        """Same entityUrn on two pages is returned only once."""
+        provider._client = mock_client
+        page1_elems = [
+            _graphql_conv_element("urn:conv:dup", last_activity_at=2000),
+            _graphql_conv_element("urn:conv:1", last_activity_at=1999),
+        ] + [
+            _graphql_conv_element(f"urn:conv:p1-{i}", last_activity_at=1998 - i)
+            for i in range(_DEFAULT_COUNT - 2)
+        ]
+        page2_elems = [
+            _graphql_conv_element("urn:conv:dup", last_activity_at=2000),
+            _graphql_conv_element("urn:conv:2", last_activity_at=900),
+        ]
+
+        me_resp = _me_response()
+        resp1 = _ok_response(_graphql_conversations(page1_elems))
+        resp2 = _ok_response(_graphql_conversations(page2_elems))
+        mock_client.get.side_effect = [me_resp, resp1, resp2]
+
+        with patch("libs.providers.linkedin.provider.time.sleep"):
+            threads = provider.list_threads()
+
+        urns = [t.platform_thread_id for t in threads]
+        assert urns.count("urn:conv:dup") == 1
+        assert "urn:conv:1" in urns
+        assert "urn:conv:2" in urns
+
+    def test_sleeps_between_pages(self, provider, mock_client):
+        """Rate limiting: sleeps between pagination requests."""
+        provider._client = mock_client
+        page1_elems = [
+            _graphql_conv_element(f"urn:conv:{i}", last_activity_at=2000 - i)
+            for i in range(_DEFAULT_COUNT)
+        ]
+        page2_elems = [_graphql_conv_element("urn:conv:last", last_activity_at=500)]
+
+        me_resp = _me_response()
+        resp1 = _ok_response(_graphql_conversations(page1_elems))
+        resp2 = _ok_response(_graphql_conversations(page2_elems))
+        mock_client.get.side_effect = [me_resp, resp1, resp2]
+
+        with patch("libs.providers.linkedin.provider.time.sleep") as mock_sleep:
+            provider.list_threads()
+
+        mock_sleep.assert_called_once_with(_DELAY_BETWEEN_PAGES_S)
+
+    def test_no_sleep_on_single_page(self, provider, mock_client):
+        """No rate-limit sleep when only one page is fetched."""
+        provider._client = mock_client
+        me_resp = _me_response()
+        graphql_resp = _ok_response(
+            _graphql_conversations([_graphql_conv_element("urn:conv:1")])
+        )
+        mock_client.get.side_effect = [me_resp, graphql_resp]
+
+        with patch("libs.providers.linkedin.provider.time.sleep") as mock_sleep:
+            provider.list_threads()
+
+        mock_sleep.assert_not_called()
+
+    def test_retries_on_429_then_succeeds(self, provider, mock_client):
+        """Retries transient 429 and succeeds on next attempt."""
+        provider._client = mock_client
+        me_resp = _me_response()
+
+        resp_429 = MagicMock(spec=httpx.Response)
+        resp_429.status_code = 429
+        resp_429.headers = {}
+        resp_429.request = MagicMock()
+
+        graphql_resp = _ok_response(
+            _graphql_conversations([_graphql_conv_element("urn:conv:1")])
+        )
+        mock_client.get.side_effect = [me_resp, resp_429, graphql_resp]
+
+        with patch("libs.providers.linkedin.provider.time.sleep"):
+            threads = provider.list_threads()
+
+        assert len(threads) == 1
+
+    def test_retry_honours_retry_after_header(self, provider, mock_client):
+        """Retry delay respects Retry-After header from LinkedIn."""
+        provider._client = mock_client
+        me_resp = _me_response()
+
+        resp_429 = MagicMock(spec=httpx.Response)
+        resp_429.status_code = 429
+        resp_429.headers = {"Retry-After": "10"}
+        resp_429.request = MagicMock()
+
+        graphql_resp = _ok_response(_graphql_conversations([]))
+        mock_client.get.side_effect = [me_resp, resp_429, graphql_resp]
+
+        with patch("libs.providers.linkedin.provider.time.sleep") as mock_sleep:
+            provider.list_threads()
+
+        # The retry sleep should be at least 10s (from Retry-After)
+        assert mock_sleep.call_args[0][0] >= 10.0
+
+    def test_exhausts_retries_on_503(self, provider, mock_client):
+        """Raises after exhausting retry attempts on persistent 5xx."""
+        provider._client = mock_client
+        me_resp = _me_response()
+
+        resp_503 = MagicMock(spec=httpx.Response)
+        resp_503.status_code = 503
+        resp_503.headers = {}
+        resp_503.request = MagicMock()
+
+        mock_client.get.side_effect = [me_resp] + [resp_503] * _RETRY_MAX_ATTEMPTS
+
+        with patch("libs.providers.linkedin.provider.time.sleep"):
+            with pytest.raises(httpx.HTTPStatusError):
+                provider.list_threads()
+
+    def test_no_retry_on_403(self, provider, mock_client):
+        """Non-retryable errors (403) are not retried."""
+        provider._client = mock_client
+        me_resp = _me_response()
+
+        resp_403 = MagicMock(spec=httpx.Response)
+        resp_403.status_code = 403
+        resp_403.is_redirect = False
+        resp_403.headers = {}
+        resp_403.text = "Forbidden"
+        resp_403.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "403", request=MagicMock(), response=resp_403
+        )
+        mock_client.get.side_effect = [me_resp, resp_403]
+
+        with patch("libs.providers.linkedin.provider.time.sleep") as mock_sleep:
+            with pytest.raises(httpx.HTTPStatusError):
+                provider.list_threads()
+
+        # time.sleep should NOT be called for retry (only _DELAY_BETWEEN_PAGES_S is possible)
+        mock_sleep.assert_not_called()
+
+    def test_context_manager_closes_client(self, auth):
+        """Provider used as context manager closes the httpx client."""
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.is_closed = False
+
+        with LinkedInProvider(auth=auth) as p:
+            p._client = mock_client
+
+        mock_client.close.assert_called_once()
 
 
 # -- Edge case: _extract_thread_title variations -----------------------------

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -17,7 +17,6 @@ from libs.providers.linkedin.provider import (
     _MAX_PAGES,
     _MESSAGES_QID_RE,
     _RETRY_MAX_ATTEMPTS,
-    _RETRYABLE_STATUS_CODES,
     _SCRIPT_SRC_RE,
     LinkedInProvider,
     LinkedInThread,

--- a/tests/test_sync_send.py
+++ b/tests/test_sync_send.py
@@ -333,12 +333,21 @@ def test_sync_endpoint_422_for_invalid_limit_per_thread(storage, account_id):
     assert resp.status_code == 422
 
 
-def test_sync_endpoint_501_when_provider_not_implemented(storage, account_id):
-    from unittest.mock import patch
+def test_sync_endpoint_501_when_fetch_messages_not_implemented(storage, account_id):
+    """list_threads is now implemented; 501 comes from fetch_messages."""
+    from unittest.mock import patch, MagicMock
     from fastapi.testclient import TestClient
     from apps.api.main import app
 
-    with patch("apps.api.main.storage", storage):
+    provider = MagicMock()
+    provider.list_threads.return_value = [
+        LinkedInThread(platform_thread_id="t1", title=None, raw=None),
+    ]
+    provider.fetch_messages.side_effect = NotImplementedError
+
+    with patch("apps.api.main.storage", storage), patch(
+        "apps.api.main.LinkedInProvider", return_value=provider
+    ):
         client = TestClient(app)
         resp = client.post(
             "/sync",

--- a/tests/test_sync_send.py
+++ b/tests/test_sync_send.py
@@ -340,6 +340,8 @@ def test_sync_endpoint_501_when_fetch_messages_not_implemented(storage, account_
     from apps.api.main import app
 
     provider = MagicMock()
+    provider.__enter__ = MagicMock(return_value=provider)
+    provider.__exit__ = MagicMock(return_value=False)
     provider.list_threads.return_value = [
         LinkedInThread(platform_thread_id="t1", title=None, raw=None),
     ]
@@ -364,6 +366,8 @@ def test_sync_endpoint_returns_detailed_counts(storage, account_id):
     from libs.providers.linkedin.provider import LinkedInThread, LinkedInMessage
 
     provider = MagicMock()
+    provider.__enter__ = MagicMock(return_value=provider)
+    provider.__exit__ = MagicMock(return_value=False)
     provider.list_threads.return_value = [
         LinkedInThread(platform_thread_id="t1", title=None, raw=None),
     ]


### PR DESCRIPTION
## Summary

Implements `list_threads()` and `fetch_messages()` for the LinkedIn provider using their GraphQL messaging API. The REST endpoints from the original issues are deprecated and return 400. Tested and verified working with real LinkedIn cookies on a local machine.

## Background

I started with the REST approach described in issues #4 and #5. Tried every variation of `/messaging/conversations` - different query params, different headers. All return 400. LinkedIn killed those endpoints.

So I opened DevTools on `linkedin.com/messaging` and watched what the browser actually calls. LinkedIn moved everything to a GraphQL endpoint at `/voyagerMessagingGraphQL/graphql`. I built the implementation around that.

Since both `list_threads` and `fetch_messages` use the same GraphQL API, I put them in one PR instead of two.

## What's in this PR

**Core:**

- `list_threads()` - calls `messengerConversations` GraphQL query, paginates through all DM threads using `lastUpdatedBefore` cursor
- `fetch_messages()` - calls `messengerMessages` GraphQL query with `syncToken` cursor for incremental sync
- Calls `/me` first to get the user's profile URN (required as `mailboxUrn` in GraphQL variables)
- Thread titles from participant names
- Messages sorted oldest-first

**Reliability:**

- Retry with exponential backoff on 429/5xx (3 attempts, honours `Retry-After` header)
- Rate limiting - 1.5s pause between pagination requests
- Thread deduplication across pages
- Message deduplication within a page
- Pagination caps at 50 pages (1,000 threads max)
- Reusable HTTP client - TCP connections shared across calls, properly closed via context manager
- Safe JSON parsing - HTML error pages from Cloudflare don't crash the sync
- Limit validation on `fetch_messages` (1-200 range, aligned with API)

**QueryId auto-detection:**

LinkedIn's GraphQL queries use `queryId` hashes that change with every frontend deploy. Instead of hardcoding values that will go stale, this fetches the `/messaging` page at startup, scans the JS bundles for current queryId hashes, and caches them for the process lifetime. Falls back to hardcoded values if detection fails.

**Error handling:**

- 302 redirect - clear message that cookies are expired
- 401/403 - auth rejected, not retried
- 429/5xx - retried with backoff
- JSESSIONID quotes stripped for the CSRF token (browser stores it with quotes, header needs them removed)
- Proxy support throughout

## How to test

**Automated tests (no LinkedIn account needed):**

```bash
pip install -e ".[test]"
pytest tests/ -v
```

247 tests, all passing.

**With real cookies:**

Get fresh `li_at` and `JSESSIONID` from Chrome DevTools (Application > Cookies > linkedin.com), then:

```bash
# Start server
uvicorn apps.api.main:app --reload --host 127.0.0.1 --port 8899

# Create account
curl -s -X POST http://127.0.0.1:8899/accounts \
  -H 'Content-Type: application/json' \
  -d '{"label":"test","li_at":"YOUR_LI_AT","jsessionid":"YOUR_JSESSIONID"}'

# Check auth
curl -s 'http://127.0.0.1:8899/auth/check?account_id=1'

# Sync threads and messages
curl -s -X POST http://127.0.0.1:8899/sync \
  -H 'Content-Type: application/json' \
  -d '{"account_id":1,"limit_per_thread":50}'

# View synced threads
curl -s 'http://127.0.0.1:8899/threads?account_id=1'
```

Note: LinkedIn blocks datacenter/VPS IPs. Use a residential IP or proxy.

## Edge cases handled

| Scenario | Behavior |
|---|---|
| Empty inbox | Returns `[]` |
| Duplicate threads across pages | Deduplicated by URN |
| Duplicate messages within page | Deduplicated by message ID |
| HTML error page instead of JSON | Handled gracefully, no crash |
| JSESSIONID with surrounding quotes | Stripped for CSRF header |
| Cookies expired (302 redirect) | Clear error message |
| Rate limited (429) | Retried with backoff, honours Retry-After |
| Server error (5xx) | Retried 3 times with exponential delay |
| Auth rejected (401/403) | Not retried, raised immediately |
| QueryId hashes change | Auto-detected from JS bundles, falls back to hardcoded |
| Max pages reached (50) | Stops with warning, returns what was fetched |
| Missing JSESSIONID | ValueError before any HTTP call |
| Fewer than `limit` messages | `next_cursor = None` |

## Files changed

| File | What changed |
|---|---|
| `libs/providers/linkedin/provider.py` | GraphQL-based list_threads + fetch_messages with retry, rate limiting, dedup, queryId auto-detection, safe JSON parsing |
| `apps/api/main.py` | Provider used as context manager for HTTP client cleanup, limit aligned to 200 |
| `pyproject.toml` | Added `httpx>=0.27` |
| `tests/test_list_threads.py` | 54 tests - parsing, pagination, retry, rate limiting, dedup, queryId discovery |
| `tests/test_fetch_messages.py` | 31 tests - message parsing, cursor handling, retry, limit validation, dedup |
| `tests/test_sync_send.py` | Updated mocks for context manager support |

Closes #4, #5

Test img:

<img width="1468" height="772" alt="1" src="https://github.com/user-attachments/assets/6631a19f-04aa-42c2-af4f-cf80cd27e76b" />

