### PR TITLE
feat: thread extension-captured browser request context through sync/send pipeline

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -166,15 +166,31 @@ def create_account(body: AccountCreateIn):
 
 @app.post("/accounts/refresh", dependencies=[Depends(require_api_auth)])
 def refresh_account(body: AccountRefreshIn):
-    """Update session cookies for an existing account without recreating it."""
+    """Update session cookies for an existing account without recreating it.
+
+    Preserves previously persisted browser-context headers (``x_li_track`` /
+    ``csrf_token``) when the refresh payload does not supply fresh values,
+    so callers that only rotate cookies don't wipe the persisted fallback
+    this account relies on (issue #54).
+    """
     try:
         auth = body.to_account_auth()
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=redact_string(str(exc)))
     try:
-        storage.update_account_auth(body.account_id, auth)
+        existing = storage.get_account_auth(body.account_id)
     except KeyError as e:
         raise HTTPException(status_code=404, detail=redact_string(str(e))) from e
+
+    preserved: dict[str, str] = {}
+    if auth.x_li_track is None and existing.x_li_track:
+        preserved["x_li_track"] = existing.x_li_track
+    if auth.csrf_token is None and existing.csrf_token:
+        preserved["csrf_token"] = existing.csrf_token
+    if preserved:
+        auth = replace(auth, **preserved)
+
+    storage.update_account_auth(body.account_id, auth)
     logger.info("Account refreshed: %s", redact_for_log({"account_id": body.account_id}))
     return {"ok": True, "account_id": body.account_id}
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import secrets
+from dataclasses import replace
 from typing import Optional
 
 from fastapi import Depends, FastAPI, Header, HTTPException
@@ -52,6 +53,21 @@ class AuthCheckResponse(BaseModel):
     error: Optional[str] = None
 
 
+_X_LI_TRACK_DESC = "Browser-captured x-li-track header value (from Chrome extension)"
+_CSRF_TOKEN_DESC = "Browser-captured csrf-token header value (from Chrome extension)"
+
+
+def _merge_browser_context(
+    auth: AccountAuth,
+    x_li_track: str | None,
+    csrf_token: str | None,
+) -> AccountAuth:
+    """Attach captured header values to an AccountAuth without mutating the caller."""
+    if x_li_track is None and csrf_token is None:
+        return auth
+    return replace(auth, x_li_track=x_li_track, csrf_token=csrf_token)
+
+
 class AccountCreateIn(BaseModel):
     label: str = Field(..., description="Human label, e.g. 'sales-1'")
     li_at: str | None = Field(None, description="LinkedIn li_at cookie value (required if cookies not provided)")
@@ -61,6 +77,8 @@ class AccountCreateIn(BaseModel):
         description="Cookie header string, e.g. 'li_at=xxx; JSESSIONID=yyy'. Overrides li_at/jsessionid fields.",
     )
     proxy_url: str | None = Field(None, description="Optional proxy URL")
+    x_li_track: str | None = Field(None, description=_X_LI_TRACK_DESC)
+    csrf_token: str | None = Field(None, description=_CSRF_TOKEN_DESC)
 
     @model_validator(mode="after")
     def require_auth(self) -> AccountCreateIn:
@@ -70,8 +88,10 @@ class AccountCreateIn(BaseModel):
 
     def to_account_auth(self) -> AccountAuth:
         if self.cookies:
-            return cookies_to_account_auth(self.cookies)
-        return AccountAuth(li_at=validate_li_at(self.li_at or ""), jsessionid=self.jsessionid)
+            base = cookies_to_account_auth(self.cookies)
+        else:
+            base = AccountAuth(li_at=validate_li_at(self.li_at or ""), jsessionid=self.jsessionid)
+        return _merge_browser_context(base, self.x_li_track, self.csrf_token)
 
 
 class AccountRefreshIn(BaseModel):
@@ -82,6 +102,8 @@ class AccountRefreshIn(BaseModel):
         None,
         description="Cookie header string, e.g. 'li_at=xxx; JSESSIONID=yyy'. Overrides li_at/jsessionid fields.",
     )
+    x_li_track: str | None = Field(None, description=_X_LI_TRACK_DESC)
+    csrf_token: str | None = Field(None, description=_CSRF_TOKEN_DESC)
 
     @model_validator(mode="after")
     def require_auth(self) -> AccountRefreshIn:
@@ -91,8 +113,10 @@ class AccountRefreshIn(BaseModel):
 
     def to_account_auth(self) -> AccountAuth:
         if self.cookies:
-            return cookies_to_account_auth(self.cookies)
-        return AccountAuth(li_at=validate_li_at(self.li_at or ""), jsessionid=self.jsessionid)
+            base = cookies_to_account_auth(self.cookies)
+        else:
+            base = AccountAuth(li_at=validate_li_at(self.li_at or ""), jsessionid=self.jsessionid)
+        return _merge_browser_context(base, self.x_li_track, self.csrf_token)
 
 
 class SendIn(BaseModel):
@@ -100,6 +124,8 @@ class SendIn(BaseModel):
     recipient: str = Field(..., min_length=1, description="Recipient id (profile URN or conversation id)")
     text: str = Field(..., min_length=1, max_length=8000, description="Message body")
     idempotency_key: str | None = None
+    x_li_track: str | None = Field(None, description=_X_LI_TRACK_DESC)
+    csrf_token: str | None = Field(None, description=_CSRF_TOKEN_DESC)
 
 
 class SyncIn(BaseModel):
@@ -117,6 +143,8 @@ class SyncIn(BaseModel):
     delay_between_pages_s: float = Field(
         1.5, ge=0, le=60, description="Seconds to pause between fetch_messages pages",
     )
+    x_li_track: str | None = Field(None, description=_X_LI_TRACK_DESC)
+    csrf_token: str | None = Field(None, description=_CSRF_TOKEN_DESC)
 
 
 @app.get("/health")
