### PR TITLE
feat(networking): rate limiting, backoff, proxy safety, and anti-bot hardening (#7)

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import logging
+import threading
+from collections import defaultdict
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
 from libs.core.cookies import cookies_to_account_auth, validate_li_at
-from libs.core.job_runner import run_send, run_sync, SyncResult
+from libs.core.job_runner import run_send, run_sync, SyncConfig, SyncResult
 from libs.core.models import AccountAuth, ProxyConfig
 from libs.core.redaction import configure_logging, redact_for_log, redact_string
 from libs.core.storage import Storage
@@ -21,6 +23,10 @@ app = FastAPI(title="Desearch LinkedIn DMs", version="0.0.2")
 
 storage = Storage()
 storage.migrate()
+
+# Per-account lock to prevent concurrent sync/send for the same account,
+# which would bypass rate-limit delays and risk LinkedIn flagging.
+_account_locks: dict[int, threading.Lock] = defaultdict(threading.Lock)
 
 
 class AuthCheckResponse(BaseModel):
@@ -87,6 +93,8 @@ class SyncIn(BaseModel):
         le=100,
         description="Max pages per thread (1=MVP); omit or null to exhaust cursor",
     )
+    delay_between_threads_s: float = Field(2.0, ge=1.0, le=60, description="Pause between threads (seconds, min 1.0)")
+    delay_between_pages_s: float = Field(1.5, ge=1.2, le=60, description="Pause between message pages (seconds, min 1.2 to stay under 50 req/min)")
 
 
 @app.get("/health")
@@ -129,7 +137,7 @@ def auth_check(account_id: int):
     except KeyError:
         return {"status": "failed", "error": "account not found"}
 
-    provider = LinkedInProvider(auth=auth, proxy=proxy)
+    provider = LinkedInProvider(auth=auth, proxy=proxy, account_id=account_id)
     result = provider.check_auth()
 
     if result.ok:
@@ -146,19 +154,30 @@ def list_threads(account_id: int):
 @app.post("/sync")
 def sync_account(body: SyncIn):
     """Trigger a sync. Default one page per thread (MVP); set max_pages_per_thread or null to exhaust."""
+    lock = _account_locks[body.account_id]
+    if not lock.acquire(blocking=False):
+        raise HTTPException(
+            status_code=429,
+            detail=f"Sync already in progress for account {body.account_id}",
+        )
     try:
-        auth = storage.get_account_auth(body.account_id)
-        proxy = storage.get_account_proxy(body.account_id)
-    except KeyError as e:
-        raise HTTPException(status_code=404, detail=redact_string(str(e))) from e
-    provider = LinkedInProvider(auth=auth, proxy=proxy)
-    try:
+        try:
+            auth = storage.get_account_auth(body.account_id)
+            proxy = storage.get_account_proxy(body.account_id)
+        except KeyError as e:
+            raise HTTPException(status_code=404, detail=redact_string(str(e))) from e
+        provider = LinkedInProvider(auth=auth, proxy=proxy, account_id=body.account_id)
+        sync_config = SyncConfig(
+            delay_between_threads_s=body.delay_between_threads_s,
+            delay_between_pages_s=body.delay_between_pages_s,
+        )
         result: SyncResult = run_sync(
             account_id=body.account_id,
             storage=storage,
             provider=provider,
             limit_per_thread=body.limit_per_thread,
             max_pages_per_thread=body.max_pages_per_thread,
+            sync_config=sync_config,
         )
         return {
             "ok": True,
@@ -166,6 +185,7 @@ def sync_account(body: SyncIn):
             "messages_inserted": result.messages_inserted,
             "messages_skipped_duplicate": result.messages_skipped_duplicate,
             "pages_fetched": result.pages_fetched,
+            "rate_limited": result.rate_limited,
         }
     except PermissionError as exc:
         raise HTTPException(
@@ -182,17 +202,25 @@ def sync_account(body: SyncIn):
             status_code=422,
             detail=redact_string(str(e)),
         ) from None
+    finally:
+        lock.release()
 
 
 @app.post("/send")
 def send_message(body: SendIn):
+    lock = _account_locks[body.account_id]
+    if not lock.acquire(blocking=False):
+        raise HTTPException(
+            status_code=429,
+            detail=f"Operation already in progress for account {body.account_id}",
+        )
     try:
-        auth = storage.get_account_auth(body.account_id)
-        proxy = storage.get_account_proxy(body.account_id)
-    except KeyError as e:
-        raise HTTPException(status_code=404, detail=redact_string(str(e))) from e
-    provider = LinkedInProvider(auth=auth, proxy=proxy)
-    try:
+        try:
+            auth = storage.get_account_auth(body.account_id)
+            proxy = storage.get_account_proxy(body.account_id)
+        except KeyError as e:
+            raise HTTPException(status_code=404, detail=redact_string(str(e))) from e
+        provider = LinkedInProvider(auth=auth, proxy=proxy, account_id=body.account_id)
         platform_message_id = run_send(
             account_id=body.account_id,
             storage=storage,
@@ -212,3 +240,5 @@ def send_message(body: SendIn):
             status_code=501,
             detail="Provider not implemented. Implement libs/providers/linkedin/provider.py",
         ) from None
+    finally:
+        lock.release()

--- a/apps/cli/__main__.py
+++ b/apps/cli/__main__.py
@@ -14,7 +14,7 @@ from typing import Sequence
 
 import httpx
 
-from libs.core.job_runner import run_send, run_sync, SyncResult
+from libs.core.job_runner import run_send, run_sync, SyncConfig, SyncResult
 from libs.core.models import AccountAuth, ProxyConfig
 from libs.core.redaction import configure_logging
 from libs.core.storage import Storage
@@ -71,6 +71,20 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         "--exhaust-pagination",
         action="store_true",
         help="Follow cursors until exhausted (same as API max_pages_per_thread=null)",
+    )
+    p_sync.add_argument(
+        "--delay-threads",
+        type=float,
+        default=2.0,
+        metavar="SEC",
+        help="Seconds to pause between threads (default: 2.0)",
+    )
+    p_sync.add_argument(
+        "--delay-pages",
+        type=float,
+        default=1.5,
+        metavar="SEC",
+        help="Seconds to pause between fetch_messages pages (default: 1.5)",
     )
 
     p_send = sub.add_parser("send", help="Send one DM via the LinkedIn provider")
@@ -129,7 +143,7 @@ def _load_provider(storage: Storage, account_id: int) -> LinkedInProvider | int:
     except ValueError as exc:
         _stderr(f"error: {exc}")
         return 1
-    return LinkedInProvider(auth=auth, proxy=proxy)
+    return LinkedInProvider(auth=auth, proxy=proxy, account_id=account_id)
 
 
 def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
@@ -138,6 +152,10 @@ def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
         return loaded
     provider = loaded
     max_pages: int | None = args._resolved_max_pages  # type: ignore[attr-defined]
+    sync_config = SyncConfig(
+        delay_between_threads_s=args.delay_threads,
+        delay_between_pages_s=args.delay_pages,
+    )
     try:
         result: SyncResult = run_sync(
             account_id=args.account_id,
@@ -145,6 +163,7 @@ def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
             provider=provider,
             limit_per_thread=args.limit_per_thread,
             max_pages_per_thread=max_pages,
+            sync_config=sync_config,
         )
     except (NotImplementedError, ValueError):
         _stderr(_PROVIDER_TODO)
@@ -160,6 +179,7 @@ def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
         "messages_inserted": result.messages_inserted,
         "messages_skipped_duplicate": result.messages_skipped_duplicate,
         "pages_fetched": result.pages_fetched,
+        "rate_limited": result.rate_limited,
     }
     print(json.dumps(payload))
     return 0

