### PR TITLE
fix: map provider HTTP failures to stable API responses (#43)

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
+import httpx
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
@@ -95,6 +96,31 @@ class SyncIn(BaseModel):
     )
 
 
+def _map_provider_http_error(exc: httpx.HTTPStatusError) -> HTTPException:
+    """Map an upstream LinkedIn HTTP error to a stable API response."""
+    status = exc.response.status_code
+    if status in (401, 403):
+        return HTTPException(
+            status_code=401,
+            detail="LinkedIn session expired or rejected — re-authenticate via POST /accounts/refresh",
+        )
+    if status in (429, 999):
+        return HTTPException(
+            status_code=429,
+            detail="LinkedIn rate limit hit — retry later",
+        )
+    if 400 <= status < 500:
+        return HTTPException(
+            status_code=502,
+            detail=f"LinkedIn rejected the request (HTTP {status}) — possible API contract drift",
+        )
+    # 5xx or anything else
+    return HTTPException(
+        status_code=502,
+        detail=f"LinkedIn upstream error (HTTP {status})",
+    )
+
+
 @app.get("/health")
 def health():
     return {"ok": True}
@@ -184,6 +210,13 @@ def sync_account(body: SyncIn):
             status_code=401,
             detail="LinkedIn session expired — re-authenticate via POST /accounts/refresh",
         ) from exc