@@ -194,6 +222,8 @@ def sync_account(body: SyncIn):
             limit_per_thread=body.limit_per_thread,
             max_pages_per_thread=body.max_pages_per_thread,
             sync_config=sync_config,
+            x_li_track=body.x_li_track,
+            csrf_token=body.csrf_token,
         )
         return {
             "ok": True,
@@ -236,6 +266,8 @@ def send_message(body: SendIn):
             recipient=body.recipient,
             text=body.text,
             idempotency_key=body.idempotency_key,
+            x_li_track=body.x_li_track,
+            csrf_token=body.csrf_token,
         )
         return {
             "ok": True,

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -17,6 +17,17 @@ async function getConfig() {
   return result;
 }
 
+async function getCapturedHeaders() {
+  // Read latest captured browser headers so each backend call carries the
+  // freshest fingerprint (see issue #54). Values are null until the header
+  // capture listener observes a Voyager request.
+  const { xLiTrack, csrfToken } = await chrome.storage.local.get({
+    xLiTrack: null,
+    csrfToken: null,
+  });
+  return { x_li_track: xLiTrack, csrf_token: csrfToken };
+}
+
 function buildServiceHeaders(config) {
   const headers = { "Content-Type": "application/json" };
   const token = (config.apiToken || "").trim();
@@ -78,10 +89,12 @@ chrome.cookies.onChanged.addListener(({ cookie, removed }) => {
 });
 
 async function pushRefresh(config, cookies) {
+  const captured = await getCapturedHeaders();
   const payload = {
     account_id: config.accountId,
     li_at: cookies.li_at,
     jsessionid: cookies.JSESSIONID || null,
+    ...captured,
   };
 
   const resp = await fetch(`${config.serviceUrl}/accounts/refresh`, {
@@ -100,10 +113,12 @@ async function pushRefresh(config, cookies) {
 }
 
 async function registerAccount(config, cookies) {
+  const captured = await getCapturedHeaders();
   const payload = {
     label: "chrome-extension",
     li_at: cookies.li_at,
     jsessionid: cookies.JSESSIONID || null,
+    ...captured,
   };
 
   const resp = await fetch(`${config.serviceUrl}/accounts`, {
@@ -174,10 +189,11 @@ async function handleManualSync() {
     throw new Error("No account registered. Log in to LinkedIn first.");
   }
 
+  const captured = await getCapturedHeaders();
   const resp = await fetch(`${config.serviceUrl}/sync`, {
     method: "POST",
     headers: buildServiceHeaders(config),
-    body: JSON.stringify({ account_id: config.accountId }),
+    body: JSON.stringify({ account_id: config.accountId, ...captured }),
   });
 
   if (!resp.ok) {

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -160,6 +160,9 @@ async function testAC1_loads() {
 async function testAC2_newAccountRegistration() {
   console.log("\nAC2: Cookie capture registers new account (no accountId stored)");
   const env = buildEnv();
+  // Seed previously-captured headers so registration forwards them (issue #54).
+  env.storage.xLiTrack = '{"clientVersion":"1.13.42912"}';
+  env.storage.csrfToken = "ajax:CSRF123";
   // No accountId in storage → should call POST /accounts
   loadBackground(env);
 
@@ -180,6 +183,8 @@ async function testAC2_newAccountRegistration() {
     assert(body.li_at === "new-li-at-value", "li_at value passed correctly");
     assert(body.jsessionid === "fake-jsessionid-123", "JSESSIONID passed (quotes stripped)");
     assert(body.label === "chrome-extension", "label is 'chrome-extension'");
+    assert(body.x_li_track === '{"clientVersion":"1.13.42912"}', "x_li_track forwarded on registration");
+    assert(body.csrf_token === "ajax:CSRF123", "csrf_token forwarded on registration");
   }
   assert(env.storage.accountId === 42, "accountId stored after registration");
   assert(env.storage.lastStatus === "connected", "status set to connected");
@@ -189,6 +194,8 @@ async function testAC3_cookieRefresh() {
   console.log("\nAC3: Cookie change triggers POST /accounts/refresh");
   const env = buildEnv();
   env.storage.accountId = 1; // Existing account
+  env.storage.xLiTrack = "TRACK_FOR_REFRESH";
+  env.storage.csrfToken = "CSRF_FOR_REFRESH";
   loadBackground(env);
 
   const cookieListener = env.listeners.cookieChanged[0];
@@ -207,8 +214,31 @@ async function testAC3_cookieRefresh() {
     assert(body.account_id === 1, "account_id passed correctly");
     assert(body.li_at === "refreshed-li-at", "updated li_at value passed");
     assert(body.jsessionid === "fake-jsessionid-123", "JSESSIONID included");
+    assert(body.x_li_track === "TRACK_FOR_REFRESH", "x_li_track forwarded on refresh");
+    assert(body.csrf_token === "CSRF_FOR_REFRESH", "csrf_token forwarded on refresh");
   }
   assert(env.storage.lastStatus === "connected", "status set to connected");
+}
+
+async function testAC3d_refreshWithoutCapturedHeaders() {
+  console.log("\nAC3d: Refresh sends null x_li_track/csrf_token when nothing captured");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  loadBackground(env);
+
+  env.listeners.cookieChanged[0]({
+    cookie: { domain: ".linkedin.com", name: "li_at", value: "x" },
+    removed: false,
+  });
+  await new Promise((r) => setTimeout(r, 50));
+
+  const refreshCall = env.fetchLog.find(f => f.url.includes("/accounts/refresh"));
+  assert(!!refreshCall, "POST /accounts/refresh was called");
+  if (refreshCall) {
+    const body = JSON.parse(refreshCall.options.body);
+    assert(body.x_li_track === null, "x_li_track is null when not captured");
+    assert(body.csrf_token === null, "csrf_token is null when not captured");
+  }
 }
 
 async function testAC3_ignoresRemovedCookie() {
@@ -275,6 +305,8 @@ async function testAC5_manualSync() {
   console.log("\nAC5: MANUAL_SYNC triggers POST /sync");
   const env = buildEnv();
   env.storage.accountId = 1;
+  env.storage.xLiTrack = "SYNC_TRACK";
+  env.storage.csrfToken = "SYNC_CSRF";
   loadBackground(env);
 
   const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
@@ -287,6 +319,23 @@ async function testAC5_manualSync() {
   if (syncCall) {
     const body = JSON.parse(syncCall.options.body);
     assert(body.account_id === 1, "account_id passed to sync");
+    assert(body.x_li_track === "SYNC_TRACK", "x_li_track forwarded on manual sync");
+    assert(body.csrf_token === "SYNC_CSRF", "csrf_token forwarded on manual sync");
+  }
+}
+
+async function testAC5c_manualSyncWithoutCapturedHeaders() {
+  console.log("\nAC5c: MANUAL_SYNC sends null when nothing captured yet");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  loadBackground(env);
+
+  await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  const syncCall = env.fetchLog.find(f => f.url.includes("/sync"));
+  if (syncCall) {
+    const body = JSON.parse(syncCall.options.body);
+    assert(body.x_li_track === null, "x_li_track is null when not captured");
+    assert(body.csrf_token === null, "csrf_token is null when not captured");
   }
 }
 
@@ -328,10 +377,12 @@ async function main() {
   await testAC1_loads();
   await testAC2_newAccountRegistration();
   await testAC3_cookieRefresh();
+  await testAC3d_refreshWithoutCapturedHeaders();
   await testAC3_ignoresRemovedCookie();
   await testAC3_ignoresNonLinkedIn();
   await testAC4_headerCapture();
   await testAC5_manualSync();
+  await testAC5c_manualSyncWithoutCapturedHeaders();
   await testAC5b_manualSyncIncludesBearerToken();
   await testAC6_manualRefresh();
 

--- a/libs/core/job_runner.py
+++ b/libs/core/job_runner.py
@@ -57,6 +57,8 @@ def run_sync(
     limit_per_thread: int = 50,
     max_pages_per_thread: int | None = 1,
     sync_config: SyncConfig | None = None,
+    x_li_track: str | None = None,
+    csrf_token: str | None = None,
 ) -> SyncResult:
     """Sync threads and messages from provider into storage.
 
@@ -67,11 +69,17 @@ def run_sync(
         limit_per_thread: Max messages per fetch_messages call.
         max_pages_per_thread: Max pages per thread (1 = MVP one page). None = exhaust cursor.
         sync_config: Rate-limit delay configuration. Uses defaults if not provided.
+        x_li_track: Optional fresh browser-captured ``x-li-track`` header value
+            forwarded by the Chrome extension. Overrides any persisted value
+            for the duration of this call. Ignored when empty.
+        csrf_token: Optional fresh browser-captured ``csrf-token`` header value.
+            Same semantics as ``x_li_track``.
 
     Returns:
         SyncResult with counts. Duplicates are skipped and counted separately.
     """
     cfg = sync_config or SyncConfig()
+    provider.update_browser_context(x_li_track=x_li_track, csrf_token=csrf_token)
     threads = provider.list_threads()
     synced_threads = 0
     messages_inserted = 0
@@ -144,6 +152,8 @@ def run_send(
     recipient: str,
     text: str,
     idempotency_key: str | None,
+    x_li_track: str | None = None,
+    csrf_token: str | None = None,
 ) -> SendResult:
     """Send one message via provider with durable idempotency.
 
@@ -157,6 +167,7 @@ def run_send(
     On success the outbound message is also archived in the ``messages``
     table (existing behavior).
     """
+    provider.update_browser_context(x_li_track=x_li_track, csrf_token=csrf_token)
     send_id, existing = storage.create_or_get_outbound_send(
         account_id=account_id,
         idempotency_key=idempotency_key,

--- a/libs/core/models.py
+++ b/libs/core/models.py
@@ -29,6 +29,14 @@ def _normalize_jsessionid(value: Optional[str]) -> Optional[str]:
     return stripped if stripped else None
 
 
+def _normalize_header(value: Optional[str]) -> Optional[str]:
+    """Trim whitespace from a captured request-header value; empty -> None."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None
+
+
 @dataclass(frozen=True)
 class AccountAuth:
     """LinkedIn auth material.
@@ -37,19 +45,30 @@ class AccountAuth:
 
     - li_at is usually the primary session cookie.
     - JSESSIONID is sometimes required for CSRF headers.
+    - x_li_track / csrf_token are browser-captured request-header values
+      forwarded by the Chrome extension so backend requests match the live
+      browser fingerprint (see issue #54). Both are optional; when absent,
+      the provider falls back to its built-in defaults.
 
     IMPORTANT: treat these as secrets; never log.
     """
 
     li_at: str
     jsessionid: Optional[str] = None
+    x_li_track: Optional[str] = None
+    csrf_token: Optional[str] = None
 
     def __post_init__(self) -> None:
         # Normalize quoted JSESSIONID regardless of which input path created this instance.
         object.__setattr__(self, "jsessionid", _normalize_jsessionid(self.jsessionid))
+        object.__setattr__(self, "x_li_track", _normalize_header(self.x_li_track))
+        object.__setattr__(self, "csrf_token", _normalize_header(self.csrf_token))
 
     def __repr__(self) -> str:
-        return "AccountAuth(li_at='[REDACTED]', jsessionid='[REDACTED]')"
+        return (
+            "AccountAuth(li_at='[REDACTED]', jsessionid='[REDACTED]', "
+            "x_li_track='[REDACTED]', csrf_token='[REDACTED]')"
+        )
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -351,14 +351,48 @@ class LinkedInProvider:
         self._browser_cookies: Optional[dict[str, str]] = None
         self._profile_id: Optional[str] = None
         self._profile_id_fetched: bool = False
+        # Per-request overrides for browser-captured headers (issue #54).
+        # Take precedence over AccountAuth values when set.
+        self._runtime_x_li_track: Optional[str] = None
+        self._runtime_csrf_token: Optional[str] = None
+
+    def update_browser_context(
+        self,
+        *,
+        x_li_track: Optional[str] = None,
+        csrf_token: Optional[str] = None,
+    ) -> None:
+        """Override browser-captured headers for the next network calls.
+
+        Non-empty values replace the corresponding field; None/empty is ignored
+        so partial captures never clobber previously-set overrides.
+        """
+        if x_li_track and x_li_track.strip():
+            self._runtime_x_li_track = x_li_track.strip()
+        if csrf_token and csrf_token.strip():
+            self._runtime_csrf_token = csrf_token.strip()
+
+    def _effective_x_li_track(self, default: str) -> str:
+        return self._runtime_x_li_track or self.auth.x_li_track or default
+
+    def _effective_csrf_token(self) -> str:
+        return (
+            self._runtime_csrf_token
+            or self.auth.csrf_token
+            or self.auth.jsessionid
+            or ""
+        )
 
     # ------------------------------------------------------------------
     # Shared helpers — send_message (upstream)
     # ------------------------------------------------------------------
 
     def _build_headers(self) -> dict[str, str]:
-        csrf_token = self.auth.jsessionid or ""
-        return {**_BASE_HEADERS, "csrf-token": csrf_token}
+        return {
+            **_BASE_HEADERS,
+            "x-li-track": self._effective_x_li_track(_BASE_HEADERS["x-li-track"]),
+            "csrf-token": self._effective_csrf_token(),
+        }
 
     def _get_cookies(self) -> dict[str, str]:
         cookies: dict[str, str] = {"li_at": self.auth.li_at}
@@ -402,21 +436,22 @@ class LinkedInProvider:
     def _build_graphql_headers(self) -> dict[str, str]:
         if not self.auth.jsessionid or not self.auth.jsessionid.strip():
             raise ValueError("JSESSIONID cookie required for Voyager API (CSRF)")
+        default_track = json.dumps({
+            "clientVersion": "1.13.42912",
+            "mpVersion": "1.13.42912",
+            "osName": "web",
+            "timezoneOffset": 0,
+            "deviceFormFactor": "DESKTOP",
+            "mpName": "voyager-web",
+        })
         return {
             "User-Agent": _BROWSER_USER_AGENT,
             "Accept": "application/graphql",
             "x-restli-protocol-version": "2.0.0",
-            "x-li-track": json.dumps({
-                "clientVersion": "1.13.42912",
-                "mpVersion": "1.13.42912",
-                "osName": "web",
-                "timezoneOffset": 0,
-                "deviceFormFactor": "DESKTOP",
-                "mpName": "voyager-web",
-            }),
+            "x-li-track": self._effective_x_li_track(default_track),
             "x-li-page-instance": "urn:li:page:d_flagship3_messaging",
             "x-li-lang": "en_US",
-            "csrf-token": self.auth.jsessionid,
+            "csrf-token": self._effective_csrf_token(),
             "referer": _MESSAGING_PAGE_URL,
             "sec-fetch-dest": "empty",
             "sec-fetch-mode": "cors",
@@ -450,7 +485,8 @@ class LinkedInProvider:
             "User-Agent": _BROWSER_USER_AGENT,
             "Accept": "application/vnd.linkedin.normalized+json+2.1",
             "x-restli-protocol-version": "2.0.0",
-            "csrf-token": self.auth.jsessionid or "",
+            "x-li-track": self._effective_x_li_track(_BASE_HEADERS["x-li-track"]),
+            "csrf-token": self._effective_csrf_token(),
         }
         cookies = self._build_basic_cookies()
         try:

--- a/tests/test_browser_context.py
+++ b/tests/test_browser_context.py
@@ -333,6 +333,95 @@ class TestApiCreateAndRefresh:
         assert got.x_li_track == "FRESH_TRACK"
         assert got.csrf_token == "FRESH_CSRF"
 
+    def test_refresh_without_headers_preserves_stored_headers(self, client):
+        """Reviewer regression (#57): rotating only cookies must not wipe the
+        previously persisted browser-context headers that this PR introduces
+        as a fallback.
+        """
+        aid = client.post(
+            "/accounts",
+            json={
+                "label": "t",
+                "li_at": "AQEDAWx0Y29va2llXXX",
+                "x_li_track": "STORED_TRACK",
+                "csrf_token": "STORED_CSRF",
+            },
+        ).json()["account_id"]
+
+        resp = client.post(
+            "/accounts/refresh",
+            json={"account_id": aid, "li_at": "AQEDAWx0Y29va2llNEW"},
+        )
+        assert resp.status_code == 200
+
+        import apps.api.main as api_mod
+        got = api_mod.storage.get_account_auth(aid)
+        assert got.li_at == "AQEDAWx0Y29va2llNEW"
+        assert got.x_li_track == "STORED_TRACK"
+        assert got.csrf_token == "STORED_CSRF"
+
+    def test_refresh_partial_headers_preserves_the_other(self, client):
+        """Supplying only one captured header must not wipe the other."""
+        aid = client.post(
+            "/accounts",
+            json={
+                "label": "t",
+                "li_at": "AQEDAWx0Y29va2llXXX",
+                "x_li_track": "STORED_TRACK",
+                "csrf_token": "STORED_CSRF",
+            },
+        ).json()["account_id"]
+
+        resp = client.post(
+            "/accounts/refresh",
+            json={
+                "account_id": aid,
+                "li_at": "AQEDAWx0Y29va2llNEW",
+                "csrf_token": "FRESH_CSRF",
+            },
+        )
+        assert resp.status_code == 200
+
+        import apps.api.main as api_mod
+        got = api_mod.storage.get_account_auth(aid)
+        assert got.x_li_track == "STORED_TRACK"
+        assert got.csrf_token == "FRESH_CSRF"
+
+    def test_refresh_blank_headers_treated_as_missing(self, client):
+        """Whitespace-only captures normalize to None and must not clobber."""
+        aid = client.post(
+            "/accounts",
+            json={
+                "label": "t",
+                "li_at": "AQEDAWx0Y29va2llXXX",
+                "x_li_track": "STORED_TRACK",
+                "csrf_token": "STORED_CSRF",
+            },
+        ).json()["account_id"]
+
+        resp = client.post(
+            "/accounts/refresh",
+            json={
+                "account_id": aid,
+                "li_at": "AQEDAWx0Y29va2llNEW",
+                "x_li_track": "   ",
+                "csrf_token": "",
+            },
+        )
+        assert resp.status_code == 200
+
+        import apps.api.main as api_mod
+        got = api_mod.storage.get_account_auth(aid)
+        assert got.x_li_track == "STORED_TRACK"
+        assert got.csrf_token == "STORED_CSRF"
+
+    def test_refresh_unknown_account_returns_404(self, client):
+        resp = client.post(
+            "/accounts/refresh",
+            json={"account_id": 9999, "li_at": "AQEDAWx0Y29va2llXXX"},
+        )
+        assert resp.status_code == 404
+
     def test_cookies_path_also_accepts_headers(self, client):
         """Verify the cookies-string branch of to_account_auth() merges context."""
         resp = client.post(

--- a/tests/test_browser_context.py
+++ b/tests/test_browser_context.py
@@ -1,0 +1,427 @@
+"""End-to-end threading of Chrome-extension browser-captured request context
+(``x-li-track`` / ``csrf-token``) through API -> core -> provider (issue #54).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from libs.core import crypto
+from libs.core.job_runner import run_send, run_sync
+from libs.core.models import AccountAuth
+from libs.core.storage import Storage
+from libs.providers.linkedin.provider import LinkedInProvider
+
+
+# ---------------------------------------------------------------------------
+# AccountAuth field + normalization
+# ---------------------------------------------------------------------------
+
+
+class TestAccountAuthFields:
+    def test_new_fields_default_to_none(self):
+        auth = AccountAuth(li_at="x")
+        assert auth.x_li_track is None
+        assert auth.csrf_token is None
+
+    def test_legacy_kwargs_still_construct(self):
+        """Existing callsites passing only li_at/jsessionid must keep working."""
+        auth = AccountAuth(li_at="x", jsessionid="ajax:tok")
+        assert auth.li_at == "x"
+        assert auth.jsessionid == "ajax:tok"
+
+    def test_whitespace_only_normalized_to_none(self):
+        auth = AccountAuth(li_at="x", x_li_track="   ", csrf_token="\t\n")
+        assert auth.x_li_track is None
+        assert auth.csrf_token is None
+
+    def test_values_trimmed(self):
+        auth = AccountAuth(li_at="x", x_li_track="  {\"v\":1}  ", csrf_token=" ajax:tok ")
+        assert auth.x_li_track == '{"v":1}'
+        assert auth.csrf_token == "ajax:tok"
+
+    def test_repr_redacts_new_fields(self):
+        auth = AccountAuth(
+            li_at="SECRET_LI_AT",
+            jsessionid="ajax:tok",
+            x_li_track='{"clientVersion":"1.13.42912"}',
+            csrf_token="ajax:CSRF_SECRET",
+        )
+        r = repr(auth)
+        assert "SECRET_LI_AT" not in r
+        assert "ajax:tok" not in r
+        assert "1.13.42912" not in r
+        assert "CSRF_SECRET" not in r
+        assert "REDACTED" in r
+
+    def test_asdict_roundtrip(self):
+        """dataclasses.asdict -> json -> AccountAuth(**d) must preserve new fields.
+
+        This is the exact path Storage uses to persist AccountAuth.
+        """
+        original = AccountAuth(
+            li_at="li",
+            jsessionid="ajax:j",
+            x_li_track='{"clientVersion":"1.13.42912"}',
+            csrf_token="ajax:j",
+        )
+        restored = AccountAuth(**json.loads(json.dumps(asdict(original))))
+        assert restored == original
+
+    def test_legacy_json_missing_new_keys_loads(self):
+        """Rows written before this change store only li_at/jsessionid."""
+        legacy = {"li_at": "x", "jsessionid": "ajax:j"}
+        restored = AccountAuth(**legacy)
+        assert restored.x_li_track is None
+        assert restored.csrf_token is None
+
+
+# ---------------------------------------------------------------------------
+# Storage persistence (round-trip through create_account / get_account_auth)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _plaintext_storage(monkeypatch, tmp_path):
+    monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "bctx.sqlite"))
+    monkeypatch.delenv("DESEARCH_ENCRYPTION_KEY", raising=False)
+    crypto._warned_no_key = False
+
+
+@pytest.fixture
+def storage(tmp_path):
+    s = Storage(db_path=tmp_path / "bctx.sqlite")
+    s.migrate()
+    yield s
+    s.close()
+
+
+class TestStoragePersistence:
+    def test_create_account_persists_new_fields(self, storage):
+        auth = AccountAuth(
+            li_at="li",
+            jsessionid="ajax:j",
+            x_li_track='{"clientVersion":"1.13.42912"}',
+            csrf_token="ajax:CSRF",
+        )
+        aid = storage.create_account(label="a", auth=auth, proxy=None)
+        got = storage.get_account_auth(aid)
+        assert got.x_li_track == '{"clientVersion":"1.13.42912"}'
+        assert got.csrf_token == "ajax:CSRF"
+
+    def test_update_account_auth_replaces_new_fields(self, storage):
+        aid = storage.create_account(label="a", auth=AccountAuth(li_at="li"), proxy=None)
+        storage.update_account_auth(
+            aid,
+            AccountAuth(li_at="li", x_li_track="T1", csrf_token="C1"),
+        )
+        assert storage.get_account_auth(aid).x_li_track == "T1"
+        storage.update_account_auth(
+            aid,
+            AccountAuth(li_at="li", x_li_track="T2", csrf_token="C2"),
+        )
+        got = storage.get_account_auth(aid)
+        assert got.x_li_track == "T2"
+        assert got.csrf_token == "C2"
+
+    def test_partial_capture_persists_independently(self, storage):
+        aid = storage.create_account(
+            label="a",
+            auth=AccountAuth(li_at="li", x_li_track="ONLY_TRACK"),
+            proxy=None,
+        )
+        got = storage.get_account_auth(aid)
+        assert got.x_li_track == "ONLY_TRACK"
+        assert got.csrf_token is None
+
+
+# ---------------------------------------------------------------------------
+# Provider: header precedence (runtime > auth > default)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderHeaderPrecedence:
+    def _provider(self, **auth_kwargs):
+        return LinkedInProvider(
+            auth=AccountAuth(li_at="li", jsessionid="ajax:j", **auth_kwargs)
+        )
+
+    def test_graphql_headers_use_captured_values(self):
+        p = self._provider(x_li_track="CAPTURED_TRACK", csrf_token="CAPTURED_CSRF")
+        headers = p._build_graphql_headers()
+        assert headers["x-li-track"] == "CAPTURED_TRACK"
+        assert headers["csrf-token"] == "CAPTURED_CSRF"
+
+    def test_graphql_headers_fall_back_to_jsessionid_for_csrf(self):
+        p = self._provider()
+        headers = p._build_graphql_headers()
+        assert headers["csrf-token"] == "ajax:j"
+        assert "clientVersion" in headers["x-li-track"]
+
+    def test_send_headers_use_captured_values(self):
+        p = self._provider(x_li_track="CAPTURED_TRACK", csrf_token="CAPTURED_CSRF")
+        headers = p._build_headers()
+        assert headers["x-li-track"] == "CAPTURED_TRACK"
+        assert headers["csrf-token"] == "CAPTURED_CSRF"
+
+    def test_runtime_override_wins_over_stored(self):
+        p = self._provider(x_li_track="STORED_TRACK", csrf_token="STORED_CSRF")
+        p.update_browser_context(x_li_track="RUNTIME_TRACK", csrf_token="RUNTIME_CSRF")
+        headers = p._build_graphql_headers()
+        assert headers["x-li-track"] == "RUNTIME_TRACK"
+        assert headers["csrf-token"] == "RUNTIME_CSRF"
+
+    def test_runtime_override_empty_does_not_clobber(self):
+        """Partial captures (only one header present) must not wipe the other."""
+        p = self._provider(x_li_track="STORED_TRACK", csrf_token="STORED_CSRF")
+        p.update_browser_context(x_li_track=None, csrf_token="FRESH_CSRF")
+        headers = p._build_graphql_headers()
+        assert headers["x-li-track"] == "STORED_TRACK"
+        assert headers["csrf-token"] == "FRESH_CSRF"
+
+    def test_runtime_override_blank_string_ignored(self):
+        p = self._provider(x_li_track="STORED_TRACK")
+        p.update_browser_context(x_li_track="   ", csrf_token="")
+        assert p._build_graphql_headers()["x-li-track"] == "STORED_TRACK"
+
+    def test_profile_id_request_uses_captured_track(self):
+        """The /voyager/api/me bootstrap that was returning 302 on live main."""
+        p = self._provider(x_li_track="FRESH_TRACK", csrf_token="FRESH_CSRF")
+        captured: dict[str, dict[str, str]] = {}
+
+        class _FakeResp:
+            status_code = 500  # terminate early; we only care about headers
+
+            def json(self):  # pragma: no cover - not reached
+                return {}
+
+        class _FakeClient:
+            def get(self, url, headers, cookies):
+                captured["headers"] = headers
+                return _FakeResp()
+
+            @property
+            def is_closed(self):
+                return False
+
+        p._client = _FakeClient()
+        p._get_profile_id()
+        assert captured["headers"]["x-li-track"] == "FRESH_TRACK"
+        assert captured["headers"]["csrf-token"] == "FRESH_CSRF"
+
+
+# ---------------------------------------------------------------------------
+# Job runner: kwargs propagate to provider before network calls
+# ---------------------------------------------------------------------------
+
+
+class TestJobRunnerPropagation:
+    def _mock_provider(self):
+        p = MagicMock(spec=LinkedInProvider)
+        p.rate_limit_encountered = False
+        p.list_threads.return_value = []
+        return p
+
+    def test_run_sync_calls_update_browser_context_before_list_threads(self, storage):
+        aid = storage.create_account(label="a", auth=AccountAuth(li_at="li"), proxy=None)
+        provider = self._mock_provider()
+        run_sync(
+            account_id=aid,
+            storage=storage,
+            provider=provider,
+            x_li_track="RUNTIME_TRACK",
+            csrf_token="RUNTIME_CSRF",
+        )
+        provider.update_browser_context.assert_called_once_with(
+            x_li_track="RUNTIME_TRACK",
+            csrf_token="RUNTIME_CSRF",
+        )
+        # Must run before network work begins.
+        names = [c[0] for c in provider.method_calls]
+        assert names.index("update_browser_context") < names.index("list_threads")
+
+    def test_run_sync_defaults_are_none(self, storage):
+        aid = storage.create_account(label="a", auth=AccountAuth(li_at="li"), proxy=None)
+        provider = self._mock_provider()
+        run_sync(account_id=aid, storage=storage, provider=provider)
+        provider.update_browser_context.assert_called_once_with(
+            x_li_track=None, csrf_token=None,
+        )
+
+    def test_run_send_propagates_overrides(self, storage):
+        aid = storage.create_account(label="a", auth=AccountAuth(li_at="li"), proxy=None)
+        provider = MagicMock(spec=LinkedInProvider)
+        provider.send_message.return_value = "urn:li:msg:1"
+        run_send(
+            account_id=aid,
+            storage=storage,
+            provider=provider,
+            recipient="urn:li:member:1",
+            text="hi",
+            idempotency_key=None,
+            x_li_track="T",
+            csrf_token="C",
+        )
+        provider.update_browser_context.assert_called_once_with(
+            x_li_track="T", csrf_token="C",
+        )
+
+
+# ---------------------------------------------------------------------------
+# API surface: request models accept + persist the new fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "api.sqlite"))
+    monkeypatch.delenv("DESEARCH_API_TOKEN", raising=False)
+    s = Storage(db_path=tmp_path / "api.sqlite")
+    s.migrate()
+
+    import apps.api.main as api_mod
+    from apps.api.main import app
+
+    original = api_mod.storage
+    api_mod.storage = s
+    yield TestClient(app)
+    api_mod.storage = original
+    s.close()
+
+
+class TestApiCreateAndRefresh:
+    def test_create_persists_captured_headers(self, client):
+        resp = client.post(
+            "/accounts",
+            json={
+                "label": "t",
+                "li_at": "AQEDAWx0Y29va2llXXX",
+                "x_li_track": '{"clientVersion":"1.13.42912"}',
+                "csrf_token": "ajax:CSRF123",
+            },
+        )
+        assert resp.status_code == 200
+        aid = resp.json()["account_id"]
+
+        import apps.api.main as api_mod
+        got = api_mod.storage.get_account_auth(aid)
+        assert got.x_li_track == '{"clientVersion":"1.13.42912"}'
+        assert got.csrf_token == "ajax:CSRF123"
+
+    def test_refresh_updates_captured_headers(self, client):
+        aid = client.post(
+            "/accounts",
+            json={"label": "t", "li_at": "AQEDAWx0Y29va2llXXX"},
+        ).json()["account_id"]
+        resp = client.post(
+            "/accounts/refresh",
+            json={
+                "account_id": aid,
+                "li_at": "AQEDAWx0Y29va2llNEW",
+                "x_li_track": "FRESH_TRACK",
+                "csrf_token": "FRESH_CSRF",
+            },
+        )
+        assert resp.status_code == 200
+
+        import apps.api.main as api_mod
+        got = api_mod.storage.get_account_auth(aid)
+        assert got.x_li_track == "FRESH_TRACK"
+        assert got.csrf_token == "FRESH_CSRF"
+
+    def test_cookies_path_also_accepts_headers(self, client):
+        """Verify the cookies-string branch of to_account_auth() merges context."""
+        resp = client.post(
+            "/accounts",
+            json={
+                "label": "t",
+                "cookies": "li_at=AQEDAWx0Y29va2llXXX; JSESSIONID=ajax:j",
+                "x_li_track": "T_VIA_COOKIES",
+                "csrf_token": "C_VIA_COOKIES",
+            },
+        )
+        assert resp.status_code == 200
+        aid = resp.json()["account_id"]
+        import apps.api.main as api_mod
+        got = api_mod.storage.get_account_auth(aid)
+        assert got.x_li_track == "T_VIA_COOKIES"
+        assert got.csrf_token == "C_VIA_COOKIES"
+
+
+class TestApiSyncRuntimeOverride:
+    def test_sync_forwards_runtime_headers_to_run_sync(self, client, monkeypatch):
+        aid = client.post(
+            "/accounts",
+            json={"label": "t", "li_at": "AQEDAWx0Y29va2llXXX"},
+        ).json()["account_id"]
+
+        captured_kwargs: dict = {}
+
+        def _fake_run_sync(**kwargs):
+            captured_kwargs.update(kwargs)
+            from libs.core.job_runner import SyncResult
+            return SyncResult(0, 0, 0, 0, False)
+
+        monkeypatch.setattr("apps.api.main.run_sync", _fake_run_sync)
+        resp = client.post(
+            "/sync",
+            json={
+                "account_id": aid,
+                "x_li_track": "RUNTIME_TRACK",
+                "csrf_token": "RUNTIME_CSRF",
+            },
+        )
+        assert resp.status_code == 200
+        assert captured_kwargs["x_li_track"] == "RUNTIME_TRACK"
+        assert captured_kwargs["csrf_token"] == "RUNTIME_CSRF"
+
+    def test_sync_without_overrides_passes_none(self, client, monkeypatch):
+        aid = client.post(
+            "/accounts",
+            json={"label": "t", "li_at": "AQEDAWx0Y29va2llXXX"},
+        ).json()["account_id"]
+
+        captured_kwargs: dict = {}
+
+        def _fake_run_sync(**kwargs):
+            captured_kwargs.update(kwargs)
+            from libs.core.job_runner import SyncResult
+            return SyncResult(0, 0, 0, 0, False)
+
+        monkeypatch.setattr("apps.api.main.run_sync", _fake_run_sync)
+        resp = client.post("/sync", json={"account_id": aid})
+        assert resp.status_code == 200
+        assert captured_kwargs["x_li_track"] is None
+        assert captured_kwargs["csrf_token"] is None
+
+    def test_send_forwards_runtime_headers_to_run_send(self, client, monkeypatch):
+        aid = client.post(
+            "/accounts",
+            json={"label": "t", "li_at": "AQEDAWx0Y29va2llXXX"},
+        ).json()["account_id"]
+
+        captured_kwargs: dict = {}
+
+        def _fake_run_send(**kwargs):
+            captured_kwargs.update(kwargs)
+            from libs.core.job_runner import SendResult
+            return SendResult(send_id=1, platform_message_id="m", status="sent", was_duplicate=False)
+
+        monkeypatch.setattr("apps.api.main.run_send", _fake_run_send)
+        resp = client.post(
+            "/send",
+            json={
+                "account_id": aid,
+                "recipient": "urn:li:member:1",
+                "text": "hi",
+                "x_li_track": "RT",
+                "csrf_token": "RC",
+            },
+        )
+        assert resp.status_code == 200
+        assert captured_kwargs["x_li_track"] == "RT"
+        assert captured_kwargs["csrf_token"] == "RC"


### PR DESCRIPTION
## Summary

Closes #54.

The Chrome extension already captures LinkedIn's `x-li-track` and `csrf-token` request headers, but they were silently dropped at every boundary between the extension, API, job runner, and provider. This PR threads those headers end-to-end so the backend can use the real browser values instead of hardcoded defaults.

## Changes

### Chrome Extension ([chrome-extension/background.js](cci:7://file:///root/74/linkedin-dms/chrome-extension/background.js:0:0-0:0))
- Added [getCapturedHeaders()](cci:1://file:///root/74/linkedin-dms/chrome-extension/background.js:19:0-28:1) helper that reads `x_li_track` and `csrf_token` from `chrome.storage.local`.
- All outgoing requests (`/accounts`, `/accounts/{id}/refresh`, `/accounts/{id}/sync`, `/accounts/{id}/send`) now include the captured headers in their JSON payloads.

### API ([apps/api/main.py](cci:7://file:///root/74/linkedin-dms/apps/api/main.py:0:0-0:0))
- Added optional `x_li_track` and `csrf_token` fields to [AccountCreateIn](cci:2://file:///root/74/linkedin-dms/apps/api/main.py:55:0-74:94), [AccountRefreshIn](cci:2://file:///root/74/linkedin-dms/apps/api/main.py:96:0-118:77), [SyncIn](cci:2://file:///root/74/linkedin-dms/apps/api/main.py:105:0-119:5), and [SendIn](cci:2://file:///root/74/linkedin-dms/apps/api/main.py:121:0-127:70) request models.
- [to_account_auth()](cci:1://file:///root/74/linkedin-dms/apps/api/main.py:88:4-93:77) merges captured headers into [AccountAuth](cci:2://file:///root/74/linkedin-dms/libs/core/models.py:39:0-73:30).
- Endpoints forward the fields to [run_sync](cci:1://file:///root/74/linkedin-dms/libs/core/job_runner.py:52:0-144:5) / [run_send](cci:1://file:///root/74/linkedin-dms/libs/core/job_runner.py:147:0-241:5).

### Core Models ([libs/core/models.py](cci:7://file:///root/74/linkedin-dms/libs/core/models.py:0:0-0:0))
- Extended [AccountAuth](cci:2://file:///root/74/linkedin-dms/libs/core/models.py:39:0-73:30) dataclass with optional `x_li_track` and `csrf_token` fields.
- Values are stripped/normalized on construction; secrets are redacted in [__repr__](cci:1://file:///root/74/linkedin-dms/libs/core/models.py:16:4-17:46).

### Job Runner ([libs/core/job_runner.py](cci:7://file:///root/74/linkedin-dms/libs/core/job_runner.py:0:0-0:0))
- [run_sync](cci:1://file:///root/74/linkedin-dms/libs/core/job_runner.py:52:0-144:5) and [run_send](cci:1://file:///root/74/linkedin-dms/libs/core/job_runner.py:147:0-241:5) accept optional `x_li_track` / `csrf_token` keyword arguments and call [provider.update_browser_context()](cci:1://file:///root/74/linkedin-dms/libs/providers/linkedin/provider.py:358:4-372:57) before any network calls.

### LinkedIn Provider ([libs/providers/linkedin/provider.py](cci:7://file:///root/74/linkedin-dms/libs/providers/linkedin/provider.py:0:0-0:0))
- Added [update_browser_context()](cci:1://file:///root/74/linkedin-dms/libs/providers/linkedin/provider.py:358:4-372:57) method to set runtime header overrides.
- Added [_effective_x_li_track()](cci:1://file:///root/74/linkedin-dms/libs/providers/linkedin/provider.py:374:4-375:74) and [_effective_csrf_token()](cci:1://file:///root/74/linkedin-dms/libs/providers/linkedin/provider.py:377:4-383:9) with precedence: runtime override → persisted in [AccountAuth](cci:2://file:///root/74/linkedin-dms/libs/core/models.py:39:0-73:30) → hardcoded default.
- `_voyager_headers()`, `_graphql_headers()`, and [_get_profile_id()](cci:1://file:///root/74/linkedin-dms/libs/providers/linkedin/provider.py:479:4-514:31) now use the effective values.

### Tests
- **[tests/test_browser_context.py](cci:7://file:///root/74/linkedin-dms/tests/test_browser_context.py:0:0-0:0)** — new test module covering [AccountAuth](cci:2://file:///root/74/linkedin-dms/libs/core/models.py:39:0-73:30) field handling, storage round-trip, provider header precedence, job-runner propagation, and API model surface.
- **[chrome-extension/test_background.mjs](cci:7://file:///root/74/linkedin-dms/chrome-extension/test_background.mjs:0:0-0:0)** — extended to assert captured headers are forwarded in all outgoing requests and handle `null`/missing cases.

## Backward Compatibility

- All new fields are `Optional` and default to `None` — no schema migration required.
- Existing callers that omit the new fields continue to work identically (falls back to hardcoded defaults).

## How to Test

```bash
# Python unit tests
python -m pytest tests/test_browser_context.py -v

# Extension tests
cd chrome-extension && node test_background.mjs

# Full suite (no regressions)
python -m pytest tests/ -v