--- a/libs/core/job_runner.py
+++ b/libs/core/job_runner.py
@@ -4,13 +4,17 @@ Reusable by the API and future CLI. Aligned to provider and storage stubs.
 """
 from __future__ import annotations
 
+import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
+
+import httpx
+
 from libs.core.storage import Storage
 from libs.providers.linkedin.provider import LinkedInProvider
 
-_DELAY_BETWEEN_PAGES_S = 1.5
+logger = logging.getLogger(__name__)
 
 
 def _normalize_sent_at(dt: datetime) -> datetime:
@@ -20,11 +24,19 @@ def _normalize_sent_at(dt: datetime) -> datetime:
 
 
 @dataclass(frozen=True)
+class SyncConfig:
+    delay_between_threads_s: float = 2.0  # pause between threads
+    delay_between_pages_s: float = 1.5    # pause between fetch_messages pages
+    delay_between_accounts_s: float = 5.0 # if running multiple accounts
+
+
+@dataclass(frozen=True)
 class SyncResult:
     synced_threads: int
     messages_inserted: int
     messages_skipped_duplicate: int
     pages_fetched: int
+    rate_limited: bool
 
 
 def run_sync(
@@ -33,6 +45,7 @@ def run_sync(
     provider: LinkedInProvider,
     limit_per_thread: int = 50,
     max_pages_per_thread: int | None = 1,
+    sync_config: SyncConfig | None = None,
 ) -> SyncResult:
     """Sync threads and messages from provider into storage.
 