+    except httpx.HTTPStatusError as exc:
+        raise _map_provider_http_error(exc) from exc
+    except ConnectionError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail="LinkedIn provider network error — check connectivity and retry",
+        ) from exc
     except NotImplementedError:
         raise HTTPException(
             status_code=501,
@@ -228,6 +261,13 @@ def send_message(body: SendIn):
         raise HTTPException(
             status_code=401,
             detail="LinkedIn session expired — re-authenticate via POST /accounts/refresh",
+        ) from exc
+    except httpx.HTTPStatusError as exc:
+        raise _map_provider_http_error(exc) from exc
+    except ConnectionError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail="LinkedIn provider network error — check connectivity and retry",
         ) from exc
     except NotImplementedError:
         raise HTTPException(

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -99,6 +99,11 @@ class SyncIn(BaseModel):
 def _map_provider_http_error(exc: httpx.HTTPStatusError) -> HTTPException:
     """Map an upstream LinkedIn HTTP error to a stable API response."""
     status = exc.response.status_code
+    if status in (301, 302, 303, 307, 308):
+        return HTTPException(
+            status_code=401,
+            detail="LinkedIn redirected to login — session expired, re-authenticate via POST /accounts/refresh",
+        )
     if status in (401, 403):
         return HTTPException(
             status_code=401,

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -831,8 +831,10 @@ class LinkedInProvider:
                 self.rate_limit_encountered = True
                 rate_limit_hits += 1
                 if rate_limit_hits > _MAX_RATE_LIMIT_RETRIES:
-                    raise RuntimeError(
-                        f"Rate-limited {rate_limit_hits} times, giving up"
+                    raise httpx.HTTPStatusError(
+                        str(resp.status_code),
+                        request=resp.request,
+                        response=resp,
                     )
                 backoff = min(
                     _BACKOFF_START_S * (2 ** (rate_limit_hits - 1)), _BACKOFF_MAX_S

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -455,26 +455,30 @@ class LinkedInProvider:
         cookies = self._build_basic_cookies()
         try:
             resp = client.get(f"{_VOYAGER_BASE}/me", headers=headers, cookies=cookies)
-            if resp.status_code == 200:
+        except Exception:
+            logger.debug("_get_profile_id: failed to fetch /me", exc_info=True)
+            self._profile_id_fetched = True
+            return self._profile_id
+        if resp.status_code in (302, 303, 401, 403):
+            raise PermissionError(
+                f"LinkedIn session rejected on /me (HTTP {resp.status_code}). Re-authenticate."
+            )
+        if resp.status_code == 200:
+            try:
                 data = resp.json()
                 pid = data.get("entityUrn") or data.get("publicIdentifier")
-
-                # Normalized response: identifiers nested under "data"
                 if not pid:
                     inner = data.get("data") or {}
                     pid = inner.get("plainId") or inner.get("*miniProfile")
-
-                # Fallback: scan "included" array for a fsd_profile dashEntityUrn
                 if not pid:
                     for item in data.get("included") or []:
                         urn = item.get("dashEntityUrn")
                         if urn and "fsd_profile" in urn:
                             pid = urn
                             break
-
                 self._profile_id = pid
-        except Exception:
-            logger.debug("_get_profile_id: failed to fetch /me", exc_info=True)
+            except Exception:
+                logger.debug("_get_profile_id: failed to parse /me response", exc_info=True)
         self._profile_id_fetched = True
         return self._profile_id
 

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -590,6 +590,12 @@ class LinkedInProvider:
                     client, url, headers=headers, cookies=cookies,
                 )
 
+            if resp.status_code in (302, 303):
+                raise PermissionError(
+                    "LinkedIn redirected to login (HTTP %d). Session expired — re-authenticate."
+                    % resp.status_code
+                )
+
             resp.raise_for_status()
             try:
                 data = resp.json() if resp.content else {}
@@ -695,6 +701,12 @@ class LinkedInProvider:
             cookies = self._harvest_and_cache_cookies()
             resp = self._get_with_retry(
                 client, url, headers=headers, cookies=cookies,
+            )
+
+        if resp.status_code in (302, 303):
+            raise PermissionError(
+                "LinkedIn redirected to login (HTTP %d). Session expired — re-authenticate."
+                % resp.status_code
             )
 
         resp.raise_for_status()

--- a/scripts/validate_issue_43.py
+++ b/scripts/validate_issue_43.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Live validation for issue #43 — provider HTTP failure → stable API response.
+
+Exercises the full API → job_runner → provider → httpx chain against a fake
+LinkedIn served by httpx.MockTransport. Uses a real httpx.Client so the
+provider's retry loop runs against actual HTTP response parsing.
+Exit 0 iff all scenarios produce the intended responses.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+
+
+def _setup_paths() -> None:
+    root = Path(__file__).resolve().parent.parent
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+
+def _make_client() -> tuple[object, int]:
+    from fastapi.testclient import TestClient
+    from libs.core.storage import Storage
+    from apps.api.main import app
+    import apps.api.main as api_mod
+
+    tmp = tempfile.mkdtemp()
+    db_path = Path(tmp) / "validate.sqlite"
+    os.environ["DESEARCH_DB_PATH"] = str(db_path)
+    storage = Storage(db_path=db_path)
+    storage.migrate()
+    api_mod.storage = storage
+    client = TestClient(app)
+    resp = client.post(
+        "/accounts",
+        json={"label": "validate", "li_at": "AQEDAWx0Y29va2llXXX", "jsessionid": "ajax:csrf123"},
+    )
+    assert resp.status_code == 200, f"account creation failed: {resp.status_code} {resp.text}"
+    return client, resp.json()["account_id"]
+
+
+_REAL_CLIENT = httpx.Client
+
+
+def _client_factory_with_transport(transport: httpx.MockTransport):
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        kwargs.pop("proxy", None)
+        return _REAL_CLIENT(*args, **kwargs)
+    return _factory
+
+
+def _profile_ok_response() -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"entityUrn": "urn:li:fsd_profile:ABC123"},
+        headers={"content-type": "application/json"},
+    )
+
+
+def scenario_sync_redirect_302(client, account_id: int) -> tuple[bool, str]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/voyager/api/me" in str(request.url):
+            return _profile_ok_response()
+        return httpx.Response(302, headers={"Location": "https://www.linkedin.com/login"})
+
+    transport = httpx.MockTransport(handler)
+    with patch(
+        "libs.providers.linkedin.provider.httpx.Client",
+        side_effect=_client_factory_with_transport(transport),
+    ), patch("libs.providers.linkedin.provider.time.sleep"), patch(
+        "libs.providers.linkedin.provider.LinkedInProvider._harvest_and_cache_cookies",
+        return_value={},
+    ):
+        resp = client.post("/sync", json={"account_id": account_id})
+    ok = resp.status_code == 401
+    return ok, f"status={resp.status_code} detail={resp.json().get('detail')}"
+
+
+def scenario_sync_expired_session_on_me(client, account_id: int) -> tuple[bool, str]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"Location": "https://www.linkedin.com/login"})
+
+    transport = httpx.MockTransport(handler)
+    with patch(
+        "libs.providers.linkedin.provider.httpx.Client",
+        side_effect=_client_factory_with_transport(transport),
+    ), patch("libs.providers.linkedin.provider.time.sleep"):
+        resp = client.post("/sync", json={"account_id": account_id})
+    ok = resp.status_code == 401
+    return ok, f"status={resp.status_code} detail={resp.json().get('detail')}"
+
+
+def scenario_send_repeated_429(client, account_id: int) -> tuple[bool, str]:
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        return httpx.Response(429)
+
+    transport = httpx.MockTransport(handler)
+    with patch(
+        "libs.providers.linkedin.provider.httpx.Client",
+        side_effect=_client_factory_with_transport(transport),
+    ), patch("libs.providers.linkedin.provider.time.sleep"):
+        resp = client.post(
+            "/send",
+            json={"account_id": account_id, "recipient": "urn:li:fs_miniProfile:abc", "text": "hi"},
+        )
+    ok = resp.status_code == 429 and call_count["n"] == 6
+    return ok, (
+        f"status={resp.status_code} detail={resp.json().get('detail')} "
+        f"post_calls={call_count['n']}"
+    )
+
+
+def scenario_sync_network_error(client, account_id: int) -> tuple[bool, str]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/voyager/api/me" in str(request.url):
+            return _profile_ok_response()
+        raise httpx.ConnectError("network unreachable")
+
+    transport = httpx.MockTransport(handler)
+    with patch(
+        "libs.providers.linkedin.provider.httpx.Client",
+        side_effect=_client_factory_with_transport(transport),
+    ), patch("libs.providers.linkedin.provider.time.sleep"):
+        resp = client.post("/sync", json={"account_id": account_id})
+    ok = resp.status_code == 502
+    return ok, f"status={resp.status_code} detail={resp.json().get('detail')}"
+
+
+def main() -> int:
+    _setup_paths()
+    client, account_id = _make_client()
+    scenarios = [
+        ("sync: LinkedIn 302 on GraphQL (post-profile) → 401", 401, scenario_sync_redirect_302),
+        ("sync: expired session, 302 on /me (real session expiry) → 401", 401, scenario_sync_expired_session_on_me),
+        ("send: repeated 429 rate-limit → 429", 429, scenario_send_repeated_429),
+        ("sync: network ConnectError → 502", 502, scenario_sync_network_error),
+    ]
+    print("=" * 70)
+    print("Issue #43 live validation (httpx.MockTransport against real httpx.Client)")
+    print("=" * 70)
+    failed = 0
+    for name, expected, fn in scenarios:
+        ok, detail = fn(client, account_id)
+        status = "PASS" if ok else "FAIL"
+        print(f"\n[{status}] {name}")
+        print(f"        expected_status={expected}")
+        print(f"        {detail}")
+        if not ok:
+            failed += 1
+    print("\n" + "=" * 70)
+    if failed:
+        print(f"FAIL: {failed}/{len(scenarios)} scenarios did not produce the intended response")
+        return 1
+    print(f"PASS: all {len(scenarios)} scenarios produced the intended API responses")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_api_error_mapping.py
+++ b/tests/test_api_error_mapping.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -117,3 +117,54 @@ def test_send_rate_limit_999_returns_429(mock_run_send, client):
     )
     assert resp.status_code == 429
     assert "rate limit" in resp.json()["detail"].lower()
