### PR TITLE
feat(cli): add python -m apps.cli sync/send runner (closes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ pip install -e .
 uvicorn apps.api.main:app --reload --host 127.0.0.1 --port 8899
 ```
 
+### CLI (no web server)
+
+Use the same SQLite database and provider stack as the API, without uvicorn:
+
+```bash
+python -m apps.cli sync --account-id 1
+python -m apps.cli send --account-id 1 --recipient 'urn:li:fsd_profile:…' --text 'Hello'
+```
+
+Optional: `--db-path /path/to/desearch_linkedin_dms.sqlite` on each subcommand. Sync also accepts `--limit-per-thread`, `--max-pages-per-thread`, and `--exhaust-pagination` (same semantics as `POST /sync`). Send accepts `--idempotency-key`.
+
+If the provider raises `NotImplementedError` (for example sync before thread listing is implemented), the CLI prints a short TODO pointing at `libs/providers/linkedin/provider.py` and exits with a non-zero status.
+
 Open:
 - Health: http://127.0.0.1:8899/health
 - Swagger UI: http://127.0.0.1:8899/docs

--- a/apps/cli/__main__.py
+++ b/apps/cli/__main__.py
@@ -1,0 +1,247 @@
+"""CLI entrypoint: sync and send without running FastAPI.
+
+Run from repo root (or installed package): ``python -m apps.cli sync --account-id 1``
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import httpx
+
+from libs.core.job_runner import run_send, run_sync, SyncResult
+from libs.core.models import AccountAuth, ProxyConfig
+from libs.core.redaction import configure_logging
+from libs.core.storage import Storage
+from libs.providers.linkedin.provider import LinkedInProvider
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER_TODO = "Provider not implemented. Implement libs/providers/linkedin/provider.py"
+
+_SEND_TEXT_MAX_LEN = 8000
+
+
+def _stderr(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def _open_storage(db_path: str | None) -> Storage:
+    if db_path is None:
+        return Storage()
+    return Storage(db_path=Path(db_path))
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m apps.cli",
+        description="Run sync/send against local SQLite storage (no web server).",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_sync = sub.add_parser("sync", help="Fetch threads and messages into storage")
+    p_sync.add_argument(
+        "--db-path",
+        metavar="PATH",
+        default=None,
+        help="SQLite database file (default: ./desearch_linkedin_dms.sqlite)",
+    )
+    p_sync.add_argument("--account-id", type=int, required=True, metavar="ID")
+    p_sync.add_argument(
+        "--limit-per-thread",
+        type=int,
+        default=50,
+        metavar="N",
+        help="Messages per provider page (default: 50, max: 500)",
+    )
+    p_sync.add_argument(
+        "--max-pages-per-thread",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Max pages per thread (default: 1). Incompatible with --exhaust-pagination.",
+    )
+    p_sync.add_argument(
+        "--exhaust-pagination",
+        action="store_true",
+        help="Follow cursors until exhausted (same as API max_pages_per_thread=null)",
+    )
+
+    p_send = sub.add_parser("send", help="Send one DM via the LinkedIn provider")
+    p_send.add_argument(
+        "--db-path",
+        metavar="PATH",
+        default=None,
+        help="SQLite database file (default: ./desearch_linkedin_dms.sqlite)",
+    )
+    p_send.add_argument("--account-id", type=int, required=True, metavar="ID")
+    p_send.add_argument("--recipient", required=True, metavar="URN_OR_CONV_ID")
+    p_send.add_argument("--text", required=True, metavar="BODY")
+    p_send.add_argument(
+        "--idempotency-key",
+        default=None,
+        metavar="KEY",
+        help="Optional idempotency key (same as API)",
+    )
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.command == "sync":
+        if args.exhaust_pagination and args.max_pages_per_thread is not None:
+            parser.error("cannot combine --exhaust-pagination with --max-pages-per-thread")
+        if not (1 <= args.limit_per_thread <= 500):
+            parser.error("--limit-per-thread must be between 1 and 500")
+        max_pages: int | None
+        if args.exhaust_pagination:
+            max_pages = None
+        elif args.max_pages_per_thread is not None:
+            if not (1 <= args.max_pages_per_thread <= 100):
+                parser.error("--max-pages-per-thread must be between 1 and 100")
+            max_pages = args.max_pages_per_thread
+        else:
+            max_pages = 1
+        args._resolved_max_pages = max_pages  # type: ignore[attr-defined]
+
+    return args
+
+
+def _account_must_exist(storage: Storage, account_id: int) -> tuple[AccountAuth, ProxyConfig | None]:
+    if account_id < 1:
+        raise ValueError("account id must be a positive integer")
+    auth = storage.get_account_auth(account_id)
+    proxy = storage.get_account_proxy(account_id)
+    return auth, proxy
+
+
+def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
+    try:
+        auth, proxy = _account_must_exist(storage, args.account_id)
+    except KeyError:
+        _stderr(f"error: account {args.account_id} not found")
+        return 1
+    except ValueError as exc:
+        _stderr(f"error: {exc}")
+        return 1
+
+    provider = LinkedInProvider(auth=auth, proxy=proxy)
+    max_pages: int | None = args._resolved_max_pages  # type: ignore[attr-defined]
+    try:
+        result: SyncResult = run_sync(
+            account_id=args.account_id,
+            storage=storage,
+            provider=provider,
+            limit_per_thread=args.limit_per_thread,
+            max_pages_per_thread=max_pages,
+        )
+    except NotImplementedError:
+        _stderr(_PROVIDER_TODO)
+        return 1
+    except Exception:
+        logger.exception("sync failed")
+        _stderr("error: sync failed unexpectedly")
+        return 1
+
+    payload = {
+        "ok": True,
+        "synced_threads": result.synced_threads,
+        "messages_inserted": result.messages_inserted,
+        "messages_skipped_duplicate": result.messages_skipped_duplicate,
+        "pages_fetched": result.pages_fetched,
+    }
+    print(json.dumps(payload))
+    return 0
+
+
+def _cmd_send(storage: Storage, args: argparse.Namespace) -> int:
+    recipient = args.recipient
+    text = args.text
+    if len(recipient) < 1:
+        _stderr("error: --recipient must be non-empty")
+        return 1
+    if len(text) < 1:
+        _stderr("error: --text must be non-empty")
+        return 1
+    if len(text) > _SEND_TEXT_MAX_LEN:
+        _stderr(f"error: --text must be at most {_SEND_TEXT_MAX_LEN} characters")
+        return 1
+
+    idem = args.idempotency_key
+    if idem is not None and len(idem) < 1:
+        _stderr("error: --idempotency-key, if provided, must be non-empty")
+        return 1
+
+    try:
+        auth, proxy = _account_must_exist(storage, args.account_id)
+    except KeyError:
+        _stderr(f"error: account {args.account_id} not found")
+        return 1
+    except ValueError as exc:
+        _stderr(f"error: {exc}")
+        return 1
+
+    provider = LinkedInProvider(auth=auth, proxy=proxy)
+    try:
+        platform_message_id = run_send(
+            account_id=args.account_id,
+            storage=storage,
+            provider=provider,
+            recipient=recipient,
+            text=text,
+            idempotency_key=idem,
+        )
+    except NotImplementedError:
+        _stderr(_PROVIDER_TODO)
+        return 1
+    except PermissionError as exc:
+        _stderr(f"error: {exc}")
+        return 1
+    except ConnectionError as exc:
+        _stderr(f"error: {exc}")
+        return 1
+    except RuntimeError as exc:
+        _stderr(f"error: {exc}")
+        return 1
+    except httpx.HTTPStatusError as exc:
+        logger.warning("send HTTP error: %s", exc.response.status_code)
+        _stderr("error: send failed (HTTP error from LinkedIn)")
+        return 1
+    except Exception:
+        logger.exception("send failed")
+        _stderr("error: send failed unexpectedly")
+        return 1
+
+    print(json.dumps({"ok": True, "platform_message_id": platform_message_id}))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Parse CLI args, run command, return process exit code (0 = success)."""
+    configure_logging()
+    try:
+        args = _parse_args(argv)
+    except SystemExit as exc:
+        code = exc.code
+        if code is None:
+            return 0
+        return int(code) if isinstance(code, int) else 1
+
+    storage = _open_storage(args.db_path)
+    try:
+        storage.migrate()
+        if args.command == "sync":
+            return _cmd_sync(storage, args)
+        if args.command == "send":
+            return _cmd_send(storage, args)
+        _stderr(f"error: unknown command {args.command!r}")
+        return 1
+    finally:
+        storage.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/cli/__main__.py
+++ b/apps/cli/__main__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import sqlite3
 import sys
 from pathlib import Path
 from typing import Sequence
@@ -118,17 +119,24 @@ def _account_must_exist(storage: Storage, account_id: int) -> tuple[AccountAuth,
     return auth, proxy
 
 
-def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
+def _load_provider(storage: Storage, account_id: int) -> LinkedInProvider | int:
+    """Return a provider for ``account_id``, or exit code ``1`` on account errors."""
     try:
-        auth, proxy = _account_must_exist(storage, args.account_id)
+        auth, proxy = _account_must_exist(storage, account_id)
     except KeyError:
-        _stderr(f"error: account {args.account_id} not found")
+        _stderr(f"error: account {account_id} not found")
         return 1
     except ValueError as exc:
         _stderr(f"error: {exc}")
         return 1
+    return LinkedInProvider(auth=auth, proxy=proxy)
 
-    provider = LinkedInProvider(auth=auth, proxy=proxy)
+
+def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
+    loaded = _load_provider(storage, args.account_id)
+    if isinstance(loaded, int):
+        return loaded
+    provider = loaded
     max_pages: int | None = args._resolved_max_pages  # type: ignore[attr-defined]
     try:
         result: SyncResult = run_sync(
@@ -175,16 +183,10 @@ def _cmd_send(storage: Storage, args: argparse.Namespace) -> int:
         _stderr("error: --idempotency-key, if provided, must be non-empty")
         return 1
 
-    try:
-        auth, proxy = _account_must_exist(storage, args.account_id)
-    except KeyError:
-        _stderr(f"error: account {args.account_id} not found")
-        return 1
-    except ValueError as exc:
-        _stderr(f"error: {exc}")
-        return 1
-
-    provider = LinkedInProvider(auth=auth, proxy=proxy)
+    loaded = _load_provider(storage, args.account_id)
+    if isinstance(loaded, int):
+        return loaded
+    provider = loaded
     try:
         platform_message_id = run_send(
             account_id=args.account_id,
@@ -197,13 +199,7 @@ def _cmd_send(storage: Storage, args: argparse.Namespace) -> int:
     except NotImplementedError:
         _stderr(_PROVIDER_TODO)
         return 1
-    except PermissionError as exc:
-        _stderr(f"error: {exc}")
-        return 1
-    except ConnectionError as exc:
-        _stderr(f"error: {exc}")
-        return 1
-    except RuntimeError as exc:
+    except (PermissionError, ConnectionError, RuntimeError) as exc:
         _stderr(f"error: {exc}")
         return 1
     except httpx.HTTPStatusError as exc:
@@ -230,9 +226,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
         return int(code) if isinstance(code, int) else 1
 
-    storage = _open_storage(args.db_path)
+    storage: Storage | None = None
     try:
+        storage = _open_storage(args.db_path)
         storage.migrate()
+    except (OSError, sqlite3.Error):
+        logger.exception("storage initialization failed")
+        _stderr("error: could not open or initialize the database")
+        if storage is not None:
+            storage.close()
+        return 1
+
+    try:
         if args.command == "sync":
             return _cmd_sync(storage, args)
         if args.command == "send":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -323,7 +323,9 @@ def test_cli_send_http_status_error_exits_one(cli_db_path: str, account_id: int)
     assert rc == 1
 
 
-def test_cli_send_not_implemented_exits_one(cli_db_path: str, account_id: int) -> None:
+def test_cli_send_not_implemented_exits_one(
+    capsys: pytest.CaptureFixture[str], cli_db_path: str, account_id: int
+) -> None:
     with patch.object(cli_main, "LinkedInProvider") as m_cls:
         inst = MagicMock()
         inst.send_message.side_effect = NotImplementedError
@@ -341,6 +343,16 @@ def test_cli_send_not_implemented_exits_one(cli_db_path: str, account_id: int) -
                 "t",
             ]
         )
+    assert rc == 1
+    assert cli_main._PROVIDER_TODO in capsys.readouterr().err
+
+
+def test_cli_unusable_db_path_exits_one(tmp_path: Path) -> None:
+    bad_dir = tmp_path / "not_a_sqlite_file"
+    bad_dir.mkdir()
+    rc = cli_main.main(
+        ["sync", "--account-id", "1", "--db-path", str(bad_dir)]
+    )
     assert rc == 1
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,360 @@
+"""Tests for ``python -m apps.cli`` sync/send entrypoint."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from apps.cli import __main__ as cli_main
+from libs.core.job_runner import SyncResult
+from libs.core.models import AccountAuth
+from libs.core.storage import Storage
+
+
+@pytest.fixture
+def cli_db_path(tmp_path: Path) -> str:
+    return str(tmp_path / "cli.sqlite")
+
+
+@pytest.fixture
+def cli_storage(cli_db_path: str) -> Storage:
+    s = Storage(db_path=cli_db_path)
+    s.migrate()
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def account_id(cli_storage: Storage) -> int:
+    auth = AccountAuth(li_at="cli-test-li-at", jsessionid=None)
+    return cli_storage.create_account(label="cli-test", auth=auth, proxy=None)
+
+
+def test_cli_sync_stderr_todo_when_provider_raises_not_implemented(
+    capsys: pytest.CaptureFixture[str], cli_db_path: str, account_id: int
+) -> None:
+    rc = cli_main.main(
+        ["sync", "--account-id", str(account_id), "--db-path", cli_db_path]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert cli_main._PROVIDER_TODO in err
+
+
+def test_cli_sync_stdout_json_on_success_with_mocked_empty_threads(
+    capsys: pytest.CaptureFixture[str],
+    cli_db_path: str,
+    account_id: int,
+) -> None:
+    with patch.object(cli_main, "LinkedInProvider") as m_cls:
+        inst = MagicMock()
+        inst.list_threads.return_value = []
+        m_cls.return_value = inst
+        rc = cli_main.main(
+            ["sync", "--account-id", str(account_id), "--db-path", cli_db_path]
+        )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out == {
+        "ok": True,
+        "synced_threads": 0,
+        "messages_inserted": 0,
+        "messages_skipped_duplicate": 0,
+        "pages_fetched": 0,
+    }
+    inst.list_threads.assert_called_once_with()
+
+
+def test_cli_sync_unknown_account_exits_one(cli_db_path: str) -> None:
+    rc = cli_main.main(["sync", "--account-id", "999", "--db-path", cli_db_path])
+    assert rc == 1
+
+
+def test_cli_sync_invalid_account_id_exits_one(cli_db_path: str) -> None:
+    rc = cli_main.main(["sync", "--account-id", "0", "--db-path", cli_db_path])
+    assert rc == 1
+
+
+def test_cli_sync_invalid_max_pages_exits_two(cli_db_path: str, account_id: int) -> None:
+    rc = cli_main.main(
+        [
+            "sync",
+            "--account-id",
+            str(account_id),
+            "--db-path",
+            cli_db_path,
+            "--max-pages-per-thread",
+            "0",
+        ]
+    )
+    assert rc == 2
+
+
+def test_cli_sync_invalid_limit_exits_two(cli_db_path: str, account_id: int) -> None:
+    rc = cli_main.main(
+        [
+            "sync",
+            "--account-id",
+            str(account_id),
+            "--db-path",
+            cli_db_path,
+            "--limit-per-thread",
+            "0",
+        ]
+    )
+    assert rc == 2
+
+
+def test_cli_sync_exhaust_conflicts_with_max_pages(cli_db_path: str, account_id: int) -> None:
+    rc = cli_main.main(
+        [
+            "sync",
+            "--account-id",
+            str(account_id),
+            "--db-path",
+            cli_db_path,
+            "--exhaust-pagination",
+            "--max-pages-per-thread",
+            "2",
+        ]
+    )
+    assert rc == 2
+
+
+def test_cli_sync_default_max_pages_per_thread_is_one(
+    cli_db_path: str, account_id: int
+) -> None:
+    with patch.object(cli_main, "run_sync") as m_run, patch.object(
+        cli_main, "LinkedInProvider"
+    ) as m_cls:
+        m_cls.return_value = MagicMock()
+        m_run.return_value = SyncResult(0, 0, 0, 0)
+        rc = cli_main.main(
+            ["sync", "--account-id", str(account_id), "--db-path", cli_db_path]
+        )
+    assert rc == 0
+    m_run.assert_called_once()
+    assert m_run.call_args.kwargs["max_pages_per_thread"] == 1
+
+
+def test_cli_sync_exhaust_pagination_passes_none_max_pages(
+    cli_db_path: str, account_id: int
+) -> None:
+    with patch.object(cli_main, "run_sync") as m_run, patch.object(
+        cli_main, "LinkedInProvider"
+    ) as m_cls:
+        m_cls.return_value = MagicMock()
+        m_run.return_value = SyncResult(0, 0, 0, 0)
+        rc = cli_main.main(
+            [
+                "sync",
+                "--account-id",
+                str(account_id),
+                "--db-path",
+                cli_db_path,
+                "--exhaust-pagination",
+            ]
+        )
+    assert rc == 0
+    m_run.assert_called_once()
+    assert m_run.call_args.kwargs["max_pages_per_thread"] is None
+
+
+def test_cli_send_stdout_json_on_success(
+    capsys: pytest.CaptureFixture[str], cli_db_path: str, account_id: int
+) -> None:
+    with patch.object(cli_main, "LinkedInProvider") as m_cls:
+        inst = MagicMock()
+        inst.send_message.return_value = "urn:li:msg:1"
+        m_cls.return_value = inst
+        rc = cli_main.main(
+            [
+                "send",
+                "--account-id",
+                str(account_id),
+                "--db-path",
+                cli_db_path,
+                "--recipient",
+                "urn:li:fsd_profile:ACoAAA",
+                "--text",
+                "hello",
+            ]
+        )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out == {"ok": True, "platform_message_id": "urn:li:msg:1"}
+    inst.send_message.assert_called_once_with(
+        recipient="urn:li:fsd_profile:ACoAAA",
+        text="hello",
+        idempotency_key=None,
+    )
+
+
+def test_cli_send_passes_idempotency_key(cli_db_path: str, account_id: int) -> None:
+    with patch.object(cli_main, "LinkedInProvider") as m_cls:
+        inst = MagicMock()
+        inst.send_message.return_value = "mid"
+        m_cls.return_value = inst
+        rc = cli_main.main(
+            [
+                "send",
+                "--account-id",
+                str(account_id),
+                "--db-path",
+                cli_db_path,
+                "--recipient",
+                "r1",
+                "--text",
+                "t",
+                "--idempotency-key",
+                "k1",
+            ]
+        )
+    assert rc == 0
+    inst.send_message.assert_called_once_with(
+        recipient="r1",
+        text="t",
+        idempotency_key="k1",
+    )
+
+
+def test_cli_send_unknown_account_exits_one(cli_db_path: str) -> None:
+    rc = cli_main.main(
+        [
+            "send",
+            "--account-id",
+            "42",
+            "--db-path",
+            cli_db_path,
+            "--recipient",
+            "r",
+            "--text",
+            "t",
+        ]
+    )
+    assert rc == 1
+
+
+def test_cli_send_invalid_account_id_exits_one(cli_db_path: str) -> None:
+    rc = cli_main.main(
+        [
+            "send",
+            "--account-id",
+            "0",
+            "--db-path",
+            cli_db_path,
+            "--recipient",
+            "r",
+            "--text",
+            "t",
+        ]
+    )
+    assert rc == 1
+
+
+def test_cli_send_text_exceeds_max_length_exits_one(
+    cli_db_path: str, account_id: int
+) -> None:
+    rc = cli_main.main(
+        [
+            "send",
+            "--account-id",
+            str(account_id),
+            "--db-path",
+            cli_db_path,
+            "--recipient",
+            "r",
+            "--text",
+            "x" * 8001,
+        ]
+    )
+    assert rc == 1
+
+
+def test_cli_send_empty_idempotency_key_exits_one(
+    cli_db_path: str, account_id: int
+) -> None:
+    rc = cli_main.main(
+        [
+            "send",
+            "--account-id",
+            str(account_id),
+            "--db-path",
+            cli_db_path,
+            "--recipient",
+            "r",
+            "--text",
+            "t",
+            "--idempotency-key",
+            "",
+        ]
+    )
+    assert rc == 1
+
+
+def test_cli_send_http_status_error_exits_one(cli_db_path: str, account_id: int) -> None:
+    req = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 500
+    err = httpx.HTTPStatusError("fail", request=req, response=resp)
+    with patch.object(cli_main, "LinkedInProvider") as m_cls:
+        inst = MagicMock()
+        inst.send_message.side_effect = err
+        m_cls.return_value = inst
+        rc = cli_main.main(
+            [
+                "send",
+                "--account-id",
+                str(account_id),
+                "--db-path",
+                cli_db_path,
+                "--recipient",
+                "r",
+                "--text",
+                "t",
+            ]
+        )
+    assert rc == 1
+
+
+def test_cli_send_not_implemented_exits_one(cli_db_path: str, account_id: int) -> None:
+    with patch.object(cli_main, "LinkedInProvider") as m_cls:
+        inst = MagicMock()
+        inst.send_message.side_effect = NotImplementedError
+        m_cls.return_value = inst
+        rc = cli_main.main(
+            [
+                "send",
+                "--account-id",
+                str(account_id),
+                "--db-path",
+                cli_db_path,
+                "--recipient",
+                "r",
+                "--text",
+                "t",
+            ]
+        )
+    assert rc == 1
+
+
+def test_cli_module_invocation_help_succeeds() -> None:
+    root = Path(__file__).resolve().parent.parent
+    env = {**os.environ, "PYTHONPATH": str(root)}
+    proc = subprocess.run(
+        [sys.executable, "-m", "apps.cli", "--help"],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "sync" in proc.stdout
+    assert "send" in proc.stdout


### PR DESCRIPTION
## Problem
Issue #10: testing the MVP required running FastAPI/uvicorn; there was no way to invoke sync/send from the shell using the same `Storage` + `LinkedInProvider` stack.

## Root Cause
Orchestration lived in `libs/core/job_runner.py` and was only wired through `apps/api/main.py`; no `python -m …` (or equivalent) CLI existed.

## Solution
Add `apps/cli/__main__.py` with `sync` and `send` subcommands that call `run_sync` / `run_send` after loading auth/proxy from SQLite. Success output is one JSON line (aligned with API response bodies). `NotImplementedError` prints the same guidance as HTTP 501. Send failures map common exceptions to stderr without echoing LinkedIn response bodies.

## Testing
- `test_cli_sync_stderr_todo_when_provider_raises_not_implemented` — real provider, sync stub → TODO + exit 1
- `test_cli_sync_stdout_json_on_success_with_mocked_empty_threads` — mocked empty thread list
- Account missing / invalid id; invalid limits; exhaust vs max-pages conflict; `run_sync` kwargs for default and exhaust modes
- Send: JSON output, idempotency key, unknown account, text length, empty idempotency key, HTTP error, `NotImplementedError`
- `test_cli_module_invocation_help_succeeds` — subprocess `python -m apps.cli --help`

Verify: `pytest tests/`

## Before / After
- **Before:** No CLI; only `POST /sync` and `POST /send` via uvicorn.
- **After:** e.g. `python -m apps.cli sync --account-id 1` and `python -m apps.cli send --account-id 1 --recipient … --text …` (optional `--db-path` per subcommand).

## Edge Cases Handled
- Unknown account; non-positive `--account-id`
- Invalid `--limit-per-thread` / `--max-pages-per-thread`; conflicting `--exhaust-pagination` + `--max-pages-per-thread`
- Provider not implemented (`NotImplementedError`); send HTTP errors without response body leakage
- Send text length cap; empty `--idempotency-key` when passed

Closes #10