### PR TITLE
feat(extension): Chrome Extension — cookie bridge, auto-refresh, header capture (#21)

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,186 @@
+// Desearch LinkedIn DMs — Chrome Extension Background Service Worker
+// Monitors li_at cookie changes and captures x-li-track / csrf-token headers.
+
+const LINKEDIN_DOMAIN = "linkedin.com";
+const VOYAGER_API_PATTERN = "https://www.linkedin.com/voyager/api/*";
+
+const SERVICE_URL_DEFAULT = "http://localhost:8899";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function getConfig() {
+  const result = await chrome.storage.local.get({
+    serviceUrl: SERVICE_URL_DEFAULT,
+    accountId: null,
+  });
+  return result;
+}
+
+async function setStatus(status, error = null) {
+  await chrome.storage.local.set({
+    lastStatus: status,
+    lastError: error,
+    lastUpdated: new Date().toISOString(),
+  });
+}
+
+async function getLinkedInCookies() {
+  const cookies = {};
+  const liAt = await chrome.cookies.get({
+    url: "https://www.linkedin.com",
+    name: "li_at",
+  });
+  if (liAt) cookies.li_at = liAt.value;
+
+  const jsessionid = await chrome.cookies.get({
+    url: "https://www.linkedin.com",
+    name: "JSESSIONID",
+  });
+  if (jsessionid) cookies.JSESSIONID = jsessionid.value.replace(/"/g, "");
+
+  return cookies;
+}
+
+// ─── Cookie Monitoring ──────────────────────────────────────────────────────
+
+chrome.cookies.onChanged.addListener(({ cookie, removed }) => {
+  if (cookie.domain.includes("linkedin.com") && cookie.name === "li_at" && !removed) {
+    // Get JSESSIONID too
+    chrome.cookies.get({ url: "https://www.linkedin.com", name: "JSESSIONID" }, async (jsession) => {
+      try {
+        const config = await getConfig();
+        const cookies = {
+          li_at: cookie.value,
+          JSESSIONID: jsession?.value?.replace(/"/g, "") || null,
+        };
+
+        if (config.accountId) {
+          await pushRefresh(config, cookies);
+        } else {
+          await registerAccount(config, cookies);
+        }
+      } catch (err) {
+        console.error("[desearch] cookie change handler error:", err);
+        await setStatus("error", err.message);
+      }
+    });
+  }
+});
+
+async function pushRefresh(config, cookies) {
+  const payload = {
+    account_id: config.accountId,
+    li_at: cookies.li_at,
+    jsessionid: cookies.JSESSIONID || null,
+  };
+
+  const resp = await fetch(`${config.serviceUrl}/accounts/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!resp.ok) {
+    const detail = await resp.text();
+    throw new Error(`Refresh failed (${resp.status}): ${detail}`);
+  }
+
+  console.log("[desearch] cookie refresh pushed successfully");
+  await setStatus("connected");
+}
+
+async function registerAccount(config, cookies) {
+  const payload = {
+    label: "chrome-extension",
+    li_at: cookies.li_at,
+    jsessionid: cookies.JSESSIONID || null,
+  };
+
+  const resp = await fetch(`${config.serviceUrl}/accounts`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!resp.ok) {
+    const detail = await resp.text();
+    throw new Error(`Account registration failed (${resp.status}): ${detail}`);
+  }
+
+  const data = await resp.json();
+  await chrome.storage.local.set({ accountId: data.account_id });
+  console.log("[desearch] account registered:", data.account_id);
+  await setStatus("connected");
+}
+
+// ─── Header Capture ─────────────────────────────────────────────────────────
+// Intercept outgoing LinkedIn Voyager API requests to capture x-li-track and
+// csrf-token header values from the real browser session.
+
+chrome.webRequest.onSendHeaders.addListener(
+  (details) => {
+    const track = details.requestHeaders.find(h => h.name === "x-li-track");
+    const csrf = details.requestHeaders.find(h => h.name === "csrf-token");
+    if (track || csrf) {
+      // store for provider use
+      chrome.storage.local.set({ xLiTrack: track?.value, csrfToken: csrf?.value });
+    }
+  },
+  { urls: [VOYAGER_API_PATTERN] },
+  ["requestHeaders"]
+);
+
+// ─── Message handling (from popup) ──────────────────────────────────────────
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg.type === "MANUAL_SYNC") {
+    handleManualSync()
+      .then((result) => sendResponse({ ok: true, data: result }))
+      .catch((err) => sendResponse({ ok: false, error: err.message }));
+    return true; // keep channel open for async response
+  }
+
+  if (msg.type === "MANUAL_REFRESH") {
+    handleManualRefresh()
+      .then(() => sendResponse({ ok: true }))
+      .catch((err) => sendResponse({ ok: false, error: err.message }));
+    return true;
+  }
+});
+
+async function handleManualSync() {
+  const config = await getConfig();
+  if (!config.accountId) {
+    throw new Error("No account registered. Log in to LinkedIn first.");
+  }
+
+  const resp = await fetch(`${config.serviceUrl}/sync`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ account_id: config.accountId }),
+  });
+
+  if (!resp.ok) {
+    const detail = await resp.text();
+    throw new Error(`Sync failed (${resp.status}): ${detail}`);
+  }
+
+  const data = await resp.json();
+  await setStatus("connected");
+  return data;
+}
+
+async function handleManualRefresh() {
+  const config = await getConfig();
+  const cookies = await getLinkedInCookies();
+
+  if (!cookies.li_at) {
+    throw new Error("Not logged in to LinkedIn — no li_at cookie found.");
+  }
+
+  if (config.accountId) {
+    await pushRefresh(config, cookies);
+  } else {
+    await registerAccount(config, cookies);
+  }
+}

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "Desearch LinkedIn DMs Bridge",
+  "version": "0.1.0",
+  "description": "Secure authentication bridge between LinkedIn browser sessions and Desearch sync service.",
+  "permissions": [
+    "cookies",
+    "storage",
+    "webRequest"
+  ],
+  "host_permissions": [
+    "https://www.linkedin.com/*",
+    "http://localhost:8899/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Desearch LinkedIn Bridge"
+  },
+  "icons": {}
+}

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=300" />
+  <title>Desearch LinkedIn Bridge</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      width: 320px;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-size: 13px;
+      color: #1d1d1f;
+      background: #fafafa;
+      padding: 16px;
+    }
+
+    h1 {
+      font-size: 15px;
+      font-weight: 600;
+      margin-bottom: 12px;
+    }
+
+    .status-card {
+      background: #fff;
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      padding: 12px;
+      margin-bottom: 12px;
+    }
+
+    .status-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 6px;
+    }
+
+    .status-row:last-child { margin-bottom: 0; }
+
+    .status-label { color: #666; }
+
+    .status-value { font-weight: 500; }
+
+    .status-dot {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      margin-right: 6px;
+      vertical-align: middle;
+    }
+
+    .dot-connected { background: #34c759; }
+    .dot-error { background: #ff3b30; }
+    .dot-unknown { background: #999; }
+
+    .config-section {
+      margin-bottom: 12px;
+    }
+
+    .config-section label {
+      display: block;
+      font-size: 11px;
+      color: #666;
+      margin-bottom: 4px;
+    }
+
+    .config-section input {
+      width: 100%;
+      padding: 6px 8px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 12px;
+    }
+
+    .btn-row {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+
+    button {
+      flex: 1;
+      padding: 8px 12px;
+      border: none;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+
+    button:hover { opacity: 0.85; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .btn-primary { background: #0a66c2; color: #fff; }
+    .btn-secondary { background: #e8e8e8; color: #333; }
+
+    #result {
+      font-size: 11px;
+      color: #555;
+      margin-top: 8px;
+      max-height: 80px;
+      overflow-y: auto;
+      word-break: break-word;
+    }
+
+    .error-text { color: #ff3b30; }
+  </style>
+</head>
+<body>
+  <h1>Desearch LinkedIn Bridge</h1>
+
+  <div class="status-card">
+    <div class="status-row">
+      <span class="status-label">Status</span>
+      <span class="status-value" id="statusText">
+        <span class="status-dot dot-unknown" id="statusDot"></span>
+        <span id="statusLabel">Checking...</span>
+      </span>
+    </div>
+    <div class="status-row">
+      <span class="status-label">Account ID</span>
+      <span class="status-value" id="accountId">—</span>
+    </div>
+    <div class="status-row">
+      <span class="status-label">Last updated</span>
+      <span class="status-value" id="lastUpdated">—</span>
+    </div>
+    <div class="status-row">
+      <span class="status-label">Headers captured</span>
+      <span class="status-value" id="headersStatus">—</span>
+    </div>
+  </div>
+
+  <div class="config-section">
+    <label for="backendUrl">Service URL</label>
+    <input type="text" id="backendUrl" placeholder="http://localhost:8899" />
+  </div>
+
+  <div class="btn-row">
+    <button class="btn-primary" id="btnSync">Sync Now</button>
+    <button class="btn-secondary" id="btnRefresh">Refresh Cookies</button>
+  </div>
+
+  <button class="btn-secondary" id="btnSaveConfig" style="width:100%">Save Config</button>
+
+  <div id="result"></div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,0 +1,123 @@
+// Desearch LinkedIn DMs — Popup UI Logic
+
+const statusDot = document.getElementById("statusDot");
+const statusLabel = document.getElementById("statusLabel");
+const accountIdEl = document.getElementById("accountId");
+const lastUpdatedEl = document.getElementById("lastUpdated");
+const headersStatusEl = document.getElementById("headersStatus");
+const backendUrlInput = document.getElementById("backendUrl");
+const resultEl = document.getElementById("result");
+const btnSync = document.getElementById("btnSync");
+const btnRefresh = document.getElementById("btnRefresh");
+const btnSaveConfig = document.getElementById("btnSaveConfig");
+
+// ─── Load state ──────────────────────────────────────────────────────────────
+
+async function loadState() {
+  const state = await chrome.storage.local.get({
+    serviceUrl: "http://localhost:8899",
+    accountId: null,
+    lastStatus: null,
+    lastError: null,
+    lastUpdated: null,
+    xLiTrack: null,
+    csrfToken: null,
+  });
+
+  backendUrlInput.value = state.serviceUrl;
+  accountIdEl.textContent = state.accountId ?? "—";
+
+  // Status indicator
+  if (state.lastStatus === "connected") {
+    statusDot.className = "status-dot dot-connected";
+    statusLabel.textContent = "Connected";
+  } else if (state.lastStatus === "error") {
+    statusDot.className = "status-dot dot-error";
+    statusLabel.textContent = state.lastError || "Error";
+  } else {
+    statusDot.className = "status-dot dot-unknown";
+    statusLabel.textContent = "Not connected";
+  }
+
+  // Last updated
+  if (state.lastUpdated) {
+    const d = new Date(state.lastUpdated);
+    lastUpdatedEl.textContent = d.toLocaleTimeString();
+  } else {
+    lastUpdatedEl.textContent = "—";
+  }
+
+  // Headers
+  const hasTrack = !!state.xLiTrack;
+  const hasCsrf = !!state.csrfToken;
+  if (hasTrack && hasCsrf) {
+    headersStatusEl.textContent = "x-li-track, csrf-token";
+  } else if (hasTrack || hasCsrf) {
+    headersStatusEl.textContent = hasTrack ? "x-li-track only" : "csrf-token only";
+  } else {
+    headersStatusEl.textContent = "—";
+  }
+}
+
+// ─── Actions ─────────────────────────────────────────────────────────────────
+
+function showResult(text, isError = false) {
+  resultEl.textContent = text;
+  resultEl.className = isError ? "error-text" : "";
+}
+
+function setButtonsDisabled(disabled) {
+  btnSync.disabled = disabled;
+  btnRefresh.disabled = disabled;
+}
+
+btnSaveConfig.addEventListener("click", async () => {
+  const url = backendUrlInput.value.trim().replace(/\/+$/, "");
+  if (!url) {
+    showResult("Backend URL is required.", true);
+    return;
+  }
+  await chrome.storage.local.set({ serviceUrl: url });
+  showResult("Config saved.");
+});
+
+btnSync.addEventListener("click", async () => {
+  setButtonsDisabled(true);
+  showResult("Syncing...");
+  try {
+    const resp = await chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+    if (resp.ok) {
+      const d = resp.data;
+      showResult(
+        `Synced ${d.synced_threads} threads, ${d.messages_inserted} new messages.`
+      );
+    } else {
+      showResult(resp.error || "Sync failed.", true);
+    }
+  } catch (err) {
+    showResult(err.message, true);
+  }
+  setButtonsDisabled(false);
+  await loadState();
+});
+
+btnRefresh.addEventListener("click", async () => {
+  setButtonsDisabled(true);
+  showResult("Refreshing cookies...");
+  try {
+    const resp = await chrome.runtime.sendMessage({ type: "MANUAL_REFRESH" });
+    if (resp.ok) {
+      showResult("Cookies refreshed successfully.");
+    } else {
+      showResult(resp.error || "Refresh failed.", true);
+    }
+  } catch (err) {
+    showResult(err.message, true);
+  }
+  setButtonsDisabled(false);
+  await loadState();
+});
+
+// ─── Init ────────────────────────────────────────────────────────────────────
+
+loadState();

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -1,0 +1,313 @@
+/**
+ * Acceptance-criteria tests for background.js
+ *
+ * Mocks chrome.cookies, chrome.storage, chrome.webRequest, chrome.runtime
+ * and global fetch to verify:
+ *   AC1 – extension loads without error
+ *   AC2 – cookie capture registers a new account via POST /accounts
+ *   AC3 – cookie change on existing account triggers POST /accounts/refresh
+ *   AC4 – header capture stores xLiTrack / csrfToken
+ *   AC5 – MANUAL_SYNC message triggers POST /sync
+ *   AC6 – MANUAL_REFRESH message triggers refresh or register
+ */
+
+import { readFileSync } from "fs";
+import { Script, createContext } from "vm";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, label) {
+  if (cond) {
+    console.log(`  ✓ ${label}`);
+    passed++;
+  } else {
+    console.log(`  ✗ ${label}`);
+    failed++;
+  }
+}
+
+// ─── Build mock chrome + fetch environment ──────────────────────────────────
+
+function buildEnv() {
+  const storage = {};
+  const listeners = {
+    cookieChanged: [],
+    onSendHeaders: [],
+    onMessage: [],
+  };
+  const fetchLog = []; // { url, options }
+
+  const chrome = {
+    cookies: {
+      onChanged: {
+        addListener: (fn) => listeners.cookieChanged.push(fn),
+      },
+      get: (query, cb) => {
+        // Return a fake JSESSIONID when asked
+        if (query.name === "JSESSIONID") {
+          if (cb) cb({ value: '"fake-jsessionid-123"' });
+          else return Promise.resolve({ value: '"fake-jsessionid-123"' });
+        } else if (query.name === "li_at") {
+          if (cb) cb({ value: "fake-li-at-token" });
+          else return Promise.resolve({ value: "fake-li-at-token" });
+        } else {
+          if (cb) cb(null);
+          else return Promise.resolve(null);
+        }
+      },
+    },
+    storage: {
+      local: {
+        get: (defaults) => {
+          const result = {};
+          for (const [k, v] of Object.entries(defaults)) {
+            result[k] = storage[k] !== undefined ? storage[k] : v;
+          }
+          return Promise.resolve(result);
+        },
+        set: (obj) => {
+          Object.assign(storage, obj);
+          return Promise.resolve();
+        },
+      },
+    },
+    webRequest: {
+      onSendHeaders: {
+        addListener: (fn, filter, opts) => listeners.onSendHeaders.push({ fn, filter, opts }),
+      },
+    },
+    runtime: {
+      onMessage: {
+        addListener: (fn) => listeners.onMessage.push(fn),
+      },
+      sendMessage: (msg) => {
+        return new Promise((resolve) => {
+          for (const fn of listeners.onMessage) {
+            fn(msg, {}, resolve);
+          }
+        });
+      },
+    },
+  };
+
+  // Mock fetch
+  const fakeFetch = (url, options) => {
+    fetchLog.push({ url, options });
+    // Return different responses based on URL
+    if (url.includes("/accounts/refresh")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, account_id: 1 }),
+        text: () => Promise.resolve("ok"),
+      });
+    }
+    if (url.includes("/accounts")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ account_id: 42 }),
+        text: () => Promise.resolve("ok"),
+      });
+    }
+    if (url.includes("/sync")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, synced_threads: 3, messages_inserted: 15, messages_skipped_duplicate: 0, pages_fetched: 3 }),
+        text: () => Promise.resolve("ok"),
+      });
+    }
+    return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve("not found") });
+  };
+
+  return { chrome, storage, listeners, fetchLog, fakeFetch };
+}
+
+function loadBackground(env) {
+  const code = readFileSync("chrome-extension/background.js", "utf8");
+  const ctx = createContext({
+    chrome: env.chrome,
+    fetch: env.fakeFetch,
+    console,
+    Promise,
+    Date,
+    JSON,
+    Error,
+    setTimeout,
+  });
+  const script = new Script(code, { filename: "background.js" });
+  script.runInContext(ctx);
+  return ctx;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+async function testAC1_loads() {
+  console.log("\nAC1: Extension loads without error");
+  try {
+    const env = buildEnv();
+    loadBackground(env);
+    assert(true, "background.js loaded successfully");
+    assert(env.listeners.cookieChanged.length === 1, "cookie listener registered");
+    assert(env.listeners.onSendHeaders.length === 1, "header capture listener registered");
+    assert(env.listeners.onMessage.length === 1, "message listener registered");
+  } catch (e) {
+    assert(false, `background.js failed to load: ${e.message}`);
+  }
+}
+
+async function testAC2_newAccountRegistration() {
+  console.log("\nAC2: Cookie capture registers new account (no accountId stored)");
+  const env = buildEnv();
+  // No accountId in storage → should call POST /accounts
+  loadBackground(env);
+
+  const cookieListener = env.listeners.cookieChanged[0];
+  // Simulate li_at cookie change
+  await new Promise((resolve) => {
+    cookieListener({
+      cookie: { domain: ".linkedin.com", name: "li_at", value: "new-li-at-value" },
+      removed: false,
+    });
+    setTimeout(resolve, 50);
+  });
+
+  const accountCall = env.fetchLog.find(f => f.url.includes("/accounts") && !f.url.includes("/refresh"));
+  assert(!!accountCall, "POST /accounts was called");
+  if (accountCall) {
+    const body = JSON.parse(accountCall.options.body);
+    assert(body.li_at === "new-li-at-value", "li_at value passed correctly");
+    assert(body.jsessionid === "fake-jsessionid-123", "JSESSIONID passed (quotes stripped)");
+    assert(body.label === "chrome-extension", "label is 'chrome-extension'");
+  }
+  assert(env.storage.accountId === 42, "accountId stored after registration");
+  assert(env.storage.lastStatus === "connected", "status set to connected");
+}
+
+async function testAC3_cookieRefresh() {
+  console.log("\nAC3: Cookie change triggers POST /accounts/refresh");
+  const env = buildEnv();
+  env.storage.accountId = 1; // Existing account
+  loadBackground(env);
+
+  const cookieListener = env.listeners.cookieChanged[0];
+  await new Promise((resolve) => {
+    cookieListener({
+      cookie: { domain: ".linkedin.com", name: "li_at", value: "refreshed-li-at" },
+      removed: false,
+    });
+    setTimeout(resolve, 50);
+  });
+
+  const refreshCall = env.fetchLog.find(f => f.url.includes("/accounts/refresh"));
+  assert(!!refreshCall, "POST /accounts/refresh was called");
+  if (refreshCall) {
+    const body = JSON.parse(refreshCall.options.body);
+    assert(body.account_id === 1, "account_id passed correctly");
+    assert(body.li_at === "refreshed-li-at", "updated li_at value passed");
+    assert(body.jsessionid === "fake-jsessionid-123", "JSESSIONID included");
+  }
+  assert(env.storage.lastStatus === "connected", "status set to connected");
+}
+
+async function testAC3_ignoresRemovedCookie() {
+  console.log("\nAC3b: Ignores removed cookies");
+  const env = buildEnv();
+  loadBackground(env);
+
+  env.listeners.cookieChanged[0]({
+    cookie: { domain: ".linkedin.com", name: "li_at", value: "x" },
+    removed: true,
+  });
+
+  await new Promise((r) => setTimeout(r, 50));
+  assert(env.fetchLog.length === 0, "no fetch call for removed cookie");
+}
+
+async function testAC3_ignoresNonLinkedIn() {
+  console.log("\nAC3c: Ignores non-LinkedIn cookies");
+  const env = buildEnv();
+  loadBackground(env);
+
+  env.listeners.cookieChanged[0]({
+    cookie: { domain: ".google.com", name: "li_at", value: "x" },
+    removed: false,
+  });
+
+  await new Promise((r) => setTimeout(r, 50));
+  assert(env.fetchLog.length === 0, "no fetch call for non-LinkedIn cookie");
+}
+
+async function testAC4_headerCapture() {
+  console.log("\nAC4: Header capture stores xLiTrack and csrfToken");
+  const env = buildEnv();
+  loadBackground(env);
+
+  const headerListener = env.listeners.onSendHeaders[0];
+  assert(headerListener.filter.urls[0] === "https://www.linkedin.com/voyager/api/*", "filter matches voyager API pattern");
+
+  // Simulate a request with both headers
+  headerListener.fn({
+    requestHeaders: [
+      { name: "x-li-track", value: '{"clientVersion":"1.13.42912"}' },
+      { name: "csrf-token", value: "ajax:abc123" },
+      { name: "accept", value: "application/json" },
+    ],
+  });
+
+  assert(env.storage.xLiTrack === '{"clientVersion":"1.13.42912"}', "xLiTrack stored");
+  assert(env.storage.csrfToken === "ajax:abc123", "csrfToken stored");
+}
+
+async function testAC5_manualSync() {
+  console.log("\nAC5: MANUAL_SYNC triggers POST /sync");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  assert(resp.ok === true, "sync response is ok");
+  assert(resp.data.synced_threads === 3, "sync result contains synced_threads");
+  assert(resp.data.messages_inserted === 15, "sync result contains messages_inserted");
+
+  const syncCall = env.fetchLog.find(f => f.url.includes("/sync"));
+  assert(!!syncCall, "POST /sync was called");
+  if (syncCall) {
+    const body = JSON.parse(syncCall.options.body);
+    assert(body.account_id === 1, "account_id passed to sync");
+  }
+}
+
+async function testAC6_manualRefresh() {
+  console.log("\nAC6: MANUAL_REFRESH triggers cookie refresh");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_REFRESH" });
+  assert(resp.ok === true, "refresh response is ok");
+
+  const refreshCall = env.fetchLog.find(f => f.url.includes("/accounts/refresh"));
+  assert(!!refreshCall, "POST /accounts/refresh was called");
+}
+
+// ─── Run ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("=== Chrome Extension Acceptance Criteria Tests ===");
+
+  await testAC1_loads();
+  await testAC2_newAccountRegistration();
+  await testAC3_cookieRefresh();
+  await testAC3_ignoresRemovedCookie();
+  await testAC3_ignoresNonLinkedIn();
+  await testAC4_headerCapture();
+  await testAC5_manualSync();
+  await testAC6_manualRefresh();
+
+  console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
Add a Manifest V3 Chrome Extension that serves as a zero-detection-risk authentication bridge between the user's LinkedIn browser session and the Desearch sync service backend.

Core capabilities:
  - Monitor li_at cookie changes on linkedin.com and automatically propagate updated credentials to POST /accounts/refresh
  - Register new accounts via POST /accounts on first cookie capture
  - Capture x-li-track and csrf-token headers from outbound Voyager API requests via chrome.webRequest.onSendHeaders
  - Popup interface with real-time connection status, header capture indicators, configurable service URL, and manual sync/refresh controls

Extension structure:
  chrome-extension/
  ├── manifest.json          # MV3, permissions: cookies, storage, webRequest
  ├── background.js          # Service worker: cookie listener, header capture
  ├── popup.html             # Status UI with sync controls
  ├── popup.js               # Popup state management and action handlers
  └── test_background.mjs    # Mock-based acceptance criteria tests

Acceptance criteria verified (27/27 tests passing):
  ✓ Extension installs and registers all listeners (cookie, header, message)
  ✓ Cookie capture triggers account registration via POST /accounts
  ✓ Cookie changes trigger automatic refresh via POST /accounts/refresh
  ✓ Non-LinkedIn and removed cookies are correctly ignored
  ✓ Header interception persists xLiTrack and csrfToken to local storage
  ✓ Popup manual sync triggers POST /sync and returns thread/message counts
  ✓ Popup manual refresh triggers credential push to backend

Depends on POST /accounts/refresh endpoint introduced in #8.