### PR TITLE
feat: add POST /accounts/refresh endpoint for session cookie renewal (closes #8)

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -167,6 +167,11 @@ def sync_account(body: SyncIn):
             "messages_skipped_duplicate": result.messages_skipped_duplicate,
             "pages_fetched": result.pages_fetched,
         }
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=401,
+            detail="LinkedIn session expired — re-authenticate via POST /accounts/refresh",
+        ) from exc
     except NotImplementedError:
         raise HTTPException(
             status_code=501,
@@ -192,6 +197,11 @@ def send_message(body: SendIn):
             idempotency_key=body.idempotency_key,
         )
         return {"ok": True, "platform_message_id": platform_message_id}
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=401,
+            detail="LinkedIn session expired — re-authenticate via POST /accounts/refresh",
+        ) from exc
     except NotImplementedError:
         raise HTTPException(
             status_code=501,

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -50,6 +50,27 @@ class AccountCreateIn(BaseModel):
         return AccountAuth(li_at=validate_li_at(self.li_at or ""), jsessionid=self.jsessionid)
 
 
+class AccountRefreshIn(BaseModel):
+    account_id: int
+    li_at: str | None = Field(None, description="LinkedIn li_at cookie value (required if cookies not provided)")
+    jsessionid: str | None = Field(None, description="Optional JSESSIONID cookie value")
+    cookies: str | None = Field(
+        None,
+        description="Cookie header string, e.g. 'li_at=xxx; JSESSIONID=yyy'. Overrides li_at/jsessionid fields.",
+    )
+
+    @model_validator(mode="after")
+    def require_auth(self) -> AccountRefreshIn:
+        if not self.cookies and not self.li_at:
+            raise ValueError("Provide either 'cookies' string or 'li_at' field")
+        return self
+
+    def to_account_auth(self) -> AccountAuth:
+        if self.cookies:
+            return cookies_to_account_auth(self.cookies)
+        return AccountAuth(li_at=validate_li_at(self.li_at or ""), jsessionid=self.jsessionid)
+
+
 class SendIn(BaseModel):
     account_id: int
     recipient: str = Field(..., min_length=1, description="Recipient id (profile URN or conversation id)")
@@ -83,6 +104,21 @@ def create_account(body: AccountCreateIn):
     account_id = storage.create_account(label=body.label, auth=auth, proxy=proxy)
     logger.info("Account created: %s", redact_for_log({"account_id": account_id, "label": body.label}))
     return {"account_id": account_id}
+
+
+@app.post("/accounts/refresh")
+def refresh_account(body: AccountRefreshIn):
+    """Update session cookies for an existing account without recreating it."""
+    try:
+        auth = body.to_account_auth()
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=redact_string(str(exc)))
+    try:
+        storage.update_account_auth(body.account_id, auth)
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=redact_string(str(e))) from e
+    logger.info("Account refreshed: %s", redact_for_log({"account_id": body.account_id}))
+    return {"ok": True, "account_id": body.account_id}
 
 
 @app.get("/auth/check", response_model=AuthCheckResponse)

--- a/libs/core/storage.py
+++ b/libs/core/storage.py
@@ -172,6 +172,25 @@ class Storage:
         self._conn.commit()
         return int(cur.lastrowid)
 
+    def update_account_auth(
+        self,
+        account_id: int,
+        auth: AccountAuth,
+    ) -> None:
+        """Replace the auth credentials for an existing account.
+
+        Raises KeyError if the account does not exist.
+        """
+        row = self._conn.execute("SELECT id FROM accounts WHERE id=?", (account_id,)).fetchone()
+        if not row:
+            raise KeyError(f"account {account_id} not found")
+        auth_json = encrypt_if_configured(json.dumps(asdict(auth)))
+        self._conn.execute(
+            "UPDATE accounts SET auth_json=? WHERE id=?",
+            (auth_json, account_id),
+        )
+        self._conn.commit()
+
     def get_account_auth(self, account_id: int) -> AccountAuth:
         row = self._conn.execute("SELECT auth_json FROM accounts WHERE id=?", (account_id,)).fetchone()
         if not row:

--- a/tests/test_api_refresh.py
+++ b/tests/test_api_refresh.py
@@ -1,8 +1,9 @@
-"""Tests for the POST /accounts/refresh endpoint — cookie refresh without account recreation."""
+"""Tests for the POST /accounts/refresh endpoint and 401 session-expired handling."""
 
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -139,3 +140,55 @@ class TestRefreshValidation:
             json={"account_id": aid, "cookies": "JSESSIONID=ajax:tok123"},
         )
         assert resp.status_code == 422
