### PR TITLE
fix: surface LinkedIn /me auth rejection during sync bootstrap

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -204,10 +204,10 @@ def sync_account(body: SyncIn):
             "rate_limited": result.rate_limited,
         }
     except PermissionError as exc:
-        raise HTTPException(
-            status_code=401,
-            detail="LinkedIn session expired — re-authenticate via POST /accounts/refresh",
-        ) from exc
+        detail = redact_string(str(exc)).strip() if str(exc) else "LinkedIn authentication failed."
+        if "POST /accounts/refresh" not in detail:
+            detail = f"{detail} re-authenticate via POST /accounts/refresh"
+        raise HTTPException(status_code=401, detail=detail) from exc
     except NotImplementedError:
         raise HTTPException(
             status_code=501,
@@ -249,10 +249,10 @@ def send_message(body: SendIn):
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from None
     except PermissionError as exc:
-        raise HTTPException(
-            status_code=401,
-            detail="LinkedIn session expired — re-authenticate via POST /accounts/refresh",
-        ) from exc
+        detail = redact_string(str(exc)).strip() if str(exc) else "LinkedIn authentication failed."
+        if "POST /accounts/refresh" not in detail:
+            detail = f"{detail} re-authenticate via POST /accounts/refresh"
+        raise HTTPException(status_code=401, detail=detail) from exc
     except NotImplementedError:
         raise HTTPException(
             status_code=501,

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -455,26 +455,41 @@ class LinkedInProvider:
         cookies = self._build_basic_cookies()
         try:
             resp = client.get(f"{_VOYAGER_BASE}/me", headers=headers, cookies=cookies)
-            if resp.status_code == 200:
+        except Exception:
+            logger.debug("_get_profile_id: failed to fetch /me", exc_info=True)
+            self._profile_id_fetched = True
+            return self._profile_id
+
+        if resp.status_code in (302, 303, 401, 403):
+            raise PermissionError(
+                f"LinkedIn session rejected on /voyager/api/me (HTTP {resp.status_code})."
+            )
+
+        if resp.status_code == 200:
+            try:
                 data = resp.json()
                 pid = data.get("entityUrn") or data.get("publicIdentifier")
 
                 # Normalized response: identifiers nested under "data"
                 if not pid:
                     inner = data.get("data") or {}
-                    pid = inner.get("plainId") or inner.get("*miniProfile")
+                    if isinstance(inner, dict):
+                        pid = inner.get("plainId") or inner.get("*miniProfile")
 
                 # Fallback: scan "included" array for a fsd_profile dashEntityUrn
                 if not pid:
                     for item in data.get("included") or []:
+                        if not isinstance(item, dict):
+                            continue
                         urn = item.get("dashEntityUrn")
                         if urn and "fsd_profile" in urn:
                             pid = urn
                             break
 
                 self._profile_id = pid
-        except Exception:
-            logger.debug("_get_profile_id: failed to fetch /me", exc_info=True)
+            except Exception:
+                logger.debug("_get_profile_id: failed to parse /me response", exc_info=True)
+
         self._profile_id_fetched = True
         return self._profile_id
 

--- a/tests/test_api_refresh.py
+++ b/tests/test_api_refresh.py
@@ -167,6 +167,23 @@ class TestSessionExpired401:
         assert resp.status_code == 401
         assert "re-authenticate via POST /accounts/refresh" in resp.json()["detail"]
 
+    def test_sync_returns_bootstrap_reason_for_me_redirect(self, client):
+        aid = _create_account(client)
+        with patch(
+            "apps.api.main.run_sync",
+            side_effect=PermissionError(
+                "LinkedIn redirected /voyager/api/me during sync bootstrap. "
+                "Refresh account cookies via POST /accounts/refresh."
+            ),
+        ):
+            resp = client.post(
+                "/sync",
+                json={"account_id": aid},
+            )
+        assert resp.status_code == 401
+        assert "/voyager/api/me" in resp.json()["detail"]
+        assert "POST /accounts/refresh" in resp.json()["detail"]
+
     def test_send_401_then_refresh_then_send_succeeds(self, client):
         """Full flow: send fails with 401, client refreshes cookies, send succeeds."""
         aid = _create_account(client)

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -513,8 +513,8 @@ class TestListThreads:
         url = mock_client.get.call_args[0][0]
         assert "mailboxUrn:urn:li:fsd_profile:ABC123" in url
 
-    def test_raises_if_profile_id_unavailable(self, auth):
-        """Raises RuntimeError if profile ID cannot be determined."""
+    def test_raises_permission_error_when_me_redirects(self, auth):
+        """A /me redirect should surface as an auth/bootstrap failure."""
         p = LinkedInProvider(auth=auth)
         p._browser_cookies = {"li_at": "x"}
         p._profile_id = None
@@ -525,7 +525,7 @@ class TestListThreads:
         me_resp.status_code = 302
         mock_client.get.return_value = me_resp
         with _patch_client(mock_client):
-            with pytest.raises(RuntimeError, match="profile ID"):
+            with pytest.raises(PermissionError, match="/voyager/api/me"):
                 p.list_threads()
 
 
@@ -669,12 +669,12 @@ class TestGetProfileId:
         assert mock_client.get.call_count == 1
 
     def test_profile_id_none_cached_when_api_fails(self, auth):
-        """If /me fails, we cache None and don't retry every call."""
+        """If /me fails with a non-auth status, we cache None and don't retry every call."""
         p = LinkedInProvider(auth=auth)
         mock_client = MagicMock()
         mock_client.is_closed = False
         me_resp = MagicMock()
-        me_resp.status_code = 403
+        me_resp.status_code = 500
         mock_client.get.return_value = me_resp
         with _patch_client(mock_client):
             first = p._get_profile_id()
@@ -682,6 +682,19 @@ class TestGetProfileId:
         assert first is None
         assert second is None
         assert mock_client.get.call_count == 1
+
+    @pytest.mark.parametrize("status_code", [302, 303, 401, 403])
+    def test_profile_id_raises_permission_error_on_auth_rejection(self, auth, status_code):
+        """Auth rejection on /me should surface as PermissionError."""
+        p = LinkedInProvider(auth=auth)
+        mock_client = MagicMock()
+        mock_client.is_closed = False
+        me_resp = MagicMock()
+        me_resp.status_code = status_code
+        mock_client.get.return_value = me_resp
+        with _patch_client(mock_client):
+            with pytest.raises(PermissionError, match="/voyager/api/me"):
+                p._get_profile_id()
 
     def test_profile_id_from_public_identifier(self, auth):
         p = LinkedInProvider(auth=auth)


### PR DESCRIPTION
## Summary
- treat `/voyager/api/me` auth-style failures (`302`, `303`, `401`, `403`) as provider auth rejection instead of silently degrading to a missing profile ID
- keep the merged `_get_profile_id()` parsing behavior for successful `200` `/me` responses from issue #38 / PR #47
- return a stable `401` from `POST /sync` with refresh guidance, so the API no longer masks this bootstrap failure as `422 Could not determine LinkedIn profile ID`

## Why
Live sync bootstrap can currently fail before thread discovery when LinkedIn redirects `/voyager/api/me`, even though the extension flow looks connected. This change makes that failure surface as an auth/bootstrap problem that the client can act on, which matches issue #53 and avoids the misleading profile-id error path.

## Test plan
- `uv run --extra test python -m pytest tests/test_list_threads.py tests/test_api_refresh.py tests/test_sync_send.py`
- locally repro the sync path with `/voyager/api/me` forced to return `302` and verify:
  - `POST /sync` returns `401`
  - response detail mentions `/voyager/api/me`
  - response detail includes `POST /accounts/refresh`
  - response detail does not include `Could not determine LinkedIn profile ID`

Fixes : #53