### PR TITLE
Fix LinkedIn /me bootstrap and session-safe sync behavior

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -204,9 +204,12 @@ def sync_account(body: SyncIn):
             "rate_limited": result.rate_limited,
         }
     except PermissionError as exc:
+        detail = redact_string(str(exc))
+        if "POST /accounts/refresh" not in detail:
+            detail = "LinkedIn session expired — re-authenticate via POST /accounts/refresh"
         raise HTTPException(
             status_code=401,
-            detail="LinkedIn session expired — re-authenticate via POST /accounts/refresh",
+            detail=detail,
         ) from exc
     except NotImplementedError:
         raise HTTPException(

--- a/docs/features.md
+++ b/docs/features.md
@@ -38,6 +38,8 @@ Status legend:
   - Calls provider thread listing and message fetch.
   - Persists threads, messages, and cursors.
   - Returns counts for synced threads, inserted messages, duplicate skips, fetched pages, and whether rate limiting was encountered.
+  - Returns `401` with the existing refresh hint when LinkedIn rejects `/voyager/api/me` bootstrap as an auth/session failure.
+  - Returns `422` with a bootstrap-specific refresh hint when `/voyager/api/me` returns blocked HTML or another unusable non-auth payload.
 
 - ✅ `POST /send`
   - Sends a message through the provider.
@@ -149,7 +151,8 @@ Status legend:
 
 - ⚠️ Profile discovery dependency
   - GraphQL thread listing depends on a successful `/voyager/api/me` request to derive the mailbox URN.
-  - If that request fails, sync cannot proceed.
+  - Redirected or rejected `/voyager/api/me` bootstrap responses now fail explicitly with refresh guidance instead of silently caching a null profile id.
+  - Blocked HTML or other unusable `/voyager/api/me` payloads now fail explicitly and leave stored auth untouched.
 
 ## Reliability and rate limiting
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -34,7 +34,20 @@ Impact:
 - `status: ok` does not prove the cookies are accepted by LinkedIn
 - expired, challenged, or region-blocked sessions may still pass `/auth/check`
 
-## 4. Cloudflare and bot defenses remain a moving target
+## 4. `/voyager/api/me` bootstrap is safer, but still a hard dependency
+
+Sync still needs `/voyager/api/me` to resolve the mailbox/profile URN before thread listing can start.
+
+Current behavior:
+- redirected or auth-rejected `/voyager/api/me` responses now surface as explicit session/bootstrap failures with `POST /accounts/refresh` guidance
+- blocked HTML or malformed `/voyager/api/me` payloads now surface as explicit bootstrap errors instead of a cached null profile id
+- stored cookies are left in place; the backend does not auto-clear auth on bootstrap failure
+
+Impact:
+- sync failure messages are clearer and safer than before
+- a locally "connected" account can still fail live sync until the operator refreshes the session or LinkedIn stops challenging the bootstrap request
+
+## 5. Cloudflare and bot defenses remain a moving target
 
 The provider contains fallback logic to harvest browser cookies with Playwright when GraphQL requests appear blocked. That helps, but it is not a guaranteed fix.
 
@@ -47,7 +60,7 @@ Why it is fragile:
 Impact:
 - sync reliability can vary substantially across environments
 
-## 5. Sync is synchronous and request-bound
+## 6. Sync is synchronous and request-bound
 
 The FastAPI `POST /sync` endpoint performs the full sync inline inside the request lifecycle.
 
@@ -56,7 +69,7 @@ Impact:
 - retries and backoff can make the request last a long time
 - there is no built-in queue, scheduler, worker pool, or cancellation path
 
-## 6. SQLite is simple but not a multi-worker architecture
+## 7. SQLite is simple but not a multi-worker architecture
 
 The current storage layer is intentionally lightweight and uses one SQLite file with a process-wide connection.
 
@@ -65,7 +78,7 @@ Impact:
 - it is not designed for horizontally scaled workers or high write concurrency
 - long-running or overlapping sync operations may still contend on the same file
 
-## 7. Plaintext storage is allowed when encryption is not configured
+## 8. Plaintext storage is allowed when encryption is not configured
 
 If `DESEARCH_ENCRYPTION_KEY` is missing, auth and proxy JSON are stored in plaintext. The code logs a warning once, but it does not block startup.
 
@@ -76,7 +89,7 @@ Impact:
 Operational advice:
 - set `DESEARCH_ENCRYPTION_KEY` anywhere secrets at rest matter
 
-## 8. Send idempotency is durable, but only by key
+## 9. Send idempotency is durable, but only by key
 
 `run_send()` uses the `outbound_sends` table to enforce idempotency when an `idempotency_key` is provided.
 
@@ -87,7 +100,7 @@ Impact:
 
 This is intended behavior, but it means callers must supply keys consistently if they want duplicate protection across retries.
 
-## 9. Outbound message threading is simplified
+## 10. Outbound message threading is simplified
 
 After a successful send, `run_send()` archives the sent message by upserting a thread whose `platform_thread_id` is the provided `recipient` value.
 
@@ -95,7 +108,7 @@ Impact:
 - if `recipient` is a profile URN instead of a real conversation URN, local thread history for sent messages may not align perfectly with sync-discovered conversation identifiers
 - this is acceptable for the current MVP, but it is not a full conversation reconciliation model
 
-## 10. Message pagination cursor is heuristic
+## 11. Message pagination cursor is heuristic
 
 `fetch_messages()` computes `next_cursor` from the oldest fetched message timestamp when the returned element count reaches the requested limit.
 
@@ -103,7 +116,7 @@ Impact:
 - pagination depends on LinkedIn continuing to interpret `createdBefore` in the expected way
 - if response ordering or cursor semantics change, paging could skip or repeat messages
 
-## 11. API error sanitization is good, but not universal by design
+## 12. API error sanitization is good, but not universal by design
 
 Many API paths redact exception detail strings before returning them, and logging has a global redaction filter. That said, callers should still avoid building exception messages that embed secrets.
 
@@ -111,7 +124,7 @@ Impact:
 - the code is defensive, not magical
 - future changes can still introduce leak risks if contributors bypass redaction helpers
 
-## 12. `POST /send` returns raw conflict text for some failures
+## 13. `POST /send` returns raw conflict text for some failures
 
 In `apps/api/main.py`, some `ValueError` and `RuntimeError` exceptions from send flow are returned directly as 409 details.
 
@@ -119,7 +132,7 @@ Impact:
 - current messages appear safe because send flow errors do not include cookie material
 - future changes should keep that invariant in mind
 
-## 13. Provider read and write paths do not share identical auth behavior
+## 14. Provider read and write paths do not share identical auth behavior
 
 GraphQL read operations require profile discovery and GraphQL-specific headers, while send uses the messaging conversations endpoint and a different request path.
 
@@ -127,7 +140,7 @@ Impact:
 - an account may succeed on one path and fail on the other depending on session state, cookies, or upstream behavior
 - debugging should treat sync failures and send failures as related but not identical problems
 
-## 14. Playwright cookie harvesting assumes Chromium availability
+## 15. Playwright cookie harvesting assumes Chromium availability
 
 The fallback browser path launches Chromium through Playwright.
 
@@ -135,7 +148,7 @@ Impact:
 - environments without the browser installed cannot use this fallback
 - headless browser restrictions, sandbox differences, or proxy incompatibilities may break the flow
 
-## 15. The repo still contains an older high-level overview
+## 16. The repo still contains an older high-level overview
 
 `docs/PROJECT_OVERVIEW.md` is still present alongside the updated docs.
 
@@ -143,7 +156,7 @@ Impact:
 - contributors should prefer `README.md`, `docs/features.md`, and `docs/architecture.md` for the current implementation picture
 - the overview file may describe the project at a higher and older level than the code now reflects
 
-## 16. CLI help text can be read as more permissive than the effective default
+## 17. CLI help text can be read as more permissive than the effective default
 
 In `apps/cli/__main__.py`, `--max-pages-per-thread` is declared with `default=None`, but the parser later resolves the effective default to `1` page unless `--exhaust-pagination` is set.
 
@@ -152,7 +165,7 @@ Impact:
 - contributors reading only the argparse declaration can misread the default behavior
 - docs should call out the effective one-page default explicitly, which this docs pass now does
 
-## 17. API auth is optional, not mandatory
+## 18. API auth is optional, not mandatory
 
 The local API can now require a bearer token through `DESEARCH_API_TOKEN`, but the protection is opt-in.
 

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -49,6 +49,7 @@ _BACKOFF_MAX_S = 900.0  # 15 min
 # ---------------------------------------------------------------------------
 
 _VOYAGER_BASE = "https://www.linkedin.com/voyager/api"
+_ME_URL = f"{_VOYAGER_BASE}/me"
 _GRAPHQL_BASE = f"{_VOYAGER_BASE}/voyagerMessagingGraphQL/graphql"
 _VOYAGER_TIMEOUT_S = 30.0
 _MAX_PAGES = 50
@@ -351,6 +352,7 @@ class LinkedInProvider:
         self._browser_cookies: Optional[dict[str, str]] = None
         self._profile_id: Optional[str] = None
         self._profile_id_fetched: bool = False
+        self._profile_id_error: Optional[Exception] = None
 
     # ------------------------------------------------------------------
     # Shared helpers — send_message (upstream)
@@ -442,8 +444,19 @@ class LinkedInProvider:
         )
         return self._browser_cookies
 