+
+
+class TestSessionExpired401:
+    """Verify /send and /sync return 401 with refresh hint when provider raises PermissionError."""
+
+    def test_send_returns_401_on_expired_session(self, client):
+        aid = _create_account(client)
+        with patch("apps.api.main.run_send", side_effect=PermissionError("LinkedIn session expired (HTTP 401)")):
+            resp = client.post(
+                "/send",
+                json={"account_id": aid, "recipient": "urn:li:member:123", "text": "hello"},
+            )
+        assert resp.status_code == 401
+        assert "re-authenticate via POST /accounts/refresh" in resp.json()["detail"]
+
+    def test_sync_returns_401_on_expired_session(self, client):
+        aid = _create_account(client)
+        with patch("apps.api.main.run_sync", side_effect=PermissionError("LinkedIn session expired (HTTP 401)")):
+            resp = client.post(
+                "/sync",
+                json={"account_id": aid},
+            )
+        assert resp.status_code == 401
+        assert "re-authenticate via POST /accounts/refresh" in resp.json()["detail"]
+
+    def test_send_401_then_refresh_then_send_succeeds(self, client):
+        """Full flow: send fails with 401, client refreshes cookies, send succeeds."""
+        aid = _create_account(client)
+
+        # First send fails with expired session
+        with patch("apps.api.main.run_send", side_effect=PermissionError("HTTP 401")):
+            resp = client.post(
+                "/send",
+                json={"account_id": aid, "recipient": "urn:li:member:123", "text": "hello"},
+            )
+        assert resp.status_code == 401
+
+        # Client refreshes cookies
+        resp = client.post(
+            "/accounts/refresh",
+            json={"account_id": aid, "li_at": "AQEDFreshNewCookie123"},
+        )
+        assert resp.status_code == 200
+
+        # Second send succeeds with new cookies
+        with patch("apps.api.main.run_send", return_value="msg-id-123"):
+            resp = client.post(
+                "/send",
+                json={"account_id": aid, "recipient": "urn:li:member:123", "text": "hello"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True

--- a/tests/test_api_refresh.py
+++ b/tests/test_api_refresh.py
@@ -1,0 +1,141 @@
+"""Tests for the POST /accounts/refresh endpoint — cookie refresh without account recreation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from libs.core import crypto
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    """Use a temp DB and reset crypto warning flag."""
+    monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "test.sqlite"))
+    monkeypatch.delenv("DESEARCH_ENCRYPTION_KEY", raising=False)
+    crypto._warned_no_key = False
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "test.sqlite"))
+    from libs.core.storage import Storage
+
+    storage = Storage(db_path=tmp_path / "test.sqlite")
+    storage.migrate()
+
+    from apps.api.main import app
+
+    import apps.api.main as api_mod
+
+    original_storage = api_mod.storage
+    api_mod.storage = storage
+    yield TestClient(app)
+    api_mod.storage = original_storage
+    storage.close()
+
+
+def _create_account(client) -> int:
+    """Helper: create an account and return its id."""
+    resp = client.post(
+        "/accounts",
+        json={"label": "test", "li_at": "AQEDAWx0Y29va2llXXX"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["account_id"]
+
+
+class TestRefreshWithRawFields:
+    def test_refresh_with_li_at(self, client):
+        aid = _create_account(client)
+        resp = client.post(
+            "/accounts/refresh",
+            json={"account_id": aid, "li_at": "AQEDNewCookieValue123"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["account_id"] == aid
+
+    def test_refresh_with_li_at_and_jsessionid(self, client):
+        aid = _create_account(client)
+        resp = client.post(
+            "/accounts/refresh",
+            json={"account_id": aid, "li_at": "AQEDNewCookieValue123", "jsessionid": "ajax:newtok"},
+        )
+        assert resp.status_code == 200
+
+    def test_refresh_updates_stored_credentials(self, client):
+        """Verify that after refresh, get_account_auth returns the new credentials."""
+        aid = _create_account(client)
+        new_li_at = "AQEDFreshSessionCookie"
+        client.post(
+            "/accounts/refresh",
+            json={"account_id": aid, "li_at": new_li_at},
+        )
+        # Use auth/check indirectly — or read storage directly
+        import apps.api.main as api_mod
+
+        auth = api_mod.storage.get_account_auth(aid)
+        assert auth.li_at == new_li_at
+
+
+class TestRefreshWithCookieString:
+    def test_refresh_with_cookies_string(self, client):
+        aid = _create_account(client)
+        resp = client.post(
+            "/accounts/refresh",
+            json={"account_id": aid, "cookies": "li_at=AQEDNewCookieXXX; JSESSIONID=ajax:tok456"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+    def test_cookies_overrides_raw_fields(self, client):
+        aid = _create_account(client)
+        resp = client.post(
+            "/accounts/refresh",
+            json={
+                "account_id": aid,
+                "li_at": "should_be_ignored",
+                "cookies": "li_at=AQEDFromCookieString",
+            },
+        )
+        assert resp.status_code == 200
+        import apps.api.main as api_mod
+
+        auth = api_mod.storage.get_account_auth(aid)
+        assert auth.li_at == "AQEDFromCookieString"
+
+
+class TestRefreshValidation:
+    def test_missing_auth_rejected(self, client):
+        aid = _create_account(client)
+        resp = client.post("/accounts/refresh", json={"account_id": aid})
+        assert resp.status_code == 422
+
+    def test_short_li_at_rejected(self, client):
+        aid = _create_account(client)
+        resp = client.post("/accounts/refresh", json={"account_id": aid, "li_at": "abc"})
+        assert resp.status_code == 422
+
+    def test_empty_li_at_rejected(self, client):
+        aid = _create_account(client)
+        resp = client.post("/accounts/refresh", json={"account_id": aid, "li_at": ""})
+        assert resp.status_code == 422
+
+    def test_nonexistent_account_returns_404(self, client):
+        resp = client.post(
+            "/accounts/refresh",
+            json={"account_id": 99999, "li_at": "AQEDNewCookieValue123"},
+        )
+        assert resp.status_code == 404
+
+    def test_cookies_without_li_at_rejected(self, client):
+        aid = _create_account(client)
+        resp = client.post(
+            "/accounts/refresh",
+            json={"account_id": aid, "cookies": "JSESSIONID=ajax:tok123"},
+        )
+        assert resp.status_code == 422

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -199,6 +199,22 @@ def test_create_account_returns_id(storage):
     assert aid >= 1
 
 
+def test_update_account_auth_replaces_credentials(storage):
+    """CRUD: update_account_auth replaces stored auth and new value is retrievable."""
+    aid = storage.create_account(label="test", auth=AccountAuth(li_at="old_cookie"), proxy=None)
+    new_auth = AccountAuth(li_at="new_cookie", jsessionid="ajax:new")
+    storage.update_account_auth(aid, new_auth)
+    got = storage.get_account_auth(aid)
+    assert got.li_at == "new_cookie"
+    assert got.jsessionid == "ajax:new"
+
+
+def test_update_account_auth_raises_for_unknown(storage):
+    """Edge case: update_account_auth raises KeyError for missing account."""
+    with pytest.raises(KeyError, match="account 99999 not found"):
+        storage.update_account_auth(99999, AccountAuth(li_at="x"))
+
+
 def test_get_account_auth_raises_for_unknown(storage):
     """Edge case: get_account_auth raises KeyError for missing account."""
     with pytest.raises(KeyError, match="account 99999 not found"):


### PR DESCRIPTION
## Summary

Closes #8

Implements `POST /accounts/refresh` endpoint to allow session cookie renewal without recreating the account.

When LinkedIn session cookies expire (detected by provider returning 401), clients — such as the Chrome Extension — need a way to push updated cookies without losing the existing account ID, threads, messages, and sync cursors. This PR adds that capability, along with proper 401 propagation from `/send` and `/sync` so clients know when to refresh.

## What's changed

### New endpoint: `POST /accounts/refresh`

**Request body:**
```json
{
  "account_id": 1,
  "li_at": "AQEDNewSessionCookie...",
  "jsessionid": "ajax:newtoken",
  "cookies": "li_at=xxx; JSESSIONID=yyy"
}
```
- `account_id` (required) — the account to update
- `li_at` / `jsessionid` — raw cookie values (same as `/accounts`)
- `cookies` — cookie header string, overrides raw fields if provided

**Responses:**
- `200` — `{"ok": true, "account_id": 1}`
- `404` — account not found
- `422` — invalid/missing credentials

### 401 session-expired handling

- `/send` and `/sync` now catch `PermissionError` (raised by the provider on HTTP 401 from LinkedIn) and return **HTTP 401** with a descriptive message: `"LinkedIn session expired — re-authenticate via POST /accounts/refresh"`
- Previously these would bubble up as unhandled 500 errors

### Storage layer
- Added `Storage.update_account_auth(account_id, auth)` — validates account exists, encrypts new credentials via `encrypt_if_configured()`, updates `auth_json` in place
- Existing account metadata (label, created_at), threads, messages, and sync cursors are preserved

### Files modified
- `libs/core/storage.py` — added `update_account_auth()` method
- `apps/api/main.py` — added `AccountRefreshIn` model, `POST /accounts/refresh` route, and 401 handlers on `/send` and `/sync`

### Files added
- `tests/test_api_refresh.py` — 13 API-level tests

### Files updated
- `tests/test_storage.py` — 2 new storage-level tests

## Test coverage (15 new tests)

- Refresh with `li_at` only
- Refresh with `li_at` + `jsessionid`
- Verify stored credentials actually updated after refresh
- Refresh with `cookies` header string
- `cookies` field overrides `li_at` field
- Rejects missing auth (no `li_at` or `cookies`)
- Rejects short `li_at` (< 10 chars)
- Rejects empty `li_at`
- Returns 404 for nonexistent account
- Rejects `cookies` string without `li_at`
- `/send` returns 401 on expired session
- `/sync` returns 401 on expired session
- Full flow: send fails 401 → refresh cookies → send succeeds
- Storage: `update_account_auth` roundtrip (encrypt → update → decrypt → verify)
- Storage: `update_account_auth` raises `KeyError` for unknown account

## Test plan

- [x] All 34 tests pass (`pytest tests/test_api_refresh.py tests/test_storage.py`)
- [x] Verify existing endpoints (`/accounts`, `/sync`, `/send`) are unaffected