### PR TITLE
feat(extension): harden header capture bridge for issue #21

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -118,13 +118,23 @@ async function registerAccount(config, cookies) {
 // csrf-token header values from the real browser session.
 
 chrome.webRequest.onSendHeaders.addListener(
-  (details) => {
-    const track = details.requestHeaders.find(h => h.name === "x-li-track");
-    const csrf = details.requestHeaders.find(h => h.name === "csrf-token");
-    if (track || csrf) {
-      // store for provider use
-      chrome.storage.local.set({ xLiTrack: track?.value, csrfToken: csrf?.value });
-    }
+  async (details) => {
+    const headers = details.requestHeaders || [];
+    const track = headers.find((h) => (h.name || "").toLowerCase() === "x-li-track");
+    const csrf = headers.find((h) => (h.name || "").toLowerCase() === "csrf-token");
+
+    if (!track && !csrf) return;
+
+    // Preserve previously captured value when only one header is present.
+    const current = await chrome.storage.local.get({ xLiTrack: null, csrfToken: null });
+    const updates = {
+      xLiTrack: track?.value ?? current.xLiTrack,
+      csrfToken: csrf?.value ?? current.csrfToken,
+      headersUpdatedAt: new Date().toISOString(),
+    };
+
+    // store for provider use
+    chrome.storage.local.set(updates);
   },
   { urls: [VOYAGER_API_PATTERN] },
   ["requestHeaders"]

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -22,6 +22,7 @@ async function loadState() {
     lastUpdated: null,
     xLiTrack: null,
     csrfToken: null,
+    headersUpdatedAt: null,
   });
 
   backendUrlInput.value = state.serviceUrl;

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -248,7 +248,7 @@ async function testAC4_headerCapture() {
   assert(headerListener.filter.urls[0] === "https://www.linkedin.com/voyager/api/*", "filter matches voyager API pattern");
 
   // Simulate a request with both headers
-  headerListener.fn({
+  await headerListener.fn({
     requestHeaders: [
       { name: "x-li-track", value: '{"clientVersion":"1.13.42912"}' },
       { name: "csrf-token", value: "ajax:abc123" },
@@ -258,6 +258,17 @@ async function testAC4_headerCapture() {
 
   assert(env.storage.xLiTrack === '{"clientVersion":"1.13.42912"}', "xLiTrack stored");
   assert(env.storage.csrfToken === "ajax:abc123", "csrfToken stored");
+  assert(!!env.storage.headersUpdatedAt, "headersUpdatedAt stored");
+
+  // Simulate partial update: only one header present (case-insensitive name)
+  await headerListener.fn({
+    requestHeaders: [
+      { name: "X-LI-TRACK", value: '{"clientVersion":"1.13.42913"}' },
+    ],
+  });
+
+  assert(env.storage.xLiTrack === '{"clientVersion":"1.13.42913"}', "xLiTrack updates on partial capture");
+  assert(env.storage.csrfToken === "ajax:abc123", "csrfToken preserved when not present in later request");
 }
 
 async function testAC5_manualSync() {


### PR DESCRIPTION
## Summary
This PR intentionally stays small and scoped to the extension bridge path for #21, following maintainer guidance.

### What changed
- Make header capture for `x-li-track` and `csrf-token` case-insensitive.
- Preserve previously captured header values when only one header appears in a request.
- Persist `headersUpdatedAt` timestamp for basic diagnostics.
- Extend extension acceptance tests for:
  - partial header updates
  - case-insensitive header names

## Why
LinkedIn request headers can be emitted with varying header-name casing and may appear partially across requests. This hardening keeps captured bridge metadata stable without broad provider changes.

## Scope
- Extension-only (`chrome-extension/*`)
- No provider-wide request-contract changes
- No broad sync architecture changes

## Validation
- `node chrome-extension/test_background.mjs`
- Result: **30 passed, 0 failed**

Closes #21