+    def _cache_profile_id_error(self, exc: Exception) -> None:
+        self._profile_id = None
+        self._profile_id_error = exc
+        self._profile_id_fetched = True
+
+    def _raise_profile_id_error(self, exc: Exception) -> None:
+        self._cache_profile_id_error(exc)
+        raise exc
+
     def _get_profile_id(self) -> Optional[str]:
         if self._profile_id_fetched:
+            if self._profile_id_error is not None:
+                raise self._profile_id_error
             return self._profile_id
         client = self._get_client()
         headers = {
@@ -454,27 +467,83 @@ class LinkedInProvider:
         }
         cookies = self._build_basic_cookies()
         try:
-            resp = client.get(f"{_VOYAGER_BASE}/me", headers=headers, cookies=cookies)
-            if resp.status_code == 200:
-                data = resp.json()
-                pid = data.get("entityUrn") or data.get("publicIdentifier")
-
-                # Normalized response: identifiers nested under "data"
-                if not pid:
-                    inner = data.get("data") or {}
-                    pid = inner.get("plainId") or inner.get("*miniProfile")
-
-                # Fallback: scan "included" array for a fsd_profile dashEntityUrn
-                if not pid:
-                    for item in data.get("included") or []:
-                        urn = item.get("dashEntityUrn")
-                        if urn and "fsd_profile" in urn:
-                            pid = urn
-                            break
-
-                self._profile_id = pid
-        except Exception:
+            resp = client.get(_ME_URL, headers=headers, cookies=cookies)
+        except Exception as exc:
             logger.debug("_get_profile_id: failed to fetch /me", exc_info=True)
