### PR TITLE
feat: Add Docker support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Application
+PORT=8000
+LOG_LEVEL=INFO
+
+# SQLite database path (default: ./desearch_linkedin_dms.sqlite)
+# DB_PATH=/app/data/desearch_linkedin_dms.sqlite
+
+# Add your environment variables here
+# Example: per-account proxy (set via API endpoints, not env vars directly)
+# PROXY_URL=http://user:pass@host:port

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.pyc
 .env
 .env.*
+!.env.example
 *.sqlite
 *.sqlite-shm
 *.sqlite-wal
@@ -11,3 +12,4 @@ __pycache__/
 *.db-wal
 .DS_Store
 desearch_dms.egg-info/
+logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python package and dependencies from pyproject.toml
+COPY pyproject.toml .
+# Copy source so pip install -e . can find packages
+COPY apps/ apps/
+COPY libs/ libs/
+
+RUN pip install --no-cache-dir -e .
+
+# Copy remaining project files
+COPY . .
+
+# Environment variables with defaults
+ENV LOG_LEVEL=INFO \
+    PORT=8000 \
+    HOST=0.0.0.0
+
+EXPOSE 8000
+
+# Health check — the /health endpoint is defined in apps/api/main.py
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+
+# Run the FastAPI app via uvicorn
+CMD ["python", "-m", "uvicorn", "apps.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -279,6 +279,35 @@ proxy_url=http://u:p@host:8080   →  proxy_url=[REDACTED]
 - [ ] LinkedIn provider: send DM (TBD)
 - [ ] Proxy + per-account rate limiting
 
+## Docker
+
+### Quick Start with Docker
+
+```bash
+# Copy environment file and edit with your settings
+cp .env.example .env
+
+# Build and run
+docker-compose up -d
+
+# View logs
+docker-compose logs -f
+
+# Stop
+docker-compose down
+```
+
+### Build manually
+
+```bash
+docker build -t linkedin-dms .
+docker run -d --env-file .env -p 8000:8000 linkedin-dms
+```
+
+Once running, the API is available at:
+- Health: http://localhost:8000/health
+- Swagger UI: http://localhost:8000/docs
+
 ---
 
 If you want to help, start with the issues in this repo.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    container_name: linkedin-dms
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "${PORT:-8000}:8000"
+    volumes:
+      - ./logs:/app/logs
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  # Uncomment if project uses a database (currently uses SQLite locally)
+  # db:
+  #   image: postgres:15-alpine
+  #   environment:
+  #     POSTGRES_DB: ${DB_NAME:-linkedin_dms}
+  #     POSTGRES_USER: ${DB_USER:-postgres}
+  #     POSTGRES_PASSWORD: ${DB_PASSWORD}
+  #   volumes:
+  #     - postgres_data:/var/lib/postgresql/data
+
+# volumes:
+#   postgres_data:


### PR DESCRIPTION
## Summary
Adds Docker support for easy deployment as requested in #21.

## Changes
- **Dockerfile**: Python 3.11-slim base image running uvicorn to serve the FastAPI app (`apps.api.main:app`). Health check uses built-in `urllib` — no extra dependencies needed.
- **docker-compose.yml**: Full stack deployment with `env_file` support, log volume, and health check configuration
- **.env.example**: Template for environment variables with inline documentation
- **.gitignore**: Add `logs/` dir; un-ignore `.env.example` (previously matched `.env.*` glob)
- **README.md**: Docker quick start and manual build instructions

## How to use
```bash
cp .env.example .env
docker-compose up -d
docker-compose logs -f
```

Closes #21