+
+
+def _mock_httpx_response(status_code: int) -> httpx.Response:
+    request = httpx.Request("GET", "https://www.linkedin.com/voyager/api/test")
+    return httpx.Response(status_code=status_code, request=request)
+
+
+def _create_account_with_jsessionid(client) -> int:
+    resp = client.post(
+        "/accounts",
+        json={"label": "test", "li_at": "AQEDAWx0Y29va2llXXX", "jsessionid": "ajax:csrf123"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["account_id"]
+
+
+@patch("libs.providers.linkedin.provider.LinkedInProvider._get_profile_id", return_value="urn:li:fsd_profile:ABC")
+@patch("libs.providers.linkedin.provider.LinkedInProvider._harvest_and_cache_cookies", return_value={})
+@patch("libs.providers.linkedin.provider.time.sleep")
+@patch("libs.providers.linkedin.provider.httpx.Client")
+def test_sync_linkedin_redirect_302_end_to_end(MockClient, _sleep, _harvest, _profile, client):
+    mock_client = MagicMock()
+    mock_client.is_closed = False
+    mock_client.get.return_value = _mock_httpx_response(302)
+    MockClient.return_value = mock_client
+
+    account_id = _create_account_with_jsessionid(client)
+    resp = client.post("/sync", json={"account_id": account_id})
+
+    assert resp.status_code == 401
+    assert "re-authenticate" in resp.json()["detail"].lower()
+
+
+@patch("libs.providers.linkedin.provider.time")
+@patch("libs.providers.linkedin.provider.httpx.Client")
+def test_send_repeated_429_end_to_end(MockClient, mock_time, client):
+    mock_time.monotonic.return_value = 1000.0
+    post_client = MagicMock()
+    post_client.post.return_value = _mock_httpx_response(429)
+    MockClient.return_value.__enter__ = MagicMock(return_value=post_client)
+    MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+    account_id = _create_account_with_jsessionid(client)
+    resp = client.post(
+        "/send",
+        json={"account_id": account_id, "recipient": "urn:li:fs_miniProfile:abc", "text": "hi"},
+    )
+
+    assert resp.status_code == 429
+    assert "rate limit" in resp.json()["detail"].lower()
+    assert post_client.post.call_count == 6

--- a/tests/test_api_error_mapping.py
+++ b/tests/test_api_error_mapping.py
@@ -1,0 +1,119 @@
+"""Tests for provider error mapping in /sync and /send endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from libs.core import crypto
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "test.sqlite"))
+    monkeypatch.delenv("DESEARCH_ENCRYPTION_KEY", raising=False)
+    crypto._warned_no_key = False
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "test.sqlite"))
+    from libs.core.storage import Storage
+
+    storage = Storage(db_path=tmp_path / "test.sqlite")
+    storage.migrate()
+
+    from apps.api.main import app
+    import apps.api.main as api_mod
+
+    original_storage = api_mod.storage
+    api_mod.storage = storage
+    yield TestClient(app)
+    api_mod.storage = original_storage
+    storage.close()
+
+
+def _create_account(client) -> int:
+    resp = client.post(
+        "/accounts",
+        json={"label": "test", "li_at": "AQEDAWx0Y29va2llXXX"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["account_id"]
+
+
+def _make_http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://www.linkedin.com/api")
+    response = httpx.Response(status_code=status_code, request=request)
+    return httpx.HTTPStatusError(
+        str(status_code), request=request, response=response,
+    )
+
+
+@patch("apps.api.main.run_sync")
+def test_sync_redirect_302_returns_401(mock_run_sync, client):
+    account_id = _create_account(client)
+    mock_run_sync.side_effect = PermissionError("LinkedIn redirected to login (HTTP 302)")
+    resp = client.post("/sync", json={"account_id": account_id})
+    assert resp.status_code == 401
+    assert "re-authenticate" in resp.json()["detail"].lower()
+
+
+@patch("apps.api.main.run_sync")
+def test_sync_redirect_303_returns_401(mock_run_sync, client):
+    account_id = _create_account(client)
+    mock_run_sync.side_effect = PermissionError("LinkedIn redirected to login (HTTP 303)")
+    resp = client.post("/sync", json={"account_id": account_id})
+    assert resp.status_code == 401
+    assert "re-authenticate" in resp.json()["detail"].lower()
+
+
+@patch("apps.api.main.run_send")
+def test_send_redirect_302_returns_401(mock_run_send, client):
+    account_id = _create_account(client)
+    mock_run_send.side_effect = PermissionError("LinkedIn redirected to login (HTTP 302)")
+    resp = client.post(
+        "/send",
+        json={"account_id": account_id, "recipient": "urn:li:fs_miniProfile:abc", "text": "hi"},
+    )
+    assert resp.status_code == 401
+    assert "re-authenticate" in resp.json()["detail"].lower()
+
+
+@patch("apps.api.main.run_send")
+def test_send_redirect_303_returns_401(mock_run_send, client):
+    account_id = _create_account(client)
+    mock_run_send.side_effect = PermissionError("LinkedIn redirected to login (HTTP 303)")
+    resp = client.post(
+        "/send",
+        json={"account_id": account_id, "recipient": "urn:li:fs_miniProfile:abc", "text": "hi"},
+    )
+    assert resp.status_code == 401
+    assert "re-authenticate" in resp.json()["detail"].lower()
+
+
+@patch("apps.api.main.run_send")
+def test_send_rate_limit_429_returns_429(mock_run_send, client):
+    account_id = _create_account(client)
+    mock_run_send.side_effect = _make_http_status_error(429)
+    resp = client.post(
+        "/send",
+        json={"account_id": account_id, "recipient": "urn:li:fs_miniProfile:abc", "text": "hi"},
+    )
+    assert resp.status_code == 429
+    assert "rate limit" in resp.json()["detail"].lower()
+
+
+@patch("apps.api.main.run_send")
+def test_send_rate_limit_999_returns_429(mock_run_send, client):
+    account_id = _create_account(client)
+    mock_run_send.side_effect = _make_http_status_error(999)
+    resp = client.post(
+        "/send",
+        json={"account_id": account_id, "recipient": "urn:li:fs_miniProfile:abc", "text": "hi"},
+    )
+    assert resp.status_code == 429
+    assert "rate limit" in resp.json()["detail"].lower()

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -514,15 +514,14 @@ class TestListThreads:
         assert "mailboxUrn:urn:li:fsd_profile:ABC123" in url
 
     def test_raises_if_profile_id_unavailable(self, auth):
-        """Raises RuntimeError if profile ID cannot be determined."""
+        """Raises RuntimeError if profile ID cannot be determined (non-auth failure)."""
         p = LinkedInProvider(auth=auth)
         p._browser_cookies = {"li_at": "x"}
         p._profile_id = None
         mock_client = MagicMock()
         mock_client.is_closed = False
-        # Mock the /me call to return non-200
         me_resp = MagicMock()
-        me_resp.status_code = 302
+        me_resp.status_code = 500
         mock_client.get.return_value = me_resp
         with _patch_client(mock_client):
             with pytest.raises(RuntimeError, match="profile ID"):
@@ -669,12 +668,12 @@ class TestGetProfileId:
         assert mock_client.get.call_count == 1
 
     def test_profile_id_none_cached_when_api_fails(self, auth):
-        """If /me fails, we cache None and don't retry every call."""
+        """If /me fails with a non-auth status, we cache None and don't retry every call."""
         p = LinkedInProvider(auth=auth)
         mock_client = MagicMock()
         mock_client.is_closed = False
         me_resp = MagicMock()
-        me_resp.status_code = 403
+        me_resp.status_code = 500
         mock_client.get.return_value = me_resp
         with _patch_client(mock_client):
             first = p._get_profile_id()
@@ -682,6 +681,19 @@ class TestGetProfileId:
         assert first is None
         assert second is None
         assert mock_client.get.call_count == 1
+
+    @pytest.mark.parametrize("status_code", [302, 303, 401, 403])
+    def test_profile_id_raises_permission_error_on_auth_rejection(self, auth, status_code):
+        """Auth-rejection on /me surfaces as PermissionError, not silent None."""
+        p = LinkedInProvider(auth=auth)
+        mock_client = MagicMock()
+        mock_client.is_closed = False
+        me_resp = MagicMock()
+        me_resp.status_code = status_code
+        mock_client.get.return_value = me_resp
+        with _patch_client(mock_client):
+            with pytest.raises(PermissionError, match="session rejected"):
+                p._get_profile_id()
 
     def test_profile_id_from_public_identifier(self, auth):
         p = LinkedInProvider(auth=auth)

--- a/tests/test_send_message.py
+++ b/tests/test_send_message.py
@@ -406,7 +406,7 @@ class TestSendMessageRateLimiting:
         client.post.return_value = _make_mock_response(429)
 
         provider = _make_provider()
-        with pytest.raises(RuntimeError, match="Rate-limited"):
+        with pytest.raises(httpx.HTTPStatusError):
             provider.send_message(recipient=SAMPLE_RECIPIENT, text="Hi")
 
         assert client.post.call_count == 6  # 5 retries + 1 final that triggers raise


### PR DESCRIPTION
## Summary
- Catch `httpx.HTTPStatusError` and `ConnectionError` in `/sync` and `/send` endpoints
- Map upstream LinkedIn HTTP status codes to stable API responses:
  - 401/403 → API 401 (session expired)
  - 429/999 → API 429 (rate limited)
  - Other 4xx → API 502 (contract drift)
  - 5xx → API 502 (upstream error)
  - ConnectionError → API 502 (network error)

Closes #43