+            self._raise_profile_id_error(RuntimeError(
+                "LinkedIn /voyager/api/me bootstrap failed before mailbox discovery. "
+                "Retry sync, and if it keeps failing refresh via POST /accounts/refresh."
+            ))
+
+        if resp.status_code == 401:
+            self._raise_profile_id_error(PermissionError(
+                "LinkedIn /voyager/api/me bootstrap rejected the session (HTTP 401). "
+                "Re-authenticate via POST /accounts/refresh."
+            ))
+
+        if resp.status_code in (302, 303):
+            self._raise_profile_id_error(PermissionError(
+                "LinkedIn /voyager/api/me bootstrap was redirected before mailbox discovery. "
+                "Re-authenticate via POST /accounts/refresh."
+            ))
+
+        if resp.status_code == 403:
+            self._raise_profile_id_error(PermissionError(
+                "LinkedIn /voyager/api/me bootstrap rejected the session (HTTP 403). "
+                "Re-authenticate via POST /accounts/refresh."
+            ))
+
+        if resp.status_code != 200:
+            self._raise_profile_id_error(RuntimeError(
+                f"LinkedIn /voyager/api/me bootstrap failed with HTTP {resp.status_code}. "
+                "Refresh via POST /accounts/refresh and retry sync."
+            ))
+
+        content_type = resp.headers.get("content-type", "")
+        if "text/html" in content_type.lower():
+            self._raise_profile_id_error(RuntimeError(
+                "LinkedIn /voyager/api/me bootstrap returned blocked HTML instead of JSON. "
+                "Refresh via POST /accounts/refresh and retry sync."
+            ))
+
+        try:
+            data = resp.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.debug("_get_profile_id: non-JSON /me response", exc_info=True)
+            self._raise_profile_id_error(RuntimeError(
+                "LinkedIn /voyager/api/me bootstrap returned invalid JSON. "
+                "Refresh via POST /accounts/refresh and retry sync."
+            ))
+
+        if not isinstance(data, dict):
+            self._raise_profile_id_error(RuntimeError(
+                "LinkedIn /voyager/api/me bootstrap returned an unexpected payload. "
+                "Refresh via POST /accounts/refresh and retry sync."
+            ))
+
+        pid = data.get("entityUrn") or data.get("publicIdentifier")
+
+        # Normalized response: identifiers nested under "data"
+        if not pid:
+            inner = data.get("data") or {}
+            pid = inner.get("plainId") or inner.get("*miniProfile")
+
+        # Fallback: scan "included" array for a fsd_profile dashEntityUrn
+        if not pid:
+            for item in data.get("included") or []:
+                urn = item.get("dashEntityUrn")
+                if urn and "fsd_profile" in urn:
+                    pid = urn
+                    break
+
+        if not pid:
+            self._raise_profile_id_error(RuntimeError(
+                "LinkedIn /voyager/api/me bootstrap did not return a usable mailbox/profile ID. "
+                "Refresh via POST /accounts/refresh and retry sync."
+            ))
+
+        self._profile_id = pid
+        self._profile_id_error = None
         self._profile_id_fetched = True
         return self._profile_id
 
