### PR TITLE
fix: align limit_per_thread validation with provider max of 200

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -11,7 +11,7 @@ from libs.core.job_runner import run_send, run_sync, SendResult, SyncConfig, Syn
 from libs.core.models import AccountAuth, ProxyConfig
 from libs.core.redaction import configure_logging, redact_for_log, redact_string
 from libs.core.storage import Storage
-from libs.providers.linkedin.provider import LinkedInProvider
+from libs.providers.linkedin.provider import LinkedInProvider, MAX_MESSAGES_PER_PAGE
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ class SendIn(BaseModel):
 
 class SyncIn(BaseModel):
     account_id: int
-    limit_per_thread: int = Field(50, ge=1, le=500, description="Messages per page")
+    limit_per_thread: int = Field(50, ge=1, le=MAX_MESSAGES_PER_PAGE, description="Messages per page")
     max_pages_per_thread: int | None = Field(
         1,
         ge=1,

--- a/apps/cli/__main__.py
+++ b/apps/cli/__main__.py
@@ -18,7 +18,7 @@ from libs.core.job_runner import run_send, run_sync, SendResult, SyncConfig, Syn
 from libs.core.models import AccountAuth, ProxyConfig
 from libs.core.redaction import configure_logging
 from libs.core.storage import Storage
-from libs.providers.linkedin.provider import LinkedInProvider
+from libs.providers.linkedin.provider import LinkedInProvider, MAX_MESSAGES_PER_PAGE
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         type=int,
         default=50,
         metavar="N",
-        help="Messages per provider page (default: 50, max: 500)",
+        help=f"Messages per provider page (default: 50, max: {MAX_MESSAGES_PER_PAGE})",
     )
     p_sync.add_argument(
         "--max-pages-per-thread",
@@ -109,8 +109,8 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     if args.command == "sync":
         if args.exhaust_pagination and args.max_pages_per_thread is not None:
             parser.error("cannot combine --exhaust-pagination with --max-pages-per-thread")
-        if not (1 <= args.limit_per_thread <= 500):
-            parser.error("--limit-per-thread must be between 1 and 500")
+        if not (1 <= args.limit_per_thread <= MAX_MESSAGES_PER_PAGE):
+            parser.error(f"--limit-per-thread must be between 1 and {MAX_MESSAGES_PER_PAGE}")
         max_pages: int | None
         if args.exhaust_pagination:
             max_pages = None

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -15,6 +15,12 @@ from libs.core.models import AccountAuth, ProxyConfig
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Constants — fetch_messages
+# ---------------------------------------------------------------------------
+
+MAX_MESSAGES_PER_PAGE = 200
+
+# ---------------------------------------------------------------------------
 # Constants — send_message (upstream)
 # ---------------------------------------------------------------------------
 
@@ -669,8 +675,8 @@ class LinkedInProvider:
         Returns:
             (messages, next_cursor).  next_cursor is None when exhausted.
         """
-        if limit < 1 or limit > 200:
-            raise ValueError(f"limit must be between 1 and 200, got {limit}")
+        if limit < 1 or limit > MAX_MESSAGES_PER_PAGE:
+            raise ValueError(f"limit must be between 1 and {MAX_MESSAGES_PER_PAGE}, got {limit}")
 
         headers = self._build_graphql_headers()
         cookies = self._get_browser_cookies()


### PR DESCRIPTION
## Summary

- Lowered `limit_per_thread` max from 500 to 200 in both the API and CLI entry points to match the LinkedIn provider's actual limit
- Extracted `MAX_MESSAGES_PER_PAGE` constant in the provider and imported it in API/CLI so the limit is defined in one place

## Test plan

- [x] All 334 existing tests pass
- [ ] Manually verify `/sync` rejects `limit_per_thread > 200` with 422
- [ ] Manually verify CLI rejects `--limit-per-thread 201` with an error

Closes #41
