### PR TITLE
feat: add rate limiting, backoff, and configurable sync delays

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
 from libs.core.cookies import cookies_to_account_auth, validate_li_at
-from libs.core.job_runner import run_send, run_sync, SyncResult
+from libs.core.job_runner import run_send, run_sync, SyncConfig, SyncResult
 from libs.core.models import AccountAuth, ProxyConfig
 from libs.core.redaction import configure_logging, redact_for_log, redact_string
 from libs.core.storage import Storage
@@ -87,6 +87,12 @@ class SyncIn(BaseModel):
         le=100,
         description="Max pages per thread (1=MVP); omit or null to exhaust cursor",
     )
+    delay_between_threads_s: float = Field(
+        2.0, ge=0, le=60, description="Seconds to pause between threads",
+    )
+    delay_between_pages_s: float = Field(
+        1.5, ge=0, le=60, description="Seconds to pause between fetch_messages pages",
+    )
 
 
 @app.get("/health")
@@ -152,6 +158,10 @@ def sync_account(body: SyncIn):
     except KeyError as e:
         raise HTTPException(status_code=404, detail=redact_string(str(e))) from e
     provider = LinkedInProvider(auth=auth, proxy=proxy)
+    sync_config = SyncConfig(
+        delay_between_threads_s=body.delay_between_threads_s,
+        delay_between_pages_s=body.delay_between_pages_s,
+    )
     try:
         result: SyncResult = run_sync(
             account_id=body.account_id,
@@ -159,6 +169,7 @@ def sync_account(body: SyncIn):
             provider=provider,
             limit_per_thread=body.limit_per_thread,
             max_pages_per_thread=body.max_pages_per_thread,
+            sync_config=sync_config,
         )
         return {
             "ok": True,
@@ -166,6 +177,7 @@ def sync_account(body: SyncIn):
             "messages_inserted": result.messages_inserted,
             "messages_skipped_duplicate": result.messages_skipped_duplicate,
             "pages_fetched": result.pages_fetched,
+            "rate_limited": result.rate_limited,
         }
     except PermissionError as exc:
         raise HTTPException(

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -157,7 +157,7 @@ def sync_account(body: SyncIn):
         proxy = storage.get_account_proxy(body.account_id)
     except KeyError as e:
         raise HTTPException(status_code=404, detail=redact_string(str(e))) from e
-    provider = LinkedInProvider(auth=auth, proxy=proxy)
+    provider = LinkedInProvider(auth=auth, proxy=proxy, account_id=body.account_id)
     sync_config = SyncConfig(
         delay_between_threads_s=body.delay_between_threads_s,
         delay_between_pages_s=body.delay_between_pages_s,
@@ -203,7 +203,7 @@ def send_message(body: SendIn):
         proxy = storage.get_account_proxy(body.account_id)
     except KeyError as e:
         raise HTTPException(status_code=404, detail=redact_string(str(e))) from e
-    provider = LinkedInProvider(auth=auth, proxy=proxy)
+    provider = LinkedInProvider(auth=auth, proxy=proxy, account_id=body.account_id)
     try:
         platform_message_id = run_send(
             account_id=body.account_id,

--- a/apps/cli/__main__.py
+++ b/apps/cli/__main__.py
@@ -143,7 +143,7 @@ def _load_provider(storage: Storage, account_id: int) -> LinkedInProvider | int:
     except ValueError as exc:
         _stderr(f"error: {exc}")
         return 1
-    return LinkedInProvider(auth=auth, proxy=proxy)
+    return LinkedInProvider(auth=auth, proxy=proxy, account_id=account_id)
 
 
 def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:

--- a/apps/cli/__main__.py
+++ b/apps/cli/__main__.py
@@ -14,7 +14,7 @@ from typing import Sequence
 
 import httpx
 
-from libs.core.job_runner import run_send, run_sync, SyncResult
+from libs.core.job_runner import run_send, run_sync, SyncConfig, SyncResult
 from libs.core.models import AccountAuth, ProxyConfig
 from libs.core.redaction import configure_logging
 from libs.core.storage import Storage
@@ -71,6 +71,20 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         "--exhaust-pagination",
         action="store_true",
         help="Follow cursors until exhausted (same as API max_pages_per_thread=null)",
+    )
+    p_sync.add_argument(
+        "--delay-threads",
+        type=float,
+        default=2.0,
+        metavar="SEC",
+        help="Seconds to pause between threads (default: 2.0)",
+    )
+    p_sync.add_argument(
+        "--delay-pages",
+        type=float,
+        default=1.5,
+        metavar="SEC",
+        help="Seconds to pause between fetch_messages pages (default: 1.5)",
     )
 
     p_send = sub.add_parser("send", help="Send one DM via the LinkedIn provider")
@@ -138,6 +152,10 @@ def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
         return loaded
     provider = loaded
     max_pages: int | None = args._resolved_max_pages  # type: ignore[attr-defined]
+    sync_config = SyncConfig(
+        delay_between_threads_s=args.delay_threads,
+        delay_between_pages_s=args.delay_pages,
+    )
     try:
         result: SyncResult = run_sync(
             account_id=args.account_id,
@@ -145,6 +163,7 @@ def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
             provider=provider,
             limit_per_thread=args.limit_per_thread,
             max_pages_per_thread=max_pages,
+            sync_config=sync_config,
         )
     except (NotImplementedError, ValueError):
         _stderr(_PROVIDER_TODO)
@@ -160,6 +179,7 @@ def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
         "messages_inserted": result.messages_inserted,
         "messages_skipped_duplicate": result.messages_skipped_duplicate,
         "pages_fetched": result.pages_fetched,
+        "rate_limited": result.rate_limited,
     }
     print(json.dumps(payload))
     return 0

--- a/libs/core/job_runner.py
+++ b/libs/core/job_runner.py
@@ -4,13 +4,14 @@ Reusable by the API and future CLI. Aligned to provider and storage stubs.
 """
 from __future__ import annotations
 
+import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from libs.core.storage import Storage
 from libs.providers.linkedin.provider import LinkedInProvider
 
-_DELAY_BETWEEN_PAGES_S = 1.5
+logger = logging.getLogger(__name__)
 
 
 def _normalize_sent_at(dt: datetime) -> datetime:
@@ -19,12 +20,21 @@ def _normalize_sent_at(dt: datetime) -> datetime:
     return dt
 
 
+@dataclass
+class SyncConfig:
+    """Configurable delays for safe sync under LinkedIn's anti-bot limits."""
+    delay_between_threads_s: float = 2.0
+    delay_between_pages_s: float = 1.5
+    delay_between_accounts_s: float = 5.0
+
+
 @dataclass(frozen=True)
 class SyncResult:
     synced_threads: int
     messages_inserted: int
     messages_skipped_duplicate: int
     pages_fetched: int
+    rate_limited: bool
 
 
 def run_sync(
@@ -33,6 +43,7 @@ def run_sync(
     provider: LinkedInProvider,
     limit_per_thread: int = 50,
     max_pages_per_thread: int | None = 1,
+    sync_config: SyncConfig | None = None,
 ) -> SyncResult:
     """Sync threads and messages from provider into storage.
 
@@ -42,16 +53,25 @@ def run_sync(
         provider: LinkedIn provider (list_threads, fetch_messages).
         limit_per_thread: Max messages per fetch_messages call.
         max_pages_per_thread: Max pages per thread (1 = MVP one page). None = exhaust cursor.
+        sync_config: Rate-limit delay configuration. Uses defaults if not provided.
 
     Returns:
         SyncResult with counts. Duplicates are skipped and counted separately.
     """
+    cfg = sync_config or SyncConfig()
     threads = provider.list_threads()
     synced_threads = 0
     messages_inserted = 0
     messages_skipped = 0
     pages_fetched = 0
-    for t in threads:
+    for i, t in enumerate(threads):
+        if i > 0:
+            logger.debug(
+                "sync: sleeping %.1fs between threads (account_id=%d)",
+                cfg.delay_between_threads_s,
+                account_id,
+            )
+            time.sleep(cfg.delay_between_threads_s)
         thread_id = storage.upsert_thread(
             account_id=account_id,
             platform_thread_id=t.platform_thread_id,
@@ -88,13 +108,14 @@ def run_sync(
             if next_cursor is None:
                 break
             cursor = next_cursor
-            time.sleep(_DELAY_BETWEEN_PAGES_S)
+            time.sleep(cfg.delay_between_pages_s)
         synced_threads += 1
     return SyncResult(
         synced_threads=synced_threads,
         messages_inserted=messages_inserted,
         messages_skipped_duplicate=messages_skipped,
         pages_fetched=pages_fetched,
+        rate_limited=provider.rate_limit_encountered,
     )
 
 

--- a/libs/core/job_runner.py
+++ b/libs/core/job_runner.py
@@ -25,6 +25,7 @@ class SyncConfig:
     """Configurable delays for safe sync under LinkedIn's anti-bot limits."""
     delay_between_threads_s: float = 2.0
     delay_between_pages_s: float = 1.5
+    # Reserved for future multi-account batch sync (not yet wired).
     delay_between_accounts_s: float = 5.0
 
 
@@ -110,6 +111,11 @@ def run_sync(
             cursor = next_cursor
             time.sleep(cfg.delay_between_pages_s)
         synced_threads += 1
+    if provider.rate_limit_encountered:
+        logger.warning(
+            "sync: rate-limit encountered during sync (account_id=%d)",
+            account_id,
+        )
     return SyncResult(
         synced_threads=synced_threads,
         messages_inserted=messages_inserted,

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -49,7 +49,8 @@ _MAX_PAGES = 50
 _DELAY_BETWEEN_PAGES_S = 1.5
 _RETRY_MAX_ATTEMPTS = 3
 _RETRY_BASE_DELAY_S = 2.0
-_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+_RETRYABLE_STATUS_CODES = frozenset({429, 999, 500, 502, 503, 504})
+_RATE_LIMIT_STATUS_CODES = frozenset({429, 999})
 _PLAYWRIGHT_NAV_RETRIES = 2
 
 # NOTE: These queryId hashes are extracted from LinkedIn's frontend JS bundle.
@@ -330,6 +331,7 @@ class LinkedInProvider:
         # send_message state (upstream)
         self._sent_keys: dict[str, str] = {}
         self._last_send_ts: float = 0.0
+        self.rate_limit_encountered: bool = False
         # GraphQL state
         self._client: Optional[httpx.Client] = None
         self._browser_cookies: Optional[dict[str, str]] = None
@@ -451,6 +453,13 @@ class LinkedInProvider:
         last_exc: Optional[httpx.HTTPStatusError] = None
         for attempt in range(_RETRY_MAX_ATTEMPTS):
             resp = client.get(url, **kwargs)
+
+            # 401 → fail fast, session is dead.
+            if resp.status_code == 401:
+                raise PermissionError(
+                    "LinkedIn session expired (HTTP 401). Re-authenticate."
+                )
+
             if resp.status_code not in _RETRYABLE_STATUS_CODES:
                 return resp
             last_exc = httpx.HTTPStatusError(
@@ -458,19 +467,37 @@ class LinkedInProvider:
             )
             if attempt == _RETRY_MAX_ATTEMPTS - 1:
                 break
-            delay = _RETRY_BASE_DELAY_S * (2 ** attempt)
-            if resp.status_code == 429:
+
+            is_rate_limit = resp.status_code in _RATE_LIMIT_STATUS_CODES
+            if is_rate_limit:
+                self.rate_limit_encountered = True
+                delay = min(
+                    _BACKOFF_START_S * (2 ** attempt), _BACKOFF_MAX_S,
+                )
+            else:
+                delay = _RETRY_BASE_DELAY_S * (2 ** attempt)
+
+            if is_rate_limit:
                 retry_after = resp.headers.get("Retry-After")
                 if retry_after:
                     try:
                         delay = max(delay, float(retry_after))
                     except (TypeError, ValueError):
                         pass
-            logger.debug(
-                "retry: %d from LinkedIn, attempt %d/%d in %.1fs",
-                resp.status_code, attempt + 1, _RETRY_MAX_ATTEMPTS, delay,
+
+            logger.warning(
+                "Rate-limit/retry: HTTP %d, account=%s, attempt %d/%d, backoff %.1fs",
+                resp.status_code,
+                "[redacted]",
+                attempt + 1,
+                _RETRY_MAX_ATTEMPTS,
+                delay,
             )
             time.sleep(delay)
+
+        # Final attempt also rate-limited — set the flag.
+        if last_exc is not None and last_exc.response.status_code in _RATE_LIMIT_STATUS_CODES:
+            self.rate_limit_encountered = True
         raise last_exc  # type: ignore[misc]
 
     def _is_cf_blocked(self, resp: httpx.Response) -> bool:
@@ -762,6 +789,7 @@ class LinkedInProvider:
                 continue
 
             if resp.status_code in (429, 999):
+                self.rate_limit_encountered = True
                 rate_limit_hits += 1
                 if rate_limit_hits > _MAX_RATE_LIMIT_RETRIES:
                     raise RuntimeError(

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -49,6 +49,7 @@ _MAX_PAGES = 50
 _DELAY_BETWEEN_PAGES_S = 1.5
 _RETRY_MAX_ATTEMPTS = 3
 _RETRY_BASE_DELAY_S = 2.0
+_RATE_LIMIT_MAX_ATTEMPTS = 6
 _RETRYABLE_STATUS_CODES = frozenset({429, 999, 500, 502, 503, 504})
 _RATE_LIMIT_STATUS_CODES = frozenset({429, 999})
 _PLAYWRIGHT_NAV_RETRIES = 2
@@ -325,9 +326,16 @@ class LinkedInProvider:
     - Do NOT implement CAPTCHA/2FA bypass.
     """
 
-    def __init__(self, *, auth: AccountAuth, proxy: Optional[ProxyConfig] = None):
+    def __init__(
+        self,
+        *,
+        auth: AccountAuth,
+        proxy: Optional[ProxyConfig] = None,
+        account_id: Optional[int] = None,
+    ):
         self.auth = auth
         self.proxy = proxy
+        self._account_id = account_id
         # send_message state (upstream)
         self._sent_keys: dict[str, str] = {}
         self._last_send_ts: float = 0.0
@@ -450,11 +458,28 @@ class LinkedInProvider:
         return self._profile_id
 
     def _get_with_retry(self, client: httpx.Client, url: str, **kwargs: Any) -> httpx.Response:
-        last_exc: Optional[httpx.HTTPStatusError] = None
-        for attempt in range(_RETRY_MAX_ATTEMPTS):
-            resp = client.get(url, **kwargs)
+        acct = self._account_id or "[unknown]"
+        network_failures = 0
+        rate_limit_attempts = 0
+        server_error_attempts = 0
 
-            # 401 → fail fast, session is dead.
+        while True:
+            try:
+                resp = client.get(url, **kwargs)
+            except (httpx.NetworkError, httpx.TimeoutException) as exc:
+                network_failures += 1
+                if network_failures >= _MAX_NETWORK_RETRIES:
+                    raise ConnectionError(
+                        f"GET failed after {network_failures} network retries"
+                    ) from exc
+                logger.warning(
+                    "Network error, account_id=%s, attempt %d/%d, retrying in %.0fs",
+                    acct, network_failures, _MAX_NETWORK_RETRIES,
+                    _NETWORK_RETRY_DELAY_S,
+                )
+                time.sleep(_NETWORK_RETRY_DELAY_S)
+                continue
+
             if resp.status_code == 401:
                 raise PermissionError(
                     "LinkedIn session expired (HTTP 401). Re-authenticate."
@@ -462,43 +487,44 @@ class LinkedInProvider:
 
             if resp.status_code not in _RETRYABLE_STATUS_CODES:
                 return resp
-            last_exc = httpx.HTTPStatusError(
-                str(resp.status_code), request=resp.request, response=resp,
-            )
-            if attempt == _RETRY_MAX_ATTEMPTS - 1:
-                break
 
             is_rate_limit = resp.status_code in _RATE_LIMIT_STATUS_CODES
             if is_rate_limit:
+                rate_limit_attempts += 1
                 self.rate_limit_encountered = True
+                if rate_limit_attempts >= _RATE_LIMIT_MAX_ATTEMPTS:
+                    raise httpx.HTTPStatusError(
+                        str(resp.status_code), request=resp.request, response=resp,
+                    )
                 delay = min(
-                    _BACKOFF_START_S * (2 ** attempt), _BACKOFF_MAX_S,
+                    _BACKOFF_START_S * (2 ** (rate_limit_attempts - 1)),
+                    _BACKOFF_MAX_S,
                 )
-            else:
-                delay = _RETRY_BASE_DELAY_S * (2 ** attempt)
-
-            if is_rate_limit:
                 retry_after = resp.headers.get("Retry-After")
                 if retry_after:
                     try:
                         delay = max(delay, float(retry_after))
                     except (TypeError, ValueError):
                         pass
+                logger.warning(
+                    "Rate-limit: HTTP %d, account_id=%s, attempt %d/%d, backoff %.1fs",
+                    resp.status_code, acct,
+                    rate_limit_attempts, _RATE_LIMIT_MAX_ATTEMPTS, delay,
+                )
+            else:
+                server_error_attempts += 1
+                if server_error_attempts >= _RETRY_MAX_ATTEMPTS:
+                    raise httpx.HTTPStatusError(
+                        str(resp.status_code), request=resp.request, response=resp,
+                    )
+                delay = _RETRY_BASE_DELAY_S * (2 ** (server_error_attempts - 1))
+                logger.warning(
+                    "Server error: HTTP %d, account_id=%s, attempt %d/%d, retry in %.1fs",
+                    resp.status_code, acct,
+                    server_error_attempts, _RETRY_MAX_ATTEMPTS, delay,
+                )
 
-            logger.warning(
-                "Rate-limit/retry: HTTP %d, account=%s, attempt %d/%d, backoff %.1fs",
-                resp.status_code,
-                "[redacted]",
-                attempt + 1,
-                _RETRY_MAX_ATTEMPTS,
-                delay,
-            )
             time.sleep(delay)
-
-        # Final attempt also rate-limited — set the flag.
-        if last_exc is not None and last_exc.response.status_code in _RATE_LIMIT_STATUS_CODES:
-            self.rate_limit_encountered = True
-        raise last_exc  # type: ignore[misc]
 
     def _is_cf_blocked(self, resp: httpx.Response) -> bool:
         if resp.status_code in (302, 303):
@@ -780,7 +806,8 @@ class LinkedInProvider:
                         f"Send failed after {network_failures} network retries"
                     ) from exc
                 logger.warning(
-                    "Network error (attempt %d/%d), retrying in %.0fs",
+                    "Network error, account_id=%s, attempt %d/%d, retrying in %.0fs",
+                    self._account_id or "[unknown]",
                     network_failures,
                     _MAX_NETWORK_RETRIES,
                     _NETWORK_RETRY_DELAY_S,
@@ -799,8 +826,9 @@ class LinkedInProvider:
                     _BACKOFF_START_S * (2 ** (rate_limit_hits - 1)), _BACKOFF_MAX_S
                 )
                 logger.warning(
-                    "Rate limited (HTTP %d, attempt %d/%d), backing off %.0fs",
+                    "Rate-limit: HTTP %d, account_id=%s, attempt %d/%d, backoff %.0fs",
                     resp.status_code,
+                    self._account_id or "[unknown]",
                     rate_limit_hits,
                     _MAX_RATE_LIMIT_RETRIES,
                     backoff,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ import httpx
 import pytest
 
 from apps.cli import __main__ as cli_main
-from libs.core.job_runner import SyncResult
+from libs.core.job_runner import SyncConfig, SyncResult
 from libs.core.models import AccountAuth
 from libs.core.storage import Storage
 
@@ -55,6 +55,7 @@ def test_cli_sync_stdout_json_on_success_with_mocked_empty_threads(
     with patch.object(cli_main, "LinkedInProvider") as m_cls:
         inst = MagicMock()
         inst.list_threads.return_value = []
+        inst.rate_limit_encountered = False
         m_cls.return_value = inst
         rc = cli_main.main(
             ["sync", "--account-id", str(account_id), "--db-path", cli_db_path]
@@ -67,6 +68,7 @@ def test_cli_sync_stdout_json_on_success_with_mocked_empty_threads(
         "messages_inserted": 0,
         "messages_skipped_duplicate": 0,
         "pages_fetched": 0,
+        "rate_limited": False,
     }
     inst.list_threads.assert_called_once_with()
 
@@ -134,7 +136,7 @@ def test_cli_sync_default_max_pages_per_thread_is_one(
         cli_main, "LinkedInProvider"
     ) as m_cls:
         m_cls.return_value = MagicMock()
-        m_run.return_value = SyncResult(0, 0, 0, 0)
+        m_run.return_value = SyncResult(0, 0, 0, 0, False)
         rc = cli_main.main(
             ["sync", "--account-id", str(account_id), "--db-path", cli_db_path]
         )
@@ -150,7 +152,7 @@ def test_cli_sync_exhaust_pagination_passes_none_max_pages(
         cli_main, "LinkedInProvider"
     ) as m_cls:
         m_cls.return_value = MagicMock()
-        m_run.return_value = SyncResult(0, 0, 0, 0)
+        m_run.return_value = SyncResult(0, 0, 0, 0, False)
         rc = cli_main.main(
             [
                 "sync",

--- a/tests/test_provider_retry.py
+++ b/tests/test_provider_retry.py
@@ -1,0 +1,262 @@
+"""Tests for LinkedInProvider retry, backoff, and rate-limit behavior."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, call
+
+import httpx
+import pytest
+
+from libs.core.models import AccountAuth
+from libs.providers.linkedin.provider import (
+    LinkedInProvider,
+    _BACKOFF_MAX_S,
+    _BACKOFF_START_S,
+    _MAX_NETWORK_RETRIES,
+    _NETWORK_RETRY_DELAY_S,
+    _RATE_LIMIT_MAX_ATTEMPTS,
+    _RETRY_BASE_DELAY_S,
+    _RETRY_MAX_ATTEMPTS,
+)
+
+
+@pytest.fixture
+def auth():
+    return AccountAuth(li_at="test-li-at", jsessionid="ajax:csrf123")
+
+
+@pytest.fixture
+def provider(auth):
+    return LinkedInProvider(auth=auth, proxy=None, account_id=42)
+
+
+def _mock_response(status_code: int, headers: dict | None = None) -> httpx.Response:
+    """Build a minimal httpx.Response with the given status code."""
+    request = httpx.Request("GET", "https://example.com/test")
+    return httpx.Response(
+        status_code=status_code,
+        request=request,
+        headers=headers or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
+def test_get_with_retry_returns_immediately_on_200(provider):
+    client = MagicMock(spec=httpx.Client)
+    client.get.return_value = _mock_response(200)
+
+    resp = provider._get_with_retry(client, "https://example.com")
+    assert resp.status_code == 200
+    client.get.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# HTTP 401 — fail fast
+# ---------------------------------------------------------------------------
+
+
+def test_get_with_retry_raises_permission_error_on_401(provider):
+    client = MagicMock(spec=httpx.Client)
+    client.get.return_value = _mock_response(401)
+
+    with pytest.raises(PermissionError, match="HTTP 401"):
+        provider._get_with_retry(client, "https://example.com")
+
+    client.get.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit (429/999) — exponential backoff
+# ---------------------------------------------------------------------------
+
+
+@patch("libs.providers.linkedin.provider.time.sleep")
+def test_get_with_retry_backoff_on_429(mock_sleep, provider):
+    """429 triggers exponential backoff starting at _BACKOFF_START_S."""
+    resp_429 = _mock_response(429)
+    resp_200 = _mock_response(200)
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [resp_429, resp_429, resp_200]
+
+    resp = provider._get_with_retry(client, "https://example.com")
+
+    assert resp.status_code == 200
+    assert client.get.call_count == 3
+    assert provider.rate_limit_encountered is True
+    assert mock_sleep.call_args_list == [
+        call(_BACKOFF_START_S),          # 30s (attempt 1)
+        call(_BACKOFF_START_S * 2),      # 60s (attempt 2)
+    ]
+
+
+@patch("libs.providers.linkedin.provider.time.sleep")
+def test_get_with_retry_999_treated_as_rate_limit(mock_sleep, provider):
+    """HTTP 999 (LinkedIn-specific) is treated as a rate limit, same as 429."""
+    resp_999 = _mock_response(999)
+    resp_200 = _mock_response(200)
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [resp_999, resp_200]
+
+    resp = provider._get_with_retry(client, "https://example.com")
+
+    assert resp.status_code == 200
+    assert provider.rate_limit_encountered is True
+    mock_sleep.assert_called_once_with(_BACKOFF_START_S)
+
+
+@patch("libs.providers.linkedin.provider.time.sleep")
+def test_get_with_retry_rate_limit_respects_retry_after(mock_sleep, provider):
+    resp_429 = _mock_response(429, headers={"Retry-After": "120"})
+    resp_200 = _mock_response(200)
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [resp_429, resp_200]
+
+    provider._get_with_retry(client, "https://example.com")
+
+    mock_sleep.assert_called_once_with(120.0)
+
+
+@patch("libs.providers.linkedin.provider.time.sleep")
+def test_get_with_retry_rate_limit_exhausts_attempts(mock_sleep, provider):
+    """After _RATE_LIMIT_MAX_ATTEMPTS, raises HTTPStatusError."""
+    resp_429 = _mock_response(429)
+    client = MagicMock(spec=httpx.Client)
+    client.get.return_value = resp_429
+
+    with pytest.raises(httpx.HTTPStatusError):
+        provider._get_with_retry(client, "https://example.com")
+
+    assert client.get.call_count == _RATE_LIMIT_MAX_ATTEMPTS
+    assert mock_sleep.call_count == _RATE_LIMIT_MAX_ATTEMPTS - 1
+    assert provider.rate_limit_encountered is True
+
+
+@patch("libs.providers.linkedin.provider.time.sleep")
+def test_get_with_retry_backoff_caps_at_max(mock_sleep, provider):
+    """Backoff delay is capped at _BACKOFF_MAX_S (15 min)."""
+    resp_429 = _mock_response(429)
+    resp_200 = _mock_response(200)
+    # 5 rate-limit responses then success (attempt 6)
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [resp_429] * 5 + [resp_200]
+
+    provider._get_with_retry(client, "https://example.com")
+
+    delays = [c.args[0] for c in mock_sleep.call_args_list]
+    for d in delays:
+        assert d <= _BACKOFF_MAX_S
+    # The 5th delay: 30 * 2^4 = 480 < 900, still under cap
+    assert delays[4] == min(_BACKOFF_START_S * (2 ** 4), _BACKOFF_MAX_S)
+
+
+# ---------------------------------------------------------------------------
+# Server errors (500, 502, etc.) — short retry
+# ---------------------------------------------------------------------------
+
+
+@patch("libs.providers.linkedin.provider.time.sleep")
+def test_get_with_retry_retries_server_error(mock_sleep, provider):
+    resp_500 = _mock_response(500)
+    resp_200 = _mock_response(200)
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [resp_500, resp_200]
+
+    resp = provider._get_with_retry(client, "https://example.com")
+
+    assert resp.status_code == 200
+    assert client.get.call_count == 2
+    mock_sleep.assert_called_once_with(_RETRY_BASE_DELAY_S)
+
+
+@patch("libs.providers.linkedin.provider.time.sleep")
+def test_get_with_retry_server_error_exhausts_attempts(mock_sleep, provider):
+    resp_502 = _mock_response(502)
+    client = MagicMock(spec=httpx.Client)
+    client.get.return_value = resp_502
+
+    with pytest.raises(httpx.HTTPStatusError):
+        provider._get_with_retry(client, "https://example.com")
+
+    assert client.get.call_count == _RETRY_MAX_ATTEMPTS
+    assert mock_sleep.call_count == _RETRY_MAX_ATTEMPTS - 1
+
+
+@patch("libs.providers.linkedin.provider.time.sleep")
+def test_get_with_retry_server_and_rate_limit_have_separate_budgets(mock_sleep, provider):
+    """Mixed errors use independent retry counters."""
+    resp_500 = _mock_response(500)
+    resp_429 = _mock_response(429)
+    resp_200 = _mock_response(200)
+    client = MagicMock(spec=httpx.Client)
+    # 2 server errors (under limit of 3) then 1 rate limit then success
+    client.get.side_effect = [resp_500, resp_500, resp_429, resp_200]
+
+    resp = provider._get_with_retry(client, "https://example.com")
+
+    assert resp.status_code == 200
+    assert client.get.call_count == 4
+    assert provider.rate_limit_encountered is True
+
+
+# ---------------------------------------------------------------------------
+# Network errors — retry with fixed delay
+# ---------------------------------------------------------------------------
+
+
+@patch("libs.providers.linkedin.provider.time.sleep")
+def test_get_with_retry_retries_on_network_error(mock_sleep, provider):
+    resp_200 = _mock_response(200)
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [httpx.ConnectError("fail"), resp_200]
+
+    resp = provider._get_with_retry(client, "https://example.com")
+
+    assert resp.status_code == 200
+    assert client.get.call_count == 2
+    mock_sleep.assert_called_once_with(_NETWORK_RETRY_DELAY_S)
+
+
+@patch("libs.providers.linkedin.provider.time.sleep")
+def test_get_with_retry_retries_on_timeout(mock_sleep, provider):
+    resp_200 = _mock_response(200)
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = [httpx.ReadTimeout("timeout"), resp_200]
+
+    resp = provider._get_with_retry(client, "https://example.com")
+
+    assert resp.status_code == 200
+    mock_sleep.assert_called_once_with(_NETWORK_RETRY_DELAY_S)
+
+
+@patch("libs.providers.linkedin.provider.time.sleep")
+def test_get_with_retry_raises_connection_error_after_max_network_retries(
+    mock_sleep, provider
+):
+    client = MagicMock(spec=httpx.Client)
+    client.get.side_effect = httpx.ConnectError("down")
+
+    with pytest.raises(ConnectionError, match="network retries"):
+        provider._get_with_retry(client, "https://example.com")
+
+    assert client.get.call_count == _MAX_NETWORK_RETRIES
+    assert mock_sleep.call_count == _MAX_NETWORK_RETRIES - 1
+
+
+# ---------------------------------------------------------------------------
+# account_id in provider
+# ---------------------------------------------------------------------------
+
+
+def test_provider_stores_account_id():
+    auth = AccountAuth(li_at="x", jsessionid="y")
+    p = LinkedInProvider(auth=auth, proxy=None, account_id=7)
+    assert p._account_id == 7
+
+
+def test_provider_account_id_defaults_to_none():
+    auth = AccountAuth(li_at="x", jsessionid="y")
+    p = LinkedInProvider(auth=auth, proxy=None)
+    assert p._account_id is None

--- a/tests/test_sync_send.py
+++ b/tests/test_sync_send.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from libs.core.job_runner import SyncResult, run_send, run_sync
+from libs.core.job_runner import SyncConfig, SyncResult, run_send, run_sync
 from libs.core.models import AccountAuth
 from libs.core.storage import Storage
 from libs.providers.linkedin.provider import LinkedInMessage, LinkedInProvider, LinkedInThread
@@ -31,6 +31,13 @@ def account_id(storage):
     return storage.create_account(label="test", auth=auth, proxy=None)
 
 
+def _mock_provider(**kwargs):
+    """Create a MagicMock provider with rate_limit_encountered attribute."""
+    provider = MagicMock(spec=LinkedInProvider, **kwargs)
+    provider.rate_limit_encountered = False
+    return provider
+
+
 def test_run_sync_upserts_threads_and_messages(storage, account_id):
     thread = LinkedInThread(platform_thread_id="urn:li:conv:1", title="Alice", raw=None)
     msg = LinkedInMessage(
@@ -41,7 +48,7 @@ def test_run_sync_upserts_threads_and_messages(storage, account_id):
         sent_at=datetime.now(timezone.utc),
         raw=None,
     )
-    provider = MagicMock(spec=LinkedInProvider)
+    provider = _mock_provider()
     provider.list_threads.return_value = [thread]
     provider.fetch_messages.return_value = ([msg], None)
 
@@ -56,6 +63,7 @@ def test_run_sync_upserts_threads_and_messages(storage, account_id):
     assert result.messages_inserted == 1
     assert result.messages_skipped_duplicate == 0
     assert result.pages_fetched == 1
+    assert result.rate_limited is False
     provider.list_threads.assert_called_once()
     provider.fetch_messages.assert_called_once_with(
         platform_thread_id="urn:li:conv:1",
@@ -69,7 +77,7 @@ def test_run_sync_upserts_threads_and_messages(storage, account_id):
 
 
 def test_run_sync_empty_threads_returns_zero_counts(storage, account_id):
-    provider = MagicMock(spec=LinkedInProvider)
+    provider = _mock_provider()
     provider.list_threads.return_value = []
 
     result = run_sync(
@@ -105,7 +113,7 @@ def test_run_sync_multiple_threads_and_messages(storage, account_id):
         sent_at=datetime.now(timezone.utc),
         raw=None,
     )
-    provider = MagicMock(spec=LinkedInProvider)
+    provider = _mock_provider()
     provider.list_threads.return_value = [t1, t2]
     provider.fetch_messages.side_effect = [([msg1], None), ([msg2], None)]
 
@@ -131,7 +139,7 @@ def test_run_sync_duplicate_messages_counted_as_skipped(storage, account_id):
         sent_at=datetime.now(timezone.utc),
         raw=None,
     )
-    provider = MagicMock(spec=LinkedInProvider)
+    provider = _mock_provider()
     provider.list_threads.return_value = [thread]
     provider.fetch_messages.return_value = ([msg], None)
 
@@ -156,7 +164,7 @@ def test_run_sync_duplicate_messages_counted_as_skipped(storage, account_id):
 
 def test_run_sync_uses_stored_cursor(storage, account_id):
     thread = LinkedInThread(platform_thread_id="t1", title=None, raw=None)
-    provider = MagicMock(spec=LinkedInProvider)
+    provider = _mock_provider()
     provider.list_threads.return_value = [thread]
     provider.fetch_messages.return_value = ([], None)
     thread_id = storage.upsert_thread(
@@ -195,7 +203,7 @@ def test_run_sync_exhausts_cursor_when_max_pages_none(storage, account_id):
         sent_at=datetime.now(timezone.utc),
         raw=None,
     )
-    provider = MagicMock(spec=LinkedInProvider)
+    provider = _mock_provider()
     provider.list_threads.return_value = [thread]
     provider.fetch_messages.side_effect = [
         ([msg1], "cursor2"),
@@ -216,7 +224,7 @@ def test_run_sync_exhausts_cursor_when_max_pages_none(storage, account_id):
 
 def test_run_sync_respects_max_pages_per_thread(storage, account_id):
     thread = LinkedInThread(platform_thread_id="t1", title=None, raw=None)
-    provider = MagicMock(spec=LinkedInProvider)
+    provider = _mock_provider()
     provider.list_threads.return_value = [thread]
     provider.fetch_messages.return_value = ([], "next")
 
@@ -242,7 +250,7 @@ def test_run_sync_normalizes_naive_sent_at(storage, account_id):
         sent_at=naive_dt,
         raw=None,
     )
-    provider = MagicMock(spec=LinkedInProvider)
+    provider = _mock_provider()
     provider.list_threads.return_value = [thread]
     provider.fetch_messages.return_value = ([msg], None)
 
@@ -258,6 +266,39 @@ def test_run_sync_normalizes_naive_sent_at(storage, account_id):
     ).fetchall()
     assert len(rows) == 1
     assert "Z" in rows[0]["sent_at"] or "+00:00" in rows[0]["sent_at"]
+
+
+def test_run_sync_rate_limited_flag_propagated(storage, account_id):
+    thread = LinkedInThread(platform_thread_id="t1", title=None, raw=None)
+    provider = _mock_provider()
+    provider.list_threads.return_value = [thread]
+    provider.fetch_messages.return_value = ([], None)
+    provider.rate_limit_encountered = True
+
+    result = run_sync(
+        account_id=account_id,
+        storage=storage,
+        provider=provider,
+        limit_per_thread=50,
+    )
+    assert result.rate_limited is True
+
+
+def test_run_sync_respects_sync_config_delays(storage, account_id):
+    """SyncConfig is accepted and doesn't break the sync."""
+    provider = _mock_provider()
+    provider.list_threads.return_value = []
+    cfg = SyncConfig(delay_between_threads_s=0.0, delay_between_pages_s=0.0)
+
+    result = run_sync(
+        account_id=account_id,
+        storage=storage,
+        provider=provider,
+        limit_per_thread=50,
+        sync_config=cfg,
+    )
+    assert result.synced_threads == 0
+    assert result.rate_limited is False
 
 
 def test_run_send_returns_platform_message_id(storage, account_id):
@@ -375,6 +416,7 @@ def test_sync_endpoint_returns_detailed_counts(storage, account_id):
     assert "messages_inserted" in data
     assert "messages_skipped_duplicate" in data
     assert "pages_fetched" in data
+    assert "rate_limited" in data
 
 
 def test_send_endpoint_404_for_unknown_account(db_path):

--- a/tests/test_sync_send.py
+++ b/tests/test_sync_send.py
@@ -285,20 +285,62 @@ def test_run_sync_rate_limited_flag_propagated(storage, account_id):
 
 
 def test_run_sync_respects_sync_config_delays(storage, account_id):
-    """SyncConfig is accepted and doesn't break the sync."""
+    """SyncConfig delays are forwarded to time.sleep between threads and pages."""
+    from unittest.mock import patch, call
+
+    t1 = LinkedInThread(platform_thread_id="c1", title=None, raw=None)
+    t2 = LinkedInThread(platform_thread_id="c2", title=None, raw=None)
+    msg = LinkedInMessage(
+        platform_message_id="m1",
+        direction="in",
+        sender=None,
+        text="x",
+        sent_at=datetime.now(timezone.utc),
+        raw=None,
+    )
+    provider = _mock_provider()
+    provider.list_threads.return_value = [t1, t2]
+    provider.fetch_messages.side_effect = [
+        ([msg], "next"),
+        ([], None),
+        ([], None),
+    ]
+    cfg = SyncConfig(delay_between_threads_s=3.5, delay_between_pages_s=1.0)
+
+    with patch("libs.core.job_runner.time.sleep") as mock_sleep:
+        result = run_sync(
+            account_id=account_id,
+            storage=storage,
+            provider=provider,
+            limit_per_thread=50,
+            max_pages_per_thread=None,
+            sync_config=cfg,
+        )
+
+    assert result.synced_threads == 2
+    sleep_calls = [c.args[0] for c in mock_sleep.call_args_list]
+    assert 3.5 in sleep_calls
+    assert 1.0 in sleep_calls
+
+
+def test_run_sync_logs_rate_limit_warning(storage, account_id, caplog):
+    """When provider signals rate-limit, run_sync logs a warning with account_id."""
+    import logging
+
     provider = _mock_provider()
     provider.list_threads.return_value = []
-    cfg = SyncConfig(delay_between_threads_s=0.0, delay_between_pages_s=0.0)
+    provider.rate_limit_encountered = True
 
-    result = run_sync(
-        account_id=account_id,
-        storage=storage,
-        provider=provider,
-        limit_per_thread=50,
-        sync_config=cfg,
-    )
-    assert result.synced_threads == 0
-    assert result.rate_limited is False
+    with caplog.at_level(logging.WARNING, logger="libs.core.job_runner"):
+        result = run_sync(
+            account_id=account_id,
+            storage=storage,
+            provider=provider,
+            limit_per_thread=50,
+        )
+    assert result.rate_limited is True
+    assert any("rate-limit" in r.message.lower() for r in caplog.records)
+    assert any(str(account_id) in r.message for r in caplog.records)
 
 
 def test_run_send_returns_platform_message_id(storage, account_id):


### PR DESCRIPTION
## Summary
- Add `SyncConfig` dataclass with configurable delays between threads, pages, and accounts
- Implement exponential backoff (30s–15min) on HTTP 429/999 rate-limit responses
- Fail fast on HTTP 401 (expired session) instead of retrying
- Track and propagate `rate_limited` flag through `SyncResult`, API, and CLI responses
- Expose `--delay-threads` / `--delay-pages` CLI args and matching API fields

## Test plan
- [x] Existing sync/send tests pass (12/12)
- [x] Manual test: trigger 429 response and verify backoff logging
- [x] Manual test: verify `rate_limited: true` in API/CLI output after rate-limit hit
- [x] Manual test: confirm configurable delays are respected between threads

Closes #7