@@ -578,8 +647,8 @@ class LinkedInProvider:
         profile_id = self._get_profile_id()
         if not profile_id:
             raise RuntimeError(
-                "Could not determine LinkedIn profile ID. "
-                "Ensure li_at and JSESSIONID cookies are valid."
+                "LinkedIn /voyager/api/me bootstrap did not return a usable mailbox/profile ID. "
+                "Refresh via POST /accounts/refresh and retry sync."
             )
 
         if "fsd_profile:" in profile_id:

--- a/tests/test_api_refresh.py
+++ b/tests/test_api_refresh.py
@@ -167,6 +167,23 @@ class TestSessionExpired401:
         assert resp.status_code == 401
         assert "re-authenticate via POST /accounts/refresh" in resp.json()["detail"]
 
+    def test_sync_returns_bootstrap_401_detail_when_provider_includes_refresh_hint(self, client):
+        aid = _create_account(client)
+        with patch(
+            "apps.api.main.run_sync",
+            side_effect=PermissionError(
+                "LinkedIn /voyager/api/me bootstrap was redirected before mailbox discovery. "
+                "Re-authenticate via POST /accounts/refresh."
+            ),
+        ):
+            resp = client.post(
+                "/sync",
+                json={"account_id": aid},
+            )
+        assert resp.status_code == 401
+        assert "/voyager/api/me" in resp.json()["detail"]
+        assert "POST /accounts/refresh" in resp.json()["detail"]
+
     def test_send_401_then_refresh_then_send_succeeds(self, client):
         """Full flow: send fails with 401, client refreshes cookies, send succeeds."""
         aid = _create_account(client)

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -513,19 +513,20 @@ class TestListThreads:
         url = mock_client.get.call_args[0][0]
         assert "mailboxUrn:urn:li:fsd_profile:ABC123" in url
 
-    def test_raises_if_profile_id_unavailable(self, auth):
-        """Raises RuntimeError if profile ID cannot be determined."""
+    def test_raises_actionable_bootstrap_error_if_profile_id_unavailable(self, auth):
+        """Redirected /me bootstrap should surface a refreshable session error."""
         p = LinkedInProvider(auth=auth)
         p._browser_cookies = {"li_at": "x"}
         p._profile_id = None
         mock_client = MagicMock()
         mock_client.is_closed = False
-        # Mock the /me call to return non-200
         me_resp = MagicMock()
         me_resp.status_code = 302
+        me_resp.headers = {"location": "https://www.linkedin.com/login"}
+        me_resp.content = b""
         mock_client.get.return_value = me_resp
         with _patch_client(mock_client):
-            with pytest.raises(RuntimeError, match="profile ID"):
+            with pytest.raises(PermissionError, match=r"POST /accounts/refresh"):
                 p.list_threads()
 
 
@@ -668,19 +669,42 @@ class TestGetProfileId:
         # Only one HTTP call — second was cached
         assert mock_client.get.call_count == 1
 
-    def test_profile_id_none_cached_when_api_fails(self, auth):
-        """If /me fails, we cache None and don't retry every call."""
+    def test_profile_id_redirect_raises_permission_error_and_caches_failure(self, auth):
+        """Redirected /me bootstrap should stay explicit, not degrade into cached None."""
         p = LinkedInProvider(auth=auth)
         mock_client = MagicMock()
         mock_client.is_closed = False
         me_resp = MagicMock()
