### PR TITLE
fix(api): protect local routes with optional bearer auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ export DESEARCH_ENCRYPTION_KEY="$(python -c "from cryptography.fernet import Fer
 
 If `DESEARCH_ENCRYPTION_KEY` is not set, the app still works, but auth and proxy JSON are stored in plaintext and the process logs a one-time warning.
 
+Optional local API bearer auth:
+
+```bash
+export DESEARCH_API_TOKEN='replace-with-a-local-shared-secret'
+```
+
+If `DESEARCH_API_TOKEN` is set, all routes except `GET /health` require:
+
+```bash
+Authorization: Bearer <token>
+```
+
 ## Running the API
 
 ```bash
@@ -77,6 +89,11 @@ Useful endpoints:
 - `GET /sends?account_id=1`
 
 Swagger UI is available at <http://127.0.0.1:8899/docs>.
+
+Security posture for local development:
+- bind to `127.0.0.1`, not `0.0.0.0`
+- set `DESEARCH_API_TOKEN` if other local processes should not be able to drive the API
+- configure the same bearer token in the Chrome extension popup when API auth is enabled
 
 ### API request and response shape
 
@@ -180,12 +197,14 @@ Examples:
 ```bash
 curl -s -X POST http://127.0.0.1:8899/accounts \
   -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer replace-with-a-local-shared-secret' \
   -d '{"label":"sales-1","li_at":"REDACTED","jsessionid":"ajax:REDACTED"}'
 ```
 
 ```bash
 curl -s -X POST http://127.0.0.1:8899/accounts \
   -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer replace-with-a-local-shared-secret' \
   -d '{"label":"sales-1","cookies":"li_at=REDACTED; JSESSIONID=ajax:REDACTED"}'
 ```
 
@@ -194,6 +213,7 @@ Refresh an existing account without recreating it:
 ```bash
 curl -s -X POST http://127.0.0.1:8899/accounts/refresh \
   -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer replace-with-a-local-shared-secret' \
   -d '{"account_id":1,"cookies":"li_at=REDACTED; JSESSIONID=ajax:REDACTED"}'
 ```
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import logging
+import os
+import secrets
 from typing import Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
 from libs.core.cookies import cookies_to_account_auth, validate_li_at
@@ -21,6 +23,28 @@ app = FastAPI(title="Desearch LinkedIn DMs", version="0.0.2")
 
 storage = Storage()
 storage.migrate()
+
+
+def _get_api_token() -> str | None:
+    value = os.getenv("DESEARCH_API_TOKEN")
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def require_api_auth(authorization: str | None = Header(default=None)) -> None:
+    expected = _get_api_token()
+    if expected is None:
+        return
+
+    scheme, _, token = (authorization or "").partition(" ")
+    if scheme.lower() != "bearer" or not token or not secrets.compare_digest(token, expected):
+        raise HTTPException(
+            status_code=401,
+            detail="Missing or invalid bearer token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
 
 class AuthCheckResponse(BaseModel):
@@ -100,7 +124,7 @@ def health():
     return {"ok": True}
 
 
-@app.post("/accounts")
+@app.post("/accounts", dependencies=[Depends(require_api_auth)])
 def create_account(body: AccountCreateIn):
     try:
         auth = body.to_account_auth()
@@ -112,7 +136,7 @@ def create_account(body: AccountCreateIn):
     return {"account_id": account_id}
 
 
-@app.post("/accounts/refresh")
+@app.post("/accounts/refresh", dependencies=[Depends(require_api_auth)])
 def refresh_account(body: AccountRefreshIn):
     """Update session cookies for an existing account without recreating it."""
     try:
@@ -127,7 +151,7 @@ def refresh_account(body: AccountRefreshIn):
     return {"ok": True, "account_id": body.account_id}
 
 
-@app.get("/auth/check", response_model=AuthCheckResponse)
+@app.get("/auth/check", response_model=AuthCheckResponse, dependencies=[Depends(require_api_auth)])
 def auth_check(account_id: int):
     try:
         auth = storage.get_account_auth(account_id)
@@ -144,12 +168,12 @@ def auth_check(account_id: int):
     return {"status": "failed", "error": result.error or "authentication check failed"}
 
 
-@app.get("/threads")
+@app.get("/threads", dependencies=[Depends(require_api_auth)])
 def list_threads(account_id: int):
     return {"threads": storage.list_threads(account_id=account_id)}
 
 
-@app.post("/sync")
+@app.post("/sync", dependencies=[Depends(require_api_auth)])
 def sync_account(body: SyncIn):
     """Trigger a sync. Default one page per thread (MVP); set max_pages_per_thread or null to exhaust."""
     try:
@@ -196,7 +220,7 @@ def sync_account(body: SyncIn):
         ) from None
 
 
-@app.post("/send")
+@app.post("/send", dependencies=[Depends(require_api_auth)])
 def send_message(body: SendIn):
     try:
         auth = storage.get_account_auth(body.account_id)
@@ -236,7 +260,7 @@ def send_message(body: SendIn):
         ) from None
 
 
-@app.get("/sends")
+@app.get("/sends", dependencies=[Depends(require_api_auth)])
 def list_sends(account_id: int, status: str | None = None):
     """Query outbound send records for an account, optionally filtered by status."""
     try:

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -11,9 +11,19 @@ const SERVICE_URL_DEFAULT = "http://localhost:8899";
 async function getConfig() {
   const result = await chrome.storage.local.get({
     serviceUrl: SERVICE_URL_DEFAULT,
+    apiToken: "",
     accountId: null,
   });
   return result;
+}
+
+function buildServiceHeaders(config) {
+  const headers = { "Content-Type": "application/json" };
+  const token = (config.apiToken || "").trim();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
 }
 
 async function setStatus(status, error = null) {
@@ -76,7 +86,7 @@ async function pushRefresh(config, cookies) {
 
   const resp = await fetch(`${config.serviceUrl}/accounts/refresh`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: buildServiceHeaders(config),
     body: JSON.stringify(payload),
   });
 
@@ -98,7 +108,7 @@ async function registerAccount(config, cookies) {
 
   const resp = await fetch(`${config.serviceUrl}/accounts`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: buildServiceHeaders(config),
     body: JSON.stringify(payload),
   });
 
@@ -156,7 +166,7 @@ async function handleManualSync() {
 
   const resp = await fetch(`${config.serviceUrl}/sync`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: buildServiceHeaders(config),
     body: JSON.stringify({ account_id: config.accountId }),
   });
 

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -140,6 +140,11 @@
     <input type="text" id="backendUrl" placeholder="http://localhost:8899" />
   </div>
 
+  <div class="config-section">
+    <label for="apiToken">API Bearer Token</label>
+    <input type="password" id="apiToken" placeholder="Optional local API token" />
+  </div>
+
   <div class="btn-row">
     <button class="btn-primary" id="btnSync">Sync Now</button>
     <button class="btn-secondary" id="btnRefresh">Refresh Cookies</button>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -6,6 +6,7 @@ const accountIdEl = document.getElementById("accountId");
 const lastUpdatedEl = document.getElementById("lastUpdated");
 const headersStatusEl = document.getElementById("headersStatus");
 const backendUrlInput = document.getElementById("backendUrl");
+const apiTokenInput = document.getElementById("apiToken");
 const resultEl = document.getElementById("result");
 const btnSync = document.getElementById("btnSync");
 const btnRefresh = document.getElementById("btnRefresh");
@@ -16,6 +17,7 @@ const btnSaveConfig = document.getElementById("btnSaveConfig");
 async function loadState() {
   const state = await chrome.storage.local.get({
     serviceUrl: "http://localhost:8899",
+    apiToken: "",
     accountId: null,
     lastStatus: null,
     lastError: null,
@@ -25,6 +27,7 @@ async function loadState() {
   });
 
   backendUrlInput.value = state.serviceUrl;
+  apiTokenInput.value = state.apiToken;
   accountIdEl.textContent = state.accountId ?? "—";
 
   // Status indicator
@@ -73,11 +76,12 @@ function setButtonsDisabled(disabled) {
 
 btnSaveConfig.addEventListener("click", async () => {
   const url = backendUrlInput.value.trim().replace(/\/+$/, "");
+  const apiToken = apiTokenInput.value.trim();
   if (!url) {
     showResult("Backend URL is required.", true);
     return;
   }
-  await chrome.storage.local.set({ serviceUrl: url });
+  await chrome.storage.local.set({ serviceUrl: url, apiToken });
   showResult("Config saved.");
 });
 

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -279,6 +279,23 @@ async function testAC5_manualSync() {
   }
 }
 
+async function testAC5b_manualSyncIncludesBearerToken() {
+  console.log("\nAC5b: MANUAL_SYNC includes Authorization when apiToken is configured");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  env.storage.apiToken = "local-api-token";
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  assert(resp.ok === true, "sync response is ok");
+
+  const syncCall = env.fetchLog.find(f => f.url.includes("/sync"));
+  assert(!!syncCall, "POST /sync was called");
+  if (syncCall) {
+    assert(syncCall.options.headers.Authorization === "Bearer local-api-token", "Authorization header included");
+  }
+}
+
 async function testAC6_manualRefresh() {
   console.log("\nAC6: MANUAL_REFRESH triggers cookie refresh");
   const env = buildEnv();
@@ -304,6 +321,7 @@ async function main() {
   await testAC3_ignoresNonLinkedIn();
   await testAC4_headerCapture();
   await testAC5_manualSync();
+  await testAC5b_manualSyncIncludesBearerToken();
   await testAC6_manualRefresh();
 
   console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -151,3 +151,15 @@ Impact:
 - the runtime behavior is correct and matches the API MVP default
 - contributors reading only the argparse declaration can misread the default behavior
 - docs should call out the effective one-page default explicitly, which this docs pass now does
+
+## 17. API auth is optional, not mandatory
+
+The local API can now require a bearer token through `DESEARCH_API_TOKEN`, but the protection is opt-in.
+
+Impact:
+- local setups that do not set the token still expose account, sync, send, and thread routes to any local process that can reach the port
+- this keeps zero-config local development simple, but it is not a hardened default for shared or remotely exposed environments
+
+Operational advice:
+- keep the bind address at `127.0.0.1`
+- set `DESEARCH_API_TOKEN` before using any non-localhost binding, reverse proxy, or shared workstation setup

--- a/tests/test_api_accounts.py
+++ b/tests/test_api_accounts.py
@@ -16,12 +16,14 @@ def _clean_env(monkeypatch, tmp_path):
     """Use a temp DB and reset crypto warning flag."""
     monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "test.sqlite"))
     monkeypatch.delenv("DESEARCH_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("DESEARCH_API_TOKEN", raising=False)
     crypto._warned_no_key = False
 
 
 @pytest.fixture()
 def client(tmp_path, monkeypatch):
     monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "test.sqlite"))
+    monkeypatch.delenv("DESEARCH_API_TOKEN", raising=False)
     # Re-import to pick up fresh Storage with tmp db
     # We patch Storage init to use tmp_path
     from libs.core.storage import Storage
@@ -99,3 +101,24 @@ class TestCreateAccountValidation:
     def test_empty_li_at_rejected(self, client):
         resp = client.post("/accounts", json={"label": "test", "li_at": ""})
         assert resp.status_code == 422
+
+
+class TestCreateAccountApiAuth:
+    def test_create_requires_bearer_token_when_configured(self, client, monkeypatch):
+        monkeypatch.setenv("DESEARCH_API_TOKEN", "secret-token")
+        resp = client.post(
+            "/accounts",
+            json={"label": "test", "li_at": "AQEDAWx0Y29va2llXXX"},
+        )
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Missing or invalid bearer token"
+
+    def test_create_accepts_bearer_token_when_configured(self, client, monkeypatch):
+        monkeypatch.setenv("DESEARCH_API_TOKEN", "secret-token")
+        resp = client.post(
+            "/accounts",
+            headers={"Authorization": "Bearer secret-token"},
+            json={"label": "test", "li_at": "AQEDAWx0Y29va2llXXX"},
+        )
+        assert resp.status_code == 200
+        assert "account_id" in resp.json()

--- a/tests/test_api_refresh.py
+++ b/tests/test_api_refresh.py
@@ -16,12 +16,14 @@ def _clean_env(monkeypatch, tmp_path):
     """Use a temp DB and reset crypto warning flag."""
     monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "test.sqlite"))
     monkeypatch.delenv("DESEARCH_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("DESEARCH_API_TOKEN", raising=False)
     crypto._warned_no_key = False
 
 
 @pytest.fixture()
 def client(tmp_path, monkeypatch):
     monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "test.sqlite"))
+    monkeypatch.delenv("DESEARCH_API_TOKEN", raising=False)
     from libs.core.storage import Storage
 
     storage = Storage(db_path=tmp_path / "test.sqlite")


### PR DESCRIPTION
## Summary

Closes #39

When `DESEARCH_API_TOKEN` is set, all API routes except `GET /health` now require:

`Authorization: Bearer <token>`

This keeps the existing local MVP flow unchanged when the token is unset, while adding an app-level security boundary for local or shared environments.

## Changes

- add optional bearer auth enforcement in `apps/api/main.py`
- protect:
  - `POST /accounts`
  - `POST /accounts/refresh`
  - `GET /auth/check`
  - `GET /threads`
  - `POST /sync`
  - `POST /send`
  - `GET /sends`
- keep `GET /health` public
- update the Chrome extension to store an optional API token and send `Authorization: Bearer ...`
- update README and known-issues docs with local hardening guidance
- keep test changes small:
  - add minimal auth coverage to existing API account tests
  - clear `DESEARCH_API_TOKEN` in existing API test fixtures
  - add one focused extension assertion for bearer-header behavior

## Tests

Automated:
- `./.venv/bin/pytest tests/test_api_accounts.py tests/test_api_refresh.py -q`
- `node chrome-extension/test_background.mjs`

Manual:
- verified `GET /health` remains public
- verified protected routes return `401` with missing or wrong token
- verified protected routes succeed with the correct token
- verified auth-disabled mode still allows legacy local-dev behavior

## Notes

- auth remains opt-in via `DESEARCH_API_TOKEN`
- localhost-only posture is still recommended
- the Chrome extension must be configured with the same token when API auth is enabled