@@ -42,16 +55,41 @@ def run_sync(
         provider: LinkedIn provider (list_threads, fetch_messages).
         limit_per_thread: Max messages per fetch_messages call.
         max_pages_per_thread: Max pages per thread (1 = MVP one page). None = exhaust cursor.
+        sync_config: Optional delay configuration. Uses defaults if None.
 
     Returns:
         SyncResult with counts. Duplicates are skipped and counted separately.
     """
+    cfg = sync_config or SyncConfig()
+
+    # Use cached profile_id from storage to avoid hitting /me every sync.
+    # Only fetch from LinkedIn if not yet cached, then persist.
+    try:
+        cached_profile_id = storage.get_profile_id(account_id)
+    except KeyError:
+        cached_profile_id = None
+    if cached_profile_id:
+        provider._profile_id = cached_profile_id
+        provider._profile_id_fetched = True
+
     threads = provider.list_threads()
+
+    # Cache profile_id after first successful fetch
+    if not cached_profile_id and provider._profile_id:
+        storage.set_profile_id(account_id, provider._profile_id)
+
     synced_threads = 0
     messages_inserted = 0
     messages_skipped = 0
     pages_fetched = 0
-    for t in threads:
+    rate_limited = False
+    for idx, t in enumerate(threads):
+        if idx > 0:
+            logger.debug(
+                "account_id=%d: sleeping %.1fs between threads",
+                account_id, cfg.delay_between_threads_s,
+            )
+            time.sleep(cfg.delay_between_threads_s)
         thread_id = storage.upsert_thread(
             account_id=account_id,
             platform_thread_id=t.platform_thread_id,
@@ -62,11 +100,30 @@ def run_sync(
         while True:
             if max_pages_per_thread is not None and pages_this_thread >= max_pages_per_thread:
                 break
-            msgs, next_cursor = provider.fetch_messages(
-                platform_thread_id=t.platform_thread_id,
-                cursor=cursor,
-                limit=limit_per_thread,
-            )
+            try:
+                msgs, next_cursor = provider.fetch_messages(
+                    platform_thread_id=t.platform_thread_id,
+                    cursor=cursor,
+                    limit=limit_per_thread,
+                )
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code in (429, 999):
+                    logger.warning(
+                        "account_id=%d: rate-limited (HTTP %d) during fetch_messages for thread %s",
+                        account_id, exc.response.status_code, t.platform_thread_id,
+                    )
+                    rate_limited = True
+                    break
+                raise
+            except RuntimeError as exc:
+                if "Rate-limited" in str(exc) or "429" in str(exc):
+                    logger.warning(
+                        "account_id=%d: rate-limited during fetch_messages for thread %s",
+                        account_id, t.platform_thread_id,
+                    )
+                    rate_limited = True
+                    break
+                raise
             pages_fetched += 1
             pages_this_thread += 1
             for m in msgs:
@@ -88,14 +145,64 @@ def run_sync(
             if next_cursor is None:
                 break
             cursor = next_cursor
-            time.sleep(_DELAY_BETWEEN_PAGES_S)
+            time.sleep(cfg.delay_between_pages_s)
         synced_threads += 1
+    # Detect rate limiting from both exception catches and provider-internal retries
+    if provider.rate_limit_encountered:
+        rate_limited = True
+        logger.warning(
+            "account_id=%d: rate-limit encountered during sync", account_id,
+        )
     return SyncResult(
         synced_threads=synced_threads,
         messages_inserted=messages_inserted,
         messages_skipped_duplicate=messages_skipped,
         pages_fetched=pages_fetched,
+        rate_limited=rate_limited,
     )
+
+
+def run_sync_multi(
+    accounts: list[tuple[int, LinkedInProvider]],
+    storage: Storage,
+    limit_per_thread: int = 50,
+    max_pages_per_thread: int | None = 1,
+    sync_config: SyncConfig | None = None,
+) -> list[SyncResult]:
+    """Sync multiple accounts with configurable delay between them.
+
+    Args:
+        accounts: List of (account_id, provider) pairs.
+        storage: Storage instance.
+        limit_per_thread: Max messages per fetch_messages call.
+        max_pages_per_thread: Max pages per thread.
+        sync_config: Delay configuration.
+
+    Returns:
+        List of SyncResult, one per account.
+    """
+    cfg = sync_config or SyncConfig()
+    results: list[SyncResult] = []
+    for idx, (account_id, provider) in enumerate(accounts):
+        if idx > 0:
+            logger.debug(
+                "sleeping %.1fs between accounts (after account_id=%d)",
+                cfg.delay_between_accounts_s, accounts[idx - 1][0],
+            )
+            time.sleep(cfg.delay_between_accounts_s)
+        result = run_sync(
+            account_id=account_id,
+            storage=storage,
+            provider=provider,
+            limit_per_thread=limit_per_thread,
+            max_pages_per_thread=max_pages_per_thread,
+            sync_config=cfg,
+        )
+        results.append(result)
+    return results
+
+
+_MAX_DAILY_SENDS = 10  # safe limit per issue #7: 5-10/day, >20 = spam flag
 
 
 def run_send(
@@ -110,6 +217,13 @@ def run_send(
 
     Persists the outbound message in storage for local archive (thread keyed by recipient).
     """
+    daily_count = storage.get_daily_send_count(account_id=account_id)
+    if daily_count >= _MAX_DAILY_SENDS:
+        raise RuntimeError(
+            f"Daily send limit reached ({_MAX_DAILY_SENDS} messages/day) "
+            f"for account {account_id}. Retry tomorrow to avoid spam flags."
+        )
+
     platform_message_id = provider.send_message(
         recipient=recipient,
         text=text,

--- a/libs/core/storage.py
+++ b/libs/core/storage.py
@@ -53,6 +53,10 @@ CREATE INDEX IF NOT EXISTS idx_messages_thread_id ON messages(thread_id);
 CREATE INDEX IF NOT EXISTS idx_messages_account_id ON messages(account_id);
 """
 
+_MIGRATION_3_PROFILE_ID = """
+ALTER TABLE accounts ADD COLUMN profile_id TEXT;
+"""
+
 
 class Storage:
     """SQLite storage.
@@ -147,7 +151,7 @@ class Storage:
             self._conn.commit()
 
         current = self._get_schema_version()
-        migrations: list[tuple[int, str]] = [(1, _MIGRATION_1_INDEXES), (2, _MIGRATION_2_MESSAGES_CHECK)]
+        migrations: list[tuple[int, str]] = [(1, _MIGRATION_1_INDEXES), (2, _MIGRATION_2_MESSAGES_CHECK), (3, _MIGRATION_3_PROFILE_ID)]
         for version, sql in migrations:
             if version > current:
                 self._conn.executescript(sql)
@@ -249,6 +253,35 @@ class Storage:
             (account_id, thread_id, cursor, utcnow().isoformat()),
         )
         self._conn.commit()
+
+    def get_profile_id(self, account_id: int) -> Optional[str]:
+        """Return cached profile_id for an account, or None if not yet fetched."""
+        row = self._conn.execute(
+            "SELECT profile_id FROM accounts WHERE id=?", (account_id,)
+        ).fetchone()
+        if not row:
+            raise KeyError(f"account {account_id} not found")
+        return row["profile_id"]
+
+    def set_profile_id(self, account_id: int, profile_id: str) -> None:
+        """Cache the profile_id for an account to avoid repeated /me calls."""
+        self._conn.execute(
+            "UPDATE accounts SET profile_id=? WHERE id=?",
+            (profile_id, account_id),
+        )
+        self._conn.commit()
+
+    def get_daily_send_count(self, *, account_id: int) -> int:
+        """Count outbound messages sent today (UTC) for an account."""
+        today = utcnow().strftime("%Y-%m-%d")
+        row = self._conn.execute(
+            """
+            SELECT COUNT(*) as cnt FROM messages
+            WHERE account_id=? AND direction='out' AND sent_at >= ?
+            """,
+            (account_id, today),
+        ).fetchone()
+        return int(row["cnt"]) if row else 0
 
     def insert_message(
         self,

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -34,7 +34,7 @@ _BASE_HEADERS = {
 _MIN_SEND_INTERVAL_S = 2.0
 _MAX_NETWORK_RETRIES = 3
 _NETWORK_RETRY_DELAY_S = 5.0
-_MAX_RATE_LIMIT_RETRIES = 5
+_MAX_RATE_LIMIT_RETRIES = 6  # separate budget for rate-limit responses
 _BACKOFF_START_S = 30.0
 _BACKOFF_MAX_S = 900.0  # 15 min
 
@@ -46,10 +46,12 @@ _VOYAGER_BASE = "https://www.linkedin.com/voyager/api"
 _GRAPHQL_BASE = f"{_VOYAGER_BASE}/voyagerMessagingGraphQL/graphql"
 _VOYAGER_TIMEOUT_S = 30.0
 _MAX_PAGES = 50
-_DELAY_BETWEEN_PAGES_S = 1.5
-_RETRY_MAX_ATTEMPTS = 3
-_RETRY_BASE_DELAY_S = 2.0
-_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+_DELAY_BETWEEN_THREAD_LIST_PAGES_S = 6.0  # ~10 req/min safe for thread list
+_SERVER_ERROR_MAX_ATTEMPTS = 3
+_SERVER_ERROR_BASE_DELAY_S = 2.0
+_RATE_LIMIT_STATUS_CODES = frozenset({429, 999})
+_SERVER_ERROR_STATUS_CODES = frozenset({500, 502, 503, 504})
+_RETRYABLE_STATUS_CODES = _RATE_LIMIT_STATUS_CODES | _SERVER_ERROR_STATUS_CODES
 _PLAYWRIGHT_NAV_RETRIES = 2
 
 # NOTE: These queryId hashes are extracted from LinkedIn's frontend JS bundle.
@@ -324,9 +326,11 @@ class LinkedInProvider:
     - Do NOT implement CAPTCHA/2FA bypass.
     """
 
-    def __init__(self, *, auth: AccountAuth, proxy: Optional[ProxyConfig] = None):
+    def __init__(self, *, auth: AccountAuth, proxy: Optional[ProxyConfig] = None, account_id: Optional[int] = None):
         self.auth = auth
         self.proxy = proxy
+        self.account_id = account_id
+        self.rate_limit_encountered: bool = False
         # send_message state (upstream)
         self._sent_keys: dict[str, str] = {}
         self._last_send_ts: float = 0.0
@@ -438,40 +442,87 @@ class LinkedInProvider:
         }
         cookies = self._build_basic_cookies()
         try:
-            resp = client.get(f"{_VOYAGER_BASE}/me", headers=headers, cookies=cookies)
+            resp = self._get_with_retry(
+                client, f"{_VOYAGER_BASE}/me", headers=headers, cookies=cookies,
+            )
             if resp.status_code == 200:
                 data = resp.json()
                 self._profile_id = data.get("entityUrn") or data.get("publicIdentifier")
+        except PermissionError:
+            raise
         except Exception:
             logger.debug("_get_profile_id: failed to fetch /me", exc_info=True)
         self._profile_id_fetched = True
         return self._profile_id
 
     def _get_with_retry(self, client: httpx.Client, url: str, **kwargs: Any) -> httpx.Response:
-        last_exc: Optional[httpx.HTTPStatusError] = None
-        for attempt in range(_RETRY_MAX_ATTEMPTS):
-            resp = client.get(url, **kwargs)
+        """GET with separate retry budgets for network, rate-limit, and server errors."""
+        acct = self.account_id or "[unknown]"
+        network_failures = 0
+        rate_limit_attempts = 0
+        server_error_attempts = 0
+
+        while True:
+            try:
+                resp = client.get(url, **kwargs)
+            except (httpx.NetworkError, httpx.TimeoutException) as exc:
+                network_failures += 1
+                if network_failures >= _MAX_NETWORK_RETRIES:
+                    raise ConnectionError(
+                        f"GET failed after {network_failures} network retries"
+                    ) from exc
+                logger.warning(
+                    "Network error, account_id=%s, attempt %d/%d, retrying in %.0fs",
+                    acct, network_failures, _MAX_NETWORK_RETRIES, _NETWORK_RETRY_DELAY_S,
+                )
+                time.sleep(_NETWORK_RETRY_DELAY_S)
+                continue
+
+            if resp.status_code == 401:
+                logger.warning(
+                    "Cookie expiry detected (HTTP 401), account_id=%s. "
+                    "Re-authenticate via POST /accounts/refresh.", acct,
+                )
+                raise PermissionError(
+                    "LinkedIn session expired (HTTP 401). Re-authenticate."
+                )
+
             if resp.status_code not in _RETRYABLE_STATUS_CODES:
                 return resp
-            last_exc = httpx.HTTPStatusError(
-                str(resp.status_code), request=resp.request, response=resp,
-            )
-            if attempt == _RETRY_MAX_ATTEMPTS - 1:
-                break
-            delay = _RETRY_BASE_DELAY_S * (2 ** attempt)
-            if resp.status_code == 429:
+
+            if resp.status_code in _RATE_LIMIT_STATUS_CODES:
+                rate_limit_attempts += 1
+                self.rate_limit_encountered = True
+                if rate_limit_attempts >= _MAX_RATE_LIMIT_RETRIES:
+                    raise httpx.HTTPStatusError(
+                        str(resp.status_code), request=resp.request, response=resp,
+                    )
+                delay = min(
+                    _BACKOFF_START_S * (2 ** (rate_limit_attempts - 1)), _BACKOFF_MAX_S,
+                )
                 retry_after = resp.headers.get("Retry-After")
                 if retry_after:
                     try:
                         delay = max(delay, float(retry_after))
                     except (TypeError, ValueError):
                         pass
-            logger.debug(
-                "retry: %d from LinkedIn, attempt %d/%d in %.1fs",
-                resp.status_code, attempt + 1, _RETRY_MAX_ATTEMPTS, delay,
-            )
+                logger.warning(
+                    "Rate-limit: HTTP %d, account_id=%s, attempt %d/%d, backoff %.1fs",
+                    resp.status_code, acct, rate_limit_attempts, _MAX_RATE_LIMIT_RETRIES, delay,
+                )
+            else:
+                server_error_attempts += 1
+                if server_error_attempts >= _SERVER_ERROR_MAX_ATTEMPTS:
+                    raise httpx.HTTPStatusError(
+                        str(resp.status_code), request=resp.request, response=resp,
+                    )
+                delay = _SERVER_ERROR_BASE_DELAY_S * (2 ** (server_error_attempts - 1))
+                logger.warning(
+                    "Server error: HTTP %d, account_id=%s, attempt %d/%d, retry in %.1fs",
+                    resp.status_code, acct, server_error_attempts, _SERVER_ERROR_MAX_ATTEMPTS, delay,
+                )
+
             time.sleep(delay)
-        raise last_exc  # type: ignore[misc]
 
     def _is_cf_blocked(self, resp: httpx.Response) -> bool:
         if resp.status_code in (302, 303):
@@ -586,7 +637,7 @@ class LinkedInProvider:
             sync_token = new_sync_token
 
             if page_num < _MAX_PAGES:
-                time.sleep(_DELAY_BETWEEN_PAGES_S)
+                time.sleep(_DELAY_BETWEEN_THREAD_LIST_PAGES_S)
         else:
             logger.warning(
                 "list_threads: reached max page limit (%d); %d threads fetched",
@@ -737,13 +788,13 @@ class LinkedInProvider:
 
         while True:
             try:
-                with httpx.Client(proxy=self._proxy_url(), timeout=30.0) as client:
-                    resp = client.post(
-                        _MESSAGING_URL,
-                        json=payload,
-                        headers=headers,
-                        cookies=self._get_cookies(),
-                    )
+                client = self._get_client()
+                resp = client.post(
+                    _MESSAGING_URL,
+                    json=payload,
+                    headers=headers,
+                    cookies=self._get_cookies(),
+                )
                 self._last_send_ts = time.monotonic()
             except (httpx.NetworkError, httpx.TimeoutException) as exc:
                 network_failures += 1
@@ -753,7 +804,8 @@ class LinkedInProvider:
                         f"Send failed after {network_failures} network retries"
                     ) from exc
                 logger.warning(
-                    "Network error (attempt %d/%d), retrying in %.0fs",
+                    "Network error, account_id=%s, attempt %d/%d, retrying in %.0fs",
+                    self.account_id or "[unknown]",
                     network_failures,
                     _MAX_NETWORK_RETRIES,
                     _NETWORK_RETRY_DELAY_S,
@@ -761,9 +813,10 @@ class LinkedInProvider:
                 time.sleep(_NETWORK_RETRY_DELAY_S)
                 continue
 
-            if resp.status_code in (429, 999):
+            if resp.status_code in _RATE_LIMIT_STATUS_CODES:
+                self.rate_limit_encountered = True
                 rate_limit_hits += 1
-                if rate_limit_hits > _MAX_RATE_LIMIT_RETRIES:
+                if rate_limit_hits >= _MAX_RATE_LIMIT_RETRIES:
                     raise RuntimeError(
                         f"Rate-limited {rate_limit_hits} times, giving up"
                     )
@@ -771,8 +824,9 @@ class LinkedInProvider:
                     _BACKOFF_START_S * (2 ** (rate_limit_hits - 1)), _BACKOFF_MAX_S
                 )
                 logger.warning(
-                    "Rate limited (HTTP %d, attempt %d/%d), backing off %.0fs",
+                    "Rate-limit: HTTP %d, account_id=%s, attempt %d/%d, backoff %.0fs",
                     resp.status_code,
+                    self.account_id or "[unknown]",
                     rate_limit_hits,
                     _MAX_RATE_LIMIT_RETRIES,
                     backoff,
@@ -781,6 +835,11 @@ class LinkedInProvider:
                 continue
 
             if resp.status_code == 401:
+                logger.warning(
+                    "Cookie expiry detected (HTTP 401), account_id=%s. "
+                    "Re-authenticate via POST /accounts/refresh.",
+                    self.account_id or "[unknown]",
+                )
                 raise PermissionError(
                     "LinkedIn session expired (HTTP 401). Re-authenticate."
                 )

--- a/tests/test_issue7_networking.py
+++ b/tests/test_issue7_networking.py
@@ -1,0 +1,788 @@
+"""Issue #7 — Networking requirements acceptance tests.
+
+Tests each requirement:
+  1. Proxy used for all provider HTTP requests
+  2. Rate limiting: configurable delays in job_runner (SyncConfig)
+  3. Backoff on errors (429/999, 401, network)
+  4. Logging: rate_limited field on SyncResult, account_id in logs
+
+Run:  python tests/test_issue7_networking.py
+"""
+from __future__ import annotations
+
+import sys
+import os
+import time
+import logging
+
+# Ensure repo root is on path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Patch libs namespace conflict (system libs package)
+import importlib
+import libs as _libs_pkg
+_libs_pkg.__path__ = [os.path.join(os.path.dirname(__file__), "..", "libs")]
+importlib.invalidate_caches()
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional, Any
+from unittest.mock import patch, MagicMock
+
+passed = 0
+failed = 0
+
+
+def assert_true(cond, label):
+    global passed, failed
+    if cond:
+        print(f"  [PASS] {label}")
+        passed += 1
+    else:
+        print(f"  [FAIL] {label}")
+        failed += 1
+
+
+# ─── Fake provider ──────────────────────────────────────────────────────────
+
+from libs.core.models import AccountAuth, ProxyConfig
+from libs.providers.linkedin.provider import LinkedInThread, LinkedInMessage
+
+
+class FakeProvider:
+    """Minimal provider stub for testing job_runner logic."""
+
+    def __init__(self, threads=None, messages=None, raise_on_fetch=None):
+        self.threads = threads or []
+        self.messages = messages or []
+        self.raise_on_fetch = raise_on_fetch
+        self.list_threads_called = 0
+        self.fetch_messages_calls = []
+        self._profile_id = None
+        self._profile_id_fetched = False
+        self.rate_limit_encountered = False
+
+    def list_threads(self):
+        self.list_threads_called += 1
+        return self.threads
+
+    def fetch_messages(self, *, platform_thread_id, cursor, limit):
+        self.fetch_messages_calls.append({
+            "thread_id": platform_thread_id,
+            "cursor": cursor,
+            "limit": limit,
+        })
+        if self.raise_on_fetch:
+            raise self.raise_on_fetch
+        return self.messages, None  # messages, next_cursor=None
+
+
+# ─── Fake storage ───────────────────────────────────────────────────────────
+
+class FakeStorage:
+    def __init__(self):
+        self._thread_counter = 0
+        self.cursors = {}
+        self.inserted = []
+        self._profile_ids = {}
+
+    def upsert_thread(self, *, account_id, platform_thread_id, title):
+        self._thread_counter += 1
+        return self._thread_counter
+
+    def get_cursor(self, *, account_id, thread_id):
+        return self.cursors.get((account_id, thread_id))
+
+    def set_cursor(self, *, account_id, thread_id, cursor):
+        self.cursors[(account_id, thread_id)] = cursor
+
+    def insert_message(self, *, account_id, thread_id, platform_message_id,
+                       direction, sender, text, sent_at, raw=None):
+        self.inserted.append(platform_message_id)
+        return True
+
+    def get_profile_id(self, account_id):
+        return self._profile_ids.get(account_id)
+
+    def set_profile_id(self, account_id, profile_id):
+        self._profile_ids[account_id] = profile_id
+
+
+# ─── Test 1: Proxy ──────────────────────────────────────────────────────────
+
+def test_proxy():
+    print("\n=== Requirement 1: Proxy used for all provider HTTP requests ===")
+
+    from libs.providers.linkedin.provider import LinkedInProvider
+
+    proxy = ProxyConfig(url="http://user:pass@proxy.example.com:8080")
+    auth = AccountAuth(li_at="fake-token", jsessionid="fake-session")
+    provider = LinkedInProvider(auth=auth, proxy=proxy)
+
+    # _get_client creates httpx.Client with proxy
+    client = provider._get_client()
+    # httpx stores proxy config internally
+    assert_true(provider._proxy_url() == "http://user:pass@proxy.example.com:8080",
+                "_proxy_url() returns configured proxy URL")
+
+    # _get_client uses proxy
+    assert_true(client is not None, "_get_client() creates client successfully")
+    provider.close()
+
+    # socks5 proxy
+    proxy_socks = ProxyConfig(url="socks5://host:1080")
+    provider2 = LinkedInProvider(auth=auth, proxy=proxy_socks)
+    assert_true(provider2._proxy_url() == "socks5://host:1080",
+                "_proxy_url() supports socks5:// scheme")
+    provider2.close()
+
+    # No proxy
+    provider3 = LinkedInProvider(auth=auth, proxy=None)
+    assert_true(provider3._proxy_url() is None,
+                "_proxy_url() returns None when no proxy configured")
+    provider3.close()
+
+    # One account -> one consistent IP: send_message reuses _get_client()
+    provider4 = LinkedInProvider(auth=auth, proxy=proxy)
+    client_a = provider4._get_client()
+    client_b = provider4._get_client()
+    assert_true(client_a is client_b,
+                "One account -> one consistent IP: _get_client() reuses same client")
+    provider4.close()
+
+    # Verify send_message uses _get_client (not a fresh httpx.Client)
+    import inspect
+    send_src = inspect.getsource(LinkedInProvider.send_message)
+    assert_true("self._get_client()" in send_src,
+                "send_message uses _get_client() (shared client, consistent IP)")
+    assert_true("httpx.Client(" not in send_src,
+                "send_message does NOT create a new httpx.Client")
+
+
+# ─── Test 2: Rate limiting — SyncConfig ─────────────────────────────────────
+
+def test_rate_limiting():
+    print("\n=== Requirement 2: Rate limiting in job_runner.py ===")
+
+    from libs.core.job_runner import SyncConfig, SyncResult, run_sync
+
+    # SyncConfig exists with correct defaults
+    cfg = SyncConfig()
+    assert_true(cfg.delay_between_threads_s == 2.0,
+                "SyncConfig.delay_between_threads_s default is 2.0")
+    assert_true(cfg.delay_between_pages_s == 1.5,
+                "SyncConfig.delay_between_pages_s default is 1.5")
+    assert_true(cfg.delay_between_accounts_s == 5.0,
+                "SyncConfig.delay_between_accounts_s default is 5.0")
+
+    # Custom config
+    cfg2 = SyncConfig(delay_between_threads_s=0.01, delay_between_pages_s=0.01)
+    assert_true(cfg2.delay_between_threads_s == 0.01,
+                "SyncConfig accepts custom delay_between_threads_s")
+
+    # Verify delay_between_threads is applied (with 3 threads, should sleep between them)
+    threads = [
+        LinkedInThread(platform_thread_id=f"t{i}", title=f"Thread {i}")
+        for i in range(3)
+    ]
+    provider = FakeProvider(threads=threads)
+    storage = FakeStorage()
+
+    with patch("libs.core.job_runner.time.sleep") as mock_sleep:
+        run_sync(
+            account_id=1,
+            storage=storage,
+            provider=provider,
+            sync_config=SyncConfig(delay_between_threads_s=2.0, delay_between_pages_s=1.5),
+        )
+        # Should sleep between threads (not before first one)
+        thread_sleeps = [c for c in mock_sleep.call_args_list if c[0][0] == 2.0]
+        assert_true(len(thread_sleeps) == 2,
+                    f"time.sleep(2.0) called 2 times between 3 threads (got {len(thread_sleeps)})")
+
+    # Verify delay_between_pages is used (provider returns next_cursor once)
+    class PagingProvider(FakeProvider):
+        def __init__(self):
+            super().__init__()
+            self.threads = [LinkedInThread(platform_thread_id="t1", title="T1")]
+            self._page_count = 0
+
+        def fetch_messages(self, *, platform_thread_id, cursor, limit):
+            self._page_count += 1
+            if self._page_count == 1:
+                msg = LinkedInMessage(
+                    platform_message_id="m1", direction="in", sender="Alice",
+                    text="hi", sent_at=datetime.now(timezone.utc),
+                )
+                return [msg], "cursor-2"  # has next page
+            return [], None  # no more
+
+    paging_provider = PagingProvider()
+    storage2 = FakeStorage()
+    with patch("libs.core.job_runner.time.sleep") as mock_sleep:
+        run_sync(
+            account_id=1,
+            storage=storage2,
+            provider=paging_provider,
+            max_pages_per_thread=5,
+            sync_config=SyncConfig(delay_between_pages_s=1.5, delay_between_threads_s=2.0),
+        )
+        page_sleeps = [c for c in mock_sleep.call_args_list if c[0][0] == 1.5]
+        assert_true(len(page_sleeps) == 1,
+                    f"time.sleep(1.5) called between pages (got {len(page_sleeps)})")
+
+
+# ─── Test 3: Backoff on errors ──────────────────────────────────────────────
+
+def test_backoff():
+    print("\n=== Requirement 3: Backoff on errors ===")
+
+    from libs.providers.linkedin.provider import LinkedInProvider
+    import libs.providers.linkedin.provider as pmod
+    import httpx
+
+    # --- Constants match issue spec ---
+
+    # send_message path
+    assert_true(pmod._MAX_NETWORK_RETRIES == 3,
+                "send: MAX_NETWORK_RETRIES is 3")
+    assert_true(pmod._NETWORK_RETRY_DELAY_S == 5.0,
+                "send: NETWORK_RETRY_DELAY_S is 5.0")
+    assert_true(pmod._BACKOFF_START_S == 30.0,
+                "send: BACKOFF_START_S is 30.0")
+    assert_true(pmod._BACKOFF_MAX_S == 900.0,
+                "send: BACKOFF_MAX_S is 900.0 (15 min)")
+
+    # GraphQL path — separate retry budgets
+    assert_true(pmod._MAX_RATE_LIMIT_RETRIES == 6,
+                "graphql: rate-limit budget is 6 attempts")
+    assert_true(pmod._SERVER_ERROR_MAX_ATTEMPTS == 3,
+                "graphql: server-error budget is 3 attempts")
+    assert_true(429 in pmod._RATE_LIMIT_STATUS_CODES,
+                "graphql: 429 in RATE_LIMIT_STATUS_CODES")
+    assert_true(999 in pmod._RATE_LIMIT_STATUS_CODES,
+                "graphql: 999 in RATE_LIMIT_STATUS_CODES")
+    assert_true(500 in pmod._SERVER_ERROR_STATUS_CODES,
+                "graphql: 500 in SERVER_ERROR_STATUS_CODES")
+
+    # --- 401 raises PermissionError + logs cookie expiry in send_message ---
+    auth = AccountAuth(li_at="fake", jsessionid="fake")
+
+    provider_logger = logging.getLogger("libs.providers.linkedin.provider")
+    provider_logger.setLevel(logging.DEBUG)
+    log_records_401 = []
+
+    class CaptureHandler401(logging.Handler):
+        def emit(self, record):
+            log_records_401.append(record)
+
+    handler_401 = CaptureHandler401()
+    provider_logger.addHandler(handler_401)
+
+    provider = LinkedInProvider(auth=auth)
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 401
+
+    # Patch _get_client to return a mock client for send_message
+    mock_client_inst = MagicMock()
+    mock_client_inst.post.return_value = mock_resp
+
+    with patch.object(provider, "_get_client", return_value=mock_client_inst):
+        try:
+            provider.send_message(recipient="urn:li:member:123", text="hi")
+            assert_true(False, "send: 401 should raise PermissionError")
+        except PermissionError:
+            assert_true(True, "send: HTTP 401 raises PermissionError (no retry)")
+
+    has_cookie_expiry_log = any(
+        "Cookie expiry" in r.getMessage() for r in log_records_401
+    )
+    assert_true(has_cookie_expiry_log,
+                "send: 401 logs cookie expiry notification")
+
+    # --- 401 raises PermissionError + logs cookie expiry in _get_with_retry ---
+    log_records_401.clear()
+    provider2 = LinkedInProvider(auth=auth)
+    mock_client = MagicMock()
+    mock_401_resp = MagicMock()
+    mock_401_resp.status_code = 401
+    mock_client.get.return_value = mock_401_resp
+
+    try:
+        provider2._get_with_retry(mock_client, "https://example.com/api")
+        assert_true(False, "graphql: 401 should raise PermissionError")
+    except PermissionError:
+        assert_true(True, "graphql: HTTP 401 raises PermissionError (no retry)")
+
+    has_cookie_expiry_log_gql = any(
+        "Cookie expiry" in r.getMessage() for r in log_records_401
+    )
+    assert_true(has_cookie_expiry_log_gql,
+                "graphql: 401 logs cookie expiry notification")
+
+    provider_logger.removeHandler(handler_401)
+
+    # --- Network error retry in _get_with_retry ---
+    provider3 = LinkedInProvider(auth=auth)
+    mock_client2 = MagicMock()
+    mock_client2.get.side_effect = httpx.NetworkError("connection reset")
+
+    with patch.object(pmod.time, "sleep"):
+        try:
+            provider3._get_with_retry(mock_client2, "https://example.com/api")
+            assert_true(False, "graphql: network error should raise ConnectionError")
+        except ConnectionError:
+            assert_true(True, "graphql: network error raises ConnectionError after 3 retries")
+
+    assert_true(mock_client2.get.call_count == 3,
+                f"graphql: retried 3 times on network error (got {mock_client2.get.call_count})")
+
+    # --- rate_limited flag via httpx.HTTPStatusError ---
+    from libs.core.job_runner import run_sync, SyncConfig
+
+    # Simulate _get_with_retry raising HTTPStatusError (429 exhausted retries)
+    mock_request = MagicMock()
+    mock_429_resp = MagicMock()
+    mock_429_resp.status_code = 429
+
+    class HTTPStatusProvider(FakeProvider):
+        def __init__(self):
+            super().__init__()
+            self.threads = [LinkedInThread(platform_thread_id="t1", title="T")]
+
+        def fetch_messages(self, **kwargs):
+            raise httpx.HTTPStatusError("429", request=mock_request, response=mock_429_resp)
+
+    storage = FakeStorage()
+    with patch("libs.core.job_runner.time.sleep"):
+        result = run_sync(
+            account_id=1, storage=storage, provider=HTTPStatusProvider(),
+            sync_config=SyncConfig(delay_between_threads_s=0, delay_between_pages_s=0),
+        )
+    assert_true(result.rate_limited is True,
+                "job_runner: rate_limited=True on httpx.HTTPStatusError(429)")
+
+    # RuntimeError path still works too
+    rate_err_provider = FakeProvider(
+        threads=[LinkedInThread(platform_thread_id="t1", title="T")],
+        raise_on_fetch=RuntimeError("Rate-limited 5 times, giving up"),
+    )
+    storage2 = FakeStorage()
+    with patch("libs.core.job_runner.time.sleep"):
+        result2 = run_sync(
+            account_id=1, storage=storage2, provider=rate_err_provider,
+            sync_config=SyncConfig(delay_between_threads_s=0, delay_between_pages_s=0),
+        )
+    assert_true(result2.rate_limited is True,
+                "job_runner: rate_limited=True on RuntimeError('Rate-limited')")
+
+    # rate_limit_encountered flag on provider (even when retries succeed internally)
+    class RateLimitFlagProvider(FakeProvider):
+        def __init__(self):
+            super().__init__()
+            self.threads = [LinkedInThread(platform_thread_id="t1", title="T")]
+            self.rate_limit_encountered = True  # simulates internal retry that succeeded
+
+    flag_provider = RateLimitFlagProvider()
+    storage3 = FakeStorage()
+    with patch("libs.core.job_runner.time.sleep"):
+        result3 = run_sync(
+            account_id=1, storage=storage3, provider=flag_provider,
+            sync_config=SyncConfig(delay_between_threads_s=0, delay_between_pages_s=0),
+        )
+    assert_true(result3.rate_limited is True,
+                "job_runner: rate_limited=True from provider.rate_limit_encountered flag")
+
+
+# ─── Test 4: Logging ────────────────────────────────────────────────────────
+
+def test_logging():
+    print("\n=== Requirement 4: Logging with account_id and rate_limited ===")
+
+    from libs.core.job_runner import SyncResult, SyncConfig, run_sync
+
+    # SyncResult has rate_limited field
+    r = SyncResult(synced_threads=1, messages_inserted=5,
+                   messages_skipped_duplicate=0, pages_fetched=1, rate_limited=False)
+    assert_true(hasattr(r, "rate_limited"), "SyncResult has rate_limited field")
+    assert_true(r.rate_limited is False, "rate_limited=False when no rate limiting")
+
+    # Verify logging includes account_id on rate limit
+    rate_err_provider = FakeProvider(
+        threads=[LinkedInThread(platform_thread_id="t1", title="T")],
+        raise_on_fetch=RuntimeError("Rate-limited 429"),
+    )
+    storage = FakeStorage()
+
+    # Use a real log handler to capture messages (mock doesn't work since
+    # the module-level logger is already bound at import time).
+    job_logger = logging.getLogger("libs.core.job_runner")
+    job_logger.setLevel(logging.DEBUG)
+    log_records = []
+
+    class CaptureHandler(logging.Handler):
+        def emit(self, record):
+            log_records.append(record)
+
+    handler = CaptureHandler()
+    job_logger.addHandler(handler)
+
+    with patch("libs.core.job_runner.time.sleep"):
+        result = run_sync(
+            account_id=42, storage=storage, provider=rate_err_provider,
+            sync_config=SyncConfig(delay_between_threads_s=0, delay_between_pages_s=0),
+        )
+    has_account_id_log = any(
+        "account_id=42" in record.getMessage() for record in log_records
+        if record.levelno >= logging.WARNING
+    )
+    assert_true(has_account_id_log,
+                "Rate-limit warning logged with account_id=42")
+    assert_true(result.rate_limited is True,
+                "SyncResult.rate_limited=True on rate limit")
+
+    # Verify debug log between threads includes account_id
+    log_records.clear()
+    threads = [
+        LinkedInThread(platform_thread_id=f"t{i}", title=f"T{i}")
+        for i in range(2)
+    ]
+    provider = FakeProvider(threads=threads)
+    storage2 = FakeStorage()
+    with patch("libs.core.job_runner.time.sleep"):
+        run_sync(
+            account_id=99, storage=storage2, provider=provider,
+            sync_config=SyncConfig(delay_between_threads_s=2.0, delay_between_pages_s=1.5),
+        )
+    has_thread_delay_log = any(
+        "account_id=99" in record.getMessage() for record in log_records
+        if record.levelno == logging.DEBUG
+    )
+    assert_true(has_thread_delay_log,
+                "Thread delay debug log includes account_id=99")
+
+    job_logger.removeHandler(handler)
+
+    # Verify provider-level rate-limit logs include account_id
+    import libs.providers.linkedin.provider as pmod
+    from libs.providers.linkedin.provider import LinkedInProvider
+
+    provider_logger = logging.getLogger("libs.providers.linkedin.provider")
+    provider_logger.setLevel(logging.DEBUG)
+    prov_log_records = []
+
+    class ProvCaptureHandler(logging.Handler):
+        def emit(self, record):
+            prov_log_records.append(record)
+
+    prov_handler = ProvCaptureHandler()
+    provider_logger.addHandler(prov_handler)
+
+    # GraphQL path: _get_with_retry rate limit log
+    auth = AccountAuth(li_at="fake", jsessionid="fake")
+    provider_with_id = LinkedInProvider(auth=auth, account_id=77)
+
+    mock_client = MagicMock()
+    mock_429_resp = MagicMock()
+    mock_429_resp.status_code = 429
+    mock_429_resp.headers = {}
+    mock_429_resp.request = MagicMock()
+    mock_client.get.return_value = mock_429_resp
+
+    with patch.object(pmod.time, "sleep"):
+        try:
+            provider_with_id._get_with_retry(mock_client, "https://example.com/api")
+        except Exception:
+            pass
+
+    has_provider_account_id = any(
+        "account_id=77" in r.getMessage() for r in prov_log_records
+        if r.levelno >= logging.WARNING
+    )
+    assert_true(has_provider_account_id,
+                "Provider rate-limit log includes account_id=77")
+
+    provider_logger.removeHandler(prov_handler)
+
+
+# ─── Test 5: Acceptance criteria ────────────────────────────────────────────
+
+def test_acceptance():
+    print("\n=== Acceptance Criteria ===")
+
+    from libs.core.job_runner import SyncConfig, run_sync
+
+    # AC1: Sync runs with configurable delays between threads
+    threads = [
+        LinkedInThread(platform_thread_id=f"t{i}", title=f"T{i}")
+        for i in range(3)
+    ]
+    provider = FakeProvider(threads=threads)
+    storage = FakeStorage()
+    custom_cfg = SyncConfig(delay_between_threads_s=3.5, delay_between_pages_s=0.5)
+
+    with patch("libs.core.job_runner.time.sleep") as mock_sleep:
+        run_sync(
+            account_id=1, storage=storage, provider=provider,
+            sync_config=custom_cfg,
+        )
+        thread_sleeps = [c for c in mock_sleep.call_args_list if c[0][0] == 3.5]
+        assert_true(len(thread_sleeps) == 2,
+                    "AC1: Configurable delay (3.5s) applied between threads")
+
+    # AC2: Rate limit response triggers backoff, not crash
+    rate_provider = FakeProvider(
+        threads=[LinkedInThread(platform_thread_id="t1", title="T")],
+        raise_on_fetch=RuntimeError("Rate-limited 429"),
+    )
+    storage2 = FakeStorage()
+    with patch("libs.core.job_runner.time.sleep"):
+        result = run_sync(
+            account_id=1, storage=storage2, provider=rate_provider,
+            sync_config=SyncConfig(delay_between_threads_s=0, delay_between_pages_s=0),
+        )
+        assert_true(result.rate_limited is True,
+                    "AC2: Rate limit sets flag, does not crash")
+        assert_true(result.synced_threads == 1,
+                    "AC2: Sync continues after rate limit (thread counted)")
+
+    # AC3: Proxy is used for all provider HTTP requests
+    from libs.providers.linkedin.provider import LinkedInProvider
+    proxy = ProxyConfig(url="http://proxy:8080")
+    auth = AccountAuth(li_at="fake", jsessionid="fake")
+    p = LinkedInProvider(auth=auth, proxy=proxy)
+    assert_true(p._proxy_url() == "http://proxy:8080",
+                "AC3: Proxy URL available for all HTTP requests")
+    client = p._get_client()
+    assert_true(client is not None,
+                "AC3: HTTP client created with proxy config")
+    p.close()
+
+
+# ─── Test 6: Safe rate limit floors ──────────────────────────────────────────
+
+def test_safe_floors():
+    print("\n=== Rate limit safe floors ===")
+
+    # Verify the API model enforces min 1.0s by reading the Field definitions
+    # (can't import SyncIn directly on Python 3.9 due to `str | None` syntax)
+    import ast
+
+    with open(os.path.join(os.path.dirname(__file__), "..", "apps", "api", "main.py")) as f:
+        source = f.read()
+
+    # Check that ge=1.0 (or ge=1) appears in the delay Field definitions
+    has_threads_floor = "delay_between_threads_s" in source and "ge=1" in source
+    has_pages_floor = "delay_between_pages_s" in source and "ge=1.2" in source
+
+    assert_true(has_threads_floor,
+                "SyncIn.delay_between_threads_s has ge=1.0 minimum floor")
+    assert_true(has_pages_floor,
+                "SyncIn.delay_between_pages_s has ge=1.2 minimum floor (max 50 req/min)")
+
+    from libs.core.job_runner import SyncConfig
+    cfg = SyncConfig()
+
+    # DM history fetch: default 1.5s between pages -> ~40 req/min (safe: 20-50)
+    # Worst case with min 1.2s -> 50 req/min (at safe boundary)
+    dm_fetch_per_min = 60.0 / cfg.delay_between_pages_s
+    assert_true(dm_fetch_per_min <= 50,
+                f"DM fetch: default ~{dm_fetch_per_min:.0f} req/min (<= 50 safe)")
+    worst_case_dm = 60.0 / 1.2
+    assert_true(worst_case_dm <= 50,
+                f"DM fetch: worst case (min 1.2s) = {worst_case_dm:.0f} req/min (<= 50)")
+
+    # Thread list: hardcoded 6.0s in provider -> 10 req/min (safe: ~10)
+    import libs.providers.linkedin.provider as pmod
+    thread_list_per_min = 60.0 / pmod._DELAY_BETWEEN_THREAD_LIST_PAGES_S
+    assert_true(thread_list_per_min <= 10,
+                f"Thread list: provider hardcoded ~{thread_list_per_min:.0f} req/min (<= 10 safe)")
+
+    # DM send: MAX_DAILY_SENDS = 10 (safe: 5-10/day)
+    from libs.core.job_runner import _MAX_DAILY_SENDS
+    assert_true(_MAX_DAILY_SENDS <= 10,
+                f"DM send: daily cap {_MAX_DAILY_SENDS} (<= 10 safe)")
+
+
+# ─── Test 7: Daily send cap ─────────────────────────────────────────────────
+
+def test_daily_send_cap():
+    print("\n=== Daily send cap ===")
+
+    from libs.core.job_runner import run_send, _MAX_DAILY_SENDS
+    from libs.providers.linkedin.provider import LinkedInProvider
+
+    assert_true(_MAX_DAILY_SENDS == 10, f"MAX_DAILY_SENDS is 10 (got {_MAX_DAILY_SENDS})")
+
+    # Use a real storage with a temp DB to test persisted daily count
+    from libs.core.storage import Storage
+    import tempfile, os
+    tmp = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+    tmp.close()
+    try:
+        real_storage = Storage(db_path=tmp.name)
+        real_storage.migrate()
+
+        # Create an account
+        auth = AccountAuth(li_at="fake-token-long-enough", jsessionid="fake-session")
+        account_id = real_storage.create_account(label="test", auth=auth)
+
+        # Insert _MAX_DAILY_SENDS outbound messages for today
+        for i in range(_MAX_DAILY_SENDS):
+            real_storage.upsert_thread(
+                account_id=account_id, platform_thread_id=f"t-{i}", title=None,
+            )
+            real_storage.insert_message(
+                account_id=account_id,
+                thread_id=1,
+                platform_message_id=f"msg-{i}",
+                direction="out",
+                sender=None,
+                text="hi",
+                sent_at=datetime.now(timezone.utc),
+            )
+
+        # Verify daily count is at the cap
+        count = real_storage.get_daily_send_count(account_id=account_id)
+        assert_true(count == _MAX_DAILY_SENDS,
+                    f"Storage reports {count} daily sends (expected {_MAX_DAILY_SENDS})")
+
+        # run_send should refuse
+        provider = LinkedInProvider(auth=auth)
+        try:
+            run_send(
+                account_id=account_id, storage=real_storage, provider=provider,
+                recipient="urn:li:member:999", text="blocked", idempotency_key=None,
+            )
+            assert_true(False, "Should raise RuntimeError when daily cap reached")
+        except RuntimeError as e:
+            assert_true("Daily send limit reached" in str(e),
+                        "Daily cap raises RuntimeError with clear message")
+
+        # With 0 sends today, it should NOT raise the cap error
+        # (it will fail on network, but the cap check passes)
+        real_storage2 = Storage(db_path=tmp.name)
+        real_storage2.migrate()
+        account_id2 = real_storage2.create_account(label="test2", auth=auth)
+        count2 = real_storage2.get_daily_send_count(account_id=account_id2)
+        assert_true(count2 == 0,
+                    "New account has 0 daily sends")
+        real_storage2.close()
+
+        real_storage.close()
+    finally:
+        os.unlink(tmp.name)
+
+
+# ─── Test 8: list_threads respects page_delay ───────────────────────────────
+
+def test_list_threads_safe_delay():
+    print("\n=== list_threads safe delay ===")
+
+    import libs.providers.linkedin.provider as pmod
+
+    # Thread list uses a hardcoded safe delay (not shared with DM fetch)
+    assert_true(pmod._DELAY_BETWEEN_THREAD_LIST_PAGES_S == 6.0,
+                "Thread list page delay hardcoded at 6.0s")
+
+    # This gives ~10 req/min, matching the safe limit from the issue
+    reqs = 60.0 / pmod._DELAY_BETWEEN_THREAD_LIST_PAGES_S
+    assert_true(reqs <= 10,
+                f"Thread list: {reqs:.0f} req/min (<= 10 safe limit)")
+
+
+# ─── Test 9: delay_between_accounts_s ────────────────────────────────────────
+
+def test_delay_between_accounts():
+    print("\n=== delay_between_accounts_s ===")
+
+    from libs.core.job_runner import SyncConfig, run_sync_multi
+
+    provider1 = FakeProvider(threads=[LinkedInThread(platform_thread_id="t1", title="T1")])
+    provider2 = FakeProvider(threads=[LinkedInThread(platform_thread_id="t2", title="T2")])
+    provider3 = FakeProvider(threads=[LinkedInThread(platform_thread_id="t3", title="T3")])
+
+    accounts = [(1, provider1), (2, provider2), (3, provider3)]
+    storage = FakeStorage()
+
+    with patch("libs.core.job_runner.time.sleep") as mock_sleep:
+        results = run_sync_multi(
+            accounts=accounts,
+            storage=storage,
+            sync_config=SyncConfig(delay_between_accounts_s=5.0, delay_between_threads_s=2.0),
+        )
+
+    assert_true(len(results) == 3, f"run_sync_multi returns 3 results (got {len(results)})")
+
+    account_sleeps = [c for c in mock_sleep.call_args_list if c[0][0] == 5.0]
+    assert_true(len(account_sleeps) == 2,
+                f"time.sleep(5.0) called 2 times between 3 accounts (got {len(account_sleeps)})")
+
+
+# ─── Test 10: Profile views caching ──────────────────────────────────────────
+
+def test_profile_views_caching():
+    print("\n=== Profile views caching ===")
+
+    from libs.core.job_runner import SyncConfig, run_sync
+
+    # First sync: no cached profile_id, provider fetches it
+    class ProfileTrackingProvider(FakeProvider):
+        def __init__(self):
+            super().__init__()
+            self.threads = [LinkedInThread(platform_thread_id="t1", title="T")]
+            self._profile_id = "urn:li:fsd_profile:ABC123"
+            self._profile_id_fetched = True
+
+    provider1 = ProfileTrackingProvider()
+    storage = FakeStorage()
+
+    with patch("libs.core.job_runner.time.sleep"):
+        run_sync(
+            account_id=1, storage=storage, provider=provider1,
+            sync_config=SyncConfig(delay_between_threads_s=0, delay_between_pages_s=0),
+        )
+
+    assert_true(storage._profile_ids.get(1) == "urn:li:fsd_profile:ABC123",
+                "Profile ID cached in storage after first sync")
+
+    # Second sync: cached profile_id should be used, no /me call needed
+    provider2 = ProfileTrackingProvider()
+    provider2._profile_id = None
+    provider2._profile_id_fetched = False
+
+    with patch("libs.core.job_runner.time.sleep"):
+        run_sync(
+            account_id=1, storage=storage, provider=provider2,
+            sync_config=SyncConfig(delay_between_threads_s=0, delay_between_pages_s=0),
+        )
+
+    assert_true(provider2._profile_id == "urn:li:fsd_profile:ABC123",
+                "Second sync uses cached profile_id (no /me call)")
+    assert_true(provider2._profile_id_fetched is True,
+                "Provider marked as fetched from cache")
+
+
+# ─── Run all ─────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Issue #7 -- Networking Requirements Tests")
+    print("=" * 60)
+
+    test_proxy()
+    test_rate_limiting()
+    test_backoff()
+    test_logging()
+    test_acceptance()
+    test_safe_floors()
+    test_daily_send_cap()
+    test_list_threads_safe_delay()
+    test_delay_between_accounts()
+    test_profile_views_caching()
+
+    print(f"\n{'=' * 60}")
+    print(f"Results: {passed} passed, {failed} failed")
+    print("=" * 60)
+    sys.exit(1 if failed > 0 else 0)


### PR DESCRIPTION
Make sync and send safe under LinkedIn's anti-bot limits by implementing configurable delays, exponential backoff, per-account concurrency control, and persistent daily send caps.

Rate limiting (job_runner.py):
  - Add SyncConfig dataclass with delay_between_threads_s (2.0), delay_between_pages_s (1.5), delay_between_accounts_s (5.0)
  - Apply configurable delays between threads, pages, and accounts
  - Add run_sync_multi() for multi-account sync with inter-account delay
  - API enforces minimum delay floors (ge=1.0 threads, ge=1.2 pages) to prevent bypassing safe request rates
  - CLI supports --delay-threads and --delay-pages arguments

Backoff on errors (provider.py):
  - Separate retry budgets: rate-limit (6 attempts, 30s-15min exponential) vs server-error (3 attempts, 2s-8s exponential)
  - HTTP 429/999 triggers exponential backoff with Retry-After support
  - HTTP 401 logs cookie expiry notification and raises PermissionError without retry
  - Network errors retry up to 3 times with 5s delay
  - All retry paths implemented in both _get_with_retry (GraphQL) and send_message code paths

Proxy safety:
  - All HTTP calls route through _get_client() (single shared client per provider instance) ensuring one account = one consistent IP
  - send_message no longer creates a fresh httpx.Client per call
  - Supports http://user:pass@host:port and socks5://host:port

Anti-bot hardening (beyond issue requirements):
  - Per-account threading lock prevents concurrent sync/send for the same account, which would bypass rate-limit delays
  - Daily send cap (10 messages/day) persisted in SQLite via storage.get_daily_send_count(), not per-instance counter
  - Thread list pagination uses dedicated 6.0s delay (~10 req/min) separate from DM fetch delay (1.5s, ~40 req/min)
  - Profile ID cached in storage after first fetch, avoiding repeated /voyager/api/me calls across syncs
  - _get_profile_id() routed through _get_with_retry for proper backoff and 401 handling

Logging:
  - All rate-limit events include account_id and timestamp
  - Provider accepts account_id parameter for contextual logging
  - rate_limit_encountered flag on provider instance tracks internal retries that succeeded (propagated to SyncResult)
  - SyncResult includes rate_limited: bool field
  - Cookie expiry (HTTP 401) logged as explicit warning

Observability:
  - API /sync response includes rate_limited field
  - CLI sync output includes rate_limited field

Acceptance criteria verified (59/59 tests passing):
  [PASS] Proxy used for all provider HTTP requests (7 tests)
  [PASS] Configurable delays between threads, pages, accounts (6 tests)
  [PASS] Backoff on 429/999, 401 cookie expiry, network retry (15 tests)
  [PASS] Logging with account_id, SyncResult.rate_limited (6 tests)
  [PASS] Acceptance criteria: delays, backoff, proxy (5 tests)
  [PASS] Safe rate floors matching LinkedIn empirical limits (6 tests)
  [PASS] Daily send cap persisted in SQLite (4 tests)
  [PASS] Thread list safe delay (2 tests)
  [PASS] Multi-account delay (2 tests)
  [PASS] Profile views caching (3 tests)
  [PASS] Provider rate_limit_encountered flag (3 tests)