-        me_resp.status_code = 403
+        me_resp.status_code = 302
+        me_resp.headers = {"location": "https://www.linkedin.com/login"}
+        me_resp.content = b""
         mock_client.get.return_value = me_resp
         with _patch_client(mock_client):
-            first = p._get_profile_id()
-            second = p._get_profile_id()
-        assert first is None
-        assert second is None
+            with pytest.raises(PermissionError, match=r"/voyager/api/me"):
+                p._get_profile_id()
+            with pytest.raises(PermissionError, match=r"POST /accounts/refresh"):
+                p._get_profile_id()
+        assert p._profile_id is None
+        assert mock_client.get.call_count == 1
+
+    def test_profile_id_html_bootstrap_error_is_cached_explicitly(self, auth):
+        """Blocked HTML /me bootstrap should raise an actionable error, not cached None."""
+        p = LinkedInProvider(auth=auth)
+        mock_client = MagicMock()
+        mock_client.is_closed = False
+        me_resp = MagicMock()
+        me_resp.status_code = 200
+        me_resp.headers = {"content-type": "text/html; charset=utf-8"}
+        me_resp.content = b"<html>Please sign in</html>"
+        me_resp.text = "<html>Please sign in</html>"
+        me_resp.json.side_effect = ValueError("not json")
+        mock_client.get.return_value = me_resp
+        with _patch_client(mock_client):
+            with pytest.raises(RuntimeError, match=r"/voyager/api/me"):
+                p._get_profile_id()
+            with pytest.raises(RuntimeError, match=r"POST /accounts/refresh"):
+                p._get_profile_id()
+        assert p._profile_id is None
         assert mock_client.get.call_count == 1
 
     def test_profile_id_from_public_identifier(self, auth):
@@ -695,14 +719,14 @@ class TestGetProfileId:
             pid = p._get_profile_id()
         assert pid == "john-doe"
 
-    def test_profile_id_exception_returns_none(self, auth):
+    def test_profile_id_network_exception_raises_bootstrap_error(self, auth):
         p = LinkedInProvider(auth=auth)
         mock_client = MagicMock()
         mock_client.is_closed = False
         mock_client.get.side_effect = httpx.ConnectError("network down")
         with _patch_client(mock_client):
-            pid = p._get_profile_id()
-        assert pid is None
+            with pytest.raises(RuntimeError, match=r"/voyager/api/me"):
+                p._get_profile_id()
 
     def test_profile_id_from_nested_plain_id(self, auth):
         """Normalized response with plainId under 'data' key."""
@@ -772,8 +796,8 @@ class TestGetProfileId:
             pid = p._get_profile_id()
         assert pid == "urn:li:fsd_profile:TOP"
 
-    def test_profile_id_skips_non_fsd_profile_in_included(self, auth):
-        """included items without fsd_profile in dashEntityUrn are ignored."""
+    def test_profile_id_raises_when_included_has_no_usable_fsd_profile(self, auth):
+        """Responses without a usable profile id should fail explicitly."""
         p = LinkedInProvider(auth=auth)
         mock_client = MagicMock()
         mock_client.is_closed = False
@@ -786,8 +810,8 @@ class TestGetProfileId:
         }
         mock_client.get.return_value = me_resp
         with _patch_client(mock_client):
-            pid = p._get_profile_id()
-        assert pid is None
+            with pytest.raises(RuntimeError, match=r"mailbox/profile ID"):
+                p._get_profile_id()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_send.py
+++ b/tests/test_sync_send.py
@@ -641,6 +641,31 @@ def test_sync_endpoint_422_when_jsessionid_missing(storage, account_id):
     assert resp.status_code == 422
     assert "jsessionid" in resp.json()["detail"].lower()
 
+def test_sync_endpoint_422_when_me_bootstrap_returns_blocked_html(storage, account_id):
+    from unittest.mock import MagicMock, patch
+    from fastapi.testclient import TestClient
+    from apps.api.main import app
+
+    provider = MagicMock()
+    provider.rate_limit_encountered = False
+    provider.list_threads.side_effect = RuntimeError(
+        "LinkedIn /voyager/api/me bootstrap returned blocked HTML. "
+        "Refresh via POST /accounts/refresh and retry sync."
+    )
+
+    with patch("apps.api.main.storage", storage), patch(
+        "apps.api.main.LinkedInProvider", return_value=provider
+    ):
+        client = TestClient(app)
+        resp = client.post(
+            "/sync",
+            json={"account_id": account_id, "limit_per_thread": 50},
+        )
+
+    assert resp.status_code == 422
+    assert "/voyager/api/me" in resp.json()["detail"]
+    assert "POST /accounts/refresh" in resp.json()["detail"]
+
 
 def test_sync_endpoint_returns_detailed_counts(storage, account_id):
     from unittest.mock import patch, MagicMock


### PR DESCRIPTION
Files changed:
- libs/providers/linkedin/provider.py — tightened `/voyager/api/me` bootstrap handling; added explicit cached bootstrap errors instead of caching a null profile id; mapped 401/403/302/303 bootstrap rejections to actionable auth failures; turned blocked HTML / invalid JSON / missing mailbox-profile payloads into explicit runtime bootstrap errors; kept sync session-safe by not mutating stored auth on bootstrap failure.
- apps/api/main.py — preserved `/sync` 401 vs 422 behavior while allowing bootstrap-specific 401 detail through when the provider already includes the refresh hint; kept the existing refresh guidance fallback.
- tests/test_list_threads.py — replaced old null-profile caching expectations with regression coverage for redirected `/me`, blocked HTML `/me`, network/bootstrap failure, and unusable `/me` payload handling.
- tests/test_api_refresh.py — added `/sync` API coverage proving bootstrap-specific provider `PermissionError` now returns 401 with `/voyager/api/me` + refresh guidance.
- tests/test_sync_send.py — added sync endpoint coverage for blocked-HTML `/me` bootstrap failures returning 422 with explicit refresh/bootstrap messaging.
- docs/features.md — documented the new `/sync` behavior for `/voyager/api/me` bootstrap failures and clarified profile discovery failure modes.
- docs/known-issues.md — documented that `/voyager/api/me` remains a hard dependency, but failures now surface explicitly and session-safely instead of degrading into a cached null profile id.

Tests added or modified:
- tests/test_list_threads.py
  - `test_raises_actionable_bootstrap_error_if_profile_id_unavailable`
  - `test_profile_id_redirect_raises_permission_error_and_caches_failure`
  - `test_profile_id_html_bootstrap_error_is_cached_explicitly`
  - `test_profile_id_network_exception_raises_bootstrap_error`
  - `test_profile_id_raises_when_included_has_no_usable_fsd_profile`
  These verify `/me` bootstrap failures stay explicit and cached as errors, not cached as `None`.
- tests/test_api_refresh.py
  - `test_sync_returns_bootstrap_401_detail_when_provider_includes_refresh_hint`
  Verifies `/sync` keeps 401 behavior for rejected bootstrap sessions and surfaces the refresh/bootstrap hint.
- tests/test_sync_send.py
  - `test_sync_endpoint_422_when_me_bootstrap_returns_blocked_html`
  Verifies blocked HTML bootstrap failures reach `/sync` as clear 422 bootstrap errors with refresh guidance.

Verification result:
- `uv run --extra test pytest tests/test_list_threads.py tests/test_sync_send.py -q` → failed first (reproduced the stale null-profile-id bug before the fix).
- `uv run --extra test pytest tests/test_list_threads.py tests/test_sync_send.py tests/test_api_refresh.py -q` → 111 passed.
- `uv run --extra test pytest -q` → 350 passed.
- `uv run --with build python -m build` → passed; sdist and wheel built successfully.
- `git show --stat --format='' HEAD` → confirmed the commit contains real source/doc/test changes.

Anything noteworthy:
- Auth-style `/me` bootstrap failures now fail fast and clearly without clearing or rewriting stored credentials, which keeps the sync path session-safe.
- Non-auth bootstrap failures (blocked HTML, invalid JSON, unusable payloads) now stay distinct from expired/rejected session failures, preserving 422 vs 401 semantics.
- Adjacent issue not fixed here: `/voyager/api/me` is still a hard dependency for mailbox discovery, so live sync can still fail when LinkedIn challenges that path even though the failure is now explicit and actionable.

---
Task: #489 — Fix LinkedIn /me bootstrap and session-safe sync behavior
Opened automatically by mission-control dispatcher.