### PR TITLE
sync fails because _get_profile_id misparses

### DIFF
--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -451,7 +451,22 @@ class LinkedInProvider:
             resp = client.get(f"{_VOYAGER_BASE}/me", headers=headers, cookies=cookies)
             if resp.status_code == 200:
                 data = resp.json()
-                self._profile_id = data.get("entityUrn") or data.get("publicIdentifier")
+                pid = data.get("entityUrn") or data.get("publicIdentifier")
+
+                # Normalized response: identifiers nested under "data"
+                if not pid:
+                    inner = data.get("data") or {}
+                    pid = inner.get("plainId") or inner.get("*miniProfile")
+
+                # Fallback: scan "included" array for a fsd_profile dashEntityUrn
+                if not pid:
+                    for item in data.get("included") or []:
+                        urn = item.get("dashEntityUrn")
+                        if urn and "fsd_profile" in urn:
+                            pid = urn
+                            break
+
+                self._profile_id = pid
         except Exception:
             logger.debug("_get_profile_id: failed to fetch /me", exc_info=True)
         self._profile_id_fetched = True

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -704,6 +704,91 @@ class TestGetProfileId:
             pid = p._get_profile_id()
         assert pid is None
 
+    def test_profile_id_from_nested_plain_id(self, auth):
+        """Normalized response with plainId under 'data' key."""
+        p = LinkedInProvider(auth=auth)
+        mock_client = MagicMock()
+        mock_client.is_closed = False
+        me_resp = MagicMock()
+        me_resp.status_code = 200
+        me_resp.json.return_value = {"data": {"plainId": "123456789"}}
+        mock_client.get.return_value = me_resp
+        with _patch_client(mock_client):
+            pid = p._get_profile_id()
+        assert pid == "123456789"
+
+    def test_profile_id_from_nested_mini_profile(self, auth):
+        """Normalized response with *miniProfile URN under 'data' key."""
+        p = LinkedInProvider(auth=auth)
+        mock_client = MagicMock()
+        mock_client.is_closed = False
+        me_resp = MagicMock()
+        me_resp.status_code = 200
+        me_resp.json.return_value = {
+            "data": {"*miniProfile": "urn:li:fsd_profile:XYZ789"},
+        }
+        mock_client.get.return_value = me_resp
+        with _patch_client(mock_client):
+            pid = p._get_profile_id()
+        assert pid == "urn:li:fsd_profile:XYZ789"
+
+    def test_profile_id_from_included_dash_entity_urn(self, auth):
+        """Normalized response with dashEntityUrn in the included array."""
+        p = LinkedInProvider(auth=auth)
+        mock_client = MagicMock()
+        mock_client.is_closed = False
+        me_resp = MagicMock()
+        me_resp.status_code = 200
+        me_resp.json.return_value = {
+            "included": [
+                {"$type": "com.linkedin.voyager.common.Me"},
+                {
+                    "$type": "com.linkedin.voyager.identity.shared.MiniProfile",
+                    "dashEntityUrn": "urn:li:fsd_profile:DASH_ABC",
+                },
+            ],
+        }
+        mock_client.get.return_value = me_resp
+        with _patch_client(mock_client):
+            pid = p._get_profile_id()
+        assert pid == "urn:li:fsd_profile:DASH_ABC"
+
+    def test_profile_id_top_level_takes_precedence(self, auth):
+        """Top-level entityUrn wins over nested fields."""
+        p = LinkedInProvider(auth=auth)
+        mock_client = MagicMock()
+        mock_client.is_closed = False
+        me_resp = MagicMock()
+        me_resp.status_code = 200
+        me_resp.json.return_value = {
+            "entityUrn": "urn:li:fsd_profile:TOP",
+            "data": {"plainId": "999"},
+            "included": [
+                {"dashEntityUrn": "urn:li:fsd_profile:INCLUDED"},
+            ],
+        }
+        mock_client.get.return_value = me_resp
+        with _patch_client(mock_client):
+            pid = p._get_profile_id()
+        assert pid == "urn:li:fsd_profile:TOP"
+
+    def test_profile_id_skips_non_fsd_profile_in_included(self, auth):
+        """included items without fsd_profile in dashEntityUrn are ignored."""
+        p = LinkedInProvider(auth=auth)
+        mock_client = MagicMock()
+        mock_client.is_closed = False
+        me_resp = MagicMock()
+        me_resp.status_code = 200
+        me_resp.json.return_value = {
+            "included": [
+                {"dashEntityUrn": "urn:li:fsd_company:CORP123"},
+            ],
+        }
+        mock_client.get.return_value = me_resp
+        with _patch_client(mock_client):
+            pid = p._get_profile_id()
+        assert pid is None
+
 
 # ---------------------------------------------------------------------------
 # JSON decode safety


### PR DESCRIPTION
## Summary
[provider.py:454](vscode-webview://08rv70eio2ma04dltg0gb7hvstugb1hju4m7tkeffg5amp9q1d60/libs/providers/linkedin/provider.py#L454) only checked two top-level fields (entityUrn, publicIdentifier) in the /voyager/api/me response. LinkedIn's actual normalized JSON response nests identifiers deeper, so valid sessions always got None and sync failed with "Could not determine LinkedIn profile ID".

## Changes
[libs/providers/linkedin/provider.py](vscode-webview://08rv70eio2ma04dltg0gb7hvstugb1hju4m7tkeffg5amp9q1d60/libs/providers/linkedin/provider.py) - _get_profile_id() now parses three tiers:

1. Top-level (original): entityUrn / publicIdentifier - backward compatible
2. Nested data: data.plainId / data.*miniProfile - normalized response format
3. included array: scans for dashEntityUrn containing fsd_profile - fallback

Close https://github.com/Desearch-ai/linkedin-dms/issues/38