### PR TITLE
Fix/session invalidation 40

### DIFF
--- a/libs/core/models.py
+++ b/libs/core/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal, Optional
-
+from pydantic import BaseModel
 
 @dataclass(frozen=True)
 class ProxyConfig:
@@ -70,3 +70,19 @@ class Message:
     text: Optional[str]
     sent_at: datetime
     raw: Optional[dict[str, Any]] = None
+
+class BrowserHeaders(BaseModel):
+    """Real browser request headers captured by the Chrome extension.
+
+    When provided, the LinkedIn provider uses these values in place of
+    the hardcoded synthetic equivalents, so the backend request fingerprint
+    matches the real browser session and LinkedIn does not challenge/invalidate it.
+
+    All fields are optional — missing fields fall back to the provider defaults.
+    """
+    user_agent: str | None = None
+    x_li_track: str | None = None
+    csrf_token: str | None = None
+    x_li_page_instance: str | None = None
+    x_li_lang: str | None = None
+


### PR DESCRIPTION
Sync Now was invalidating the active LinkedIn browser session and forcing 
re-login. The root cause was a fingerprint mismatch — the backend was making 
LinkedIn API requests with hardcoded synthetic headers (User-Agent, x-li-track, 
csrf-token) while the Chrome extension captured real browser values but never 
forwarded them.

This PR threads the real browser headers through the entire sync pipeline so 
the backend uses them instead of the hardcoded fallbacks. All changes are 
fully backward-compatible — browser_headers is optional everywhere and 
falls back to existing defaults when not provided.

Closes #40