### PR TITLE
Capture current LinkedIn messaging request contract in the extension

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -3,6 +3,7 @@
 
 const LINKEDIN_DOMAIN = "linkedin.com";
 const VOYAGER_API_PATTERN = "https://www.linkedin.com/voyager/api/*";
+const MESSAGING_GRAPHQL_PATH = "/voyagerMessagingGraphQL/graphql";
 
 const SERVICE_URL_DEFAULT = "http://localhost:8899";
 
@@ -17,6 +18,46 @@ async function getConfig() {
   return result;
 }
 
+// Capture the live messaging GraphQL request contract (queryId + variables shape)
+// from real LinkedIn browser traffic. Stores only metadata — never cookies or auth.
+async function captureMessagingContract(url) {
+  try {
+    const parsed = new URL(url);
+    const queryId = parsed.searchParams.get("queryId") || "";
+    const variablesRaw = parsed.searchParams.get("variables") || "";
+
+    if (!queryId) return;
+
+    // Extract key names only — shape without runtime identifying values.
+    const variablesShape = variablesRaw
+      .replace(/^\(|\)$/g, "")
+      .split(",")
+      .filter(Boolean)
+      .map((kv) => kv.split(":")[0].trim())
+      .filter(Boolean);
+
+    const current = await chrome.storage.local.get({ messagingContract: {} });
+    const contract = { ...(current.messagingContract || {}) };
+
+    if (queryId.startsWith("messengerConversations.")) {
+      contract.conversationsQueryId = queryId;
+      contract.conversationsVariablesShape = variablesShape;
+    } else if (queryId.startsWith("messengerMessages.")) {
+      contract.messagesQueryId = queryId;
+      contract.messagesVariablesShape = variablesShape;
+    } else {
+      return;
+    }
+
+    contract.endpointPath = parsed.pathname;
+    contract.capturedAt = new Date().toISOString();
+
+    await chrome.storage.local.set({ messagingContract: contract });
+  } catch (_) {
+    // best-effort; never propagate
+  }
+}
+
 async function getCapturedHeaders() {
   // Read latest captured browser headers so each backend call carries the
   // freshest fingerprint (see issue #54). Values are null until the header
@@ -26,6 +67,11 @@ async function getCapturedHeaders() {
     csrfToken: null,
   });
   return { x_li_track: xLiTrack, csrf_token: csrfToken };
+}
+
+async function getCapturedMessagingContract() {
+  const { messagingContract } = await chrome.storage.local.get({ messagingContract: null });
+  return messagingContract;
 }
 
 function buildServiceHeaders(config) {
@@ -144,9 +190,15 @@ async function registerAccount(config, cookies) {
 
 chrome.webRequest.onSendHeaders.addListener(
   async (details) => {
+    const url = details.url || "";
     const headers = details.requestHeaders || [];
     const track = headers.find((h) => (h.name || "").toLowerCase() === "x-li-track");
     const csrf = headers.find((h) => (h.name || "").toLowerCase() === "csrf-token");
+
+    // Record live messaging GraphQL contract (queryId + variables shape) from real traffic.
+    if (url.includes(MESSAGING_GRAPHQL_PATH)) {
+      await captureMessagingContract(url);
+    }
 
     if (!track && !csrf) return;
 
@@ -190,10 +242,11 @@ async function handleManualSync() {
   }
 
   const captured = await getCapturedHeaders();
+  const messagingContract = await getCapturedMessagingContract();
   const resp = await fetch(`${config.serviceUrl}/sync`, {
     method: "POST",
     headers: buildServiceHeaders(config),
-    body: JSON.stringify({ account_id: config.accountId, ...captured }),
+    body: JSON.stringify({ account_id: config.accountId, ...captured, messaging_contract: messagingContract }),
   });
 
   if (!resp.ok) {

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -135,6 +135,7 @@ function loadBackground(env) {
     JSON,
     Error,
     setTimeout,
+    URL, // needed for URL parsing in captureMessagingContract
   });
   const script = new Script(code, { filename: "background.js" });
   script.runInContext(ctx);
@@ -390,6 +391,142 @@ async function testAC6_manualRefresh() {
   assert(!!refreshCall, "POST /accounts/refresh was called");
 }
 
+async function testAC7_messagingContractConversations() {
+  console.log("\nAC7: Captures conversations queryId from real messaging traffic");
+  const env = buildEnv();
+  loadBackground(env);
+
+  const headerListener = env.listeners.onSendHeaders[0];
+  const url =
+    "https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql" +
+    "?queryId=messengerConversations.abc123def456&variables=(mailboxUrn:urn:li:fsd_profile:42,count:20)";
+
+  await headerListener.fn({
+    url,
+    requestHeaders: [
+      { name: "x-li-track", value: '{"clientVersion":"1.13.42912"}' },
+      { name: "csrf-token", value: "ajax:abc123" },
+    ],
+  });
+
+  const contract = env.storage.messagingContract;
+  assert(!!contract, "messagingContract stored after conversations request");
+  assert(
+    contract.conversationsQueryId === "messengerConversations.abc123def456",
+    "conversationsQueryId captured correctly"
+  );
+  assert(
+    contract.endpointPath === "/voyager/api/voyagerMessagingGraphQL/graphql",
+    "endpointPath captured"
+  );
+  assert(!!contract.capturedAt, "capturedAt recorded");
+  assert(Array.isArray(contract.conversationsVariablesShape), "conversationsVariablesShape is an array");
+  assert(contract.conversationsVariablesShape.includes("mailboxUrn"), "mailboxUrn key in shape");
+  assert(contract.conversationsVariablesShape.includes("count"), "count key in shape");
+}
+
+async function testAC7b_messagingContractMessages() {
+  console.log("\nAC7b: Captures messages queryId from real messaging traffic");
+  const env = buildEnv();
+  loadBackground(env);
+
+  const headerListener = env.listeners.onSendHeaders[0];
+  const url =
+    "https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql" +
+    "?queryId=messengerMessages.def456abc789&variables=(conversationUrn:2-abc,count:50,createdBefore:1234567890)";
+
+  await headerListener.fn({
+    url,
+    requestHeaders: [
+      { name: "x-li-track", value: '{"clientVersion":"1.13.42912"}' },
+    ],
+  });
+
+  const contract = env.storage.messagingContract;
+  assert(!!contract, "messagingContract stored after messages request");
+  assert(
+    contract.messagesQueryId === "messengerMessages.def456abc789",
+    "messagesQueryId captured correctly"
+  );
+  assert(Array.isArray(contract.messagesVariablesShape), "messagesVariablesShape is an array");
+  assert(contract.messagesVariablesShape.includes("conversationUrn"), "conversationUrn key in shape");
+  assert(contract.messagesVariablesShape.includes("count"), "count key in shape");
+  assert(contract.messagesVariablesShape.includes("createdBefore"), "createdBefore key in shape");
+}
+
+async function testAC7c_messagingContractNoSecrets() {
+  console.log("\nAC7c: Messaging contract does not store cookies or raw auth values");
+  const env = buildEnv();
+  loadBackground(env);
+
+  const headerListener = env.listeners.onSendHeaders[0];
+  const url =
+    "https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql" +
+    "?queryId=messengerConversations.abc123&variables=(mailboxUrn:urn:li:fsd_profile:42)";
+
+  await headerListener.fn({
+    url,
+    requestHeaders: [
+      { name: "cookie", value: "li_at=super-secret-li-at-token; JSESSIONID=js123" },
+      { name: "x-li-track", value: '{"clientVersion":"1.13.42912"}' },
+      { name: "csrf-token", value: "ajax:csrf999" },
+    ],
+  });
+
+  const contract = env.storage.messagingContract;
+  assert(!!contract, "messagingContract stored");
+  const contractStr = JSON.stringify(contract);
+  assert(!contractStr.includes("super-secret-li-at-token"), "li_at cookie value not in stored contract");
+  assert(!contractStr.includes("js123"), "JSESSIONID value not in stored contract");
+  // The contract must not include any field named 'cookie'
+  assert(!Object.prototype.hasOwnProperty.call(contract, "cookie"), "no cookie field on contract object");
+}
+
+async function testAC5d_manualSyncIncludesMessagingContract() {
+  console.log("\nAC5d: MANUAL_SYNC includes messaging_contract when previously captured");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  env.storage.messagingContract = {
+    conversationsQueryId: "messengerConversations.live123",
+    messagesQueryId: "messengerMessages.live456",
+    endpointPath: "/voyager/api/voyagerMessagingGraphQL/graphql",
+    capturedAt: "2026-04-27T10:00:00.000Z",
+  };
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  assert(resp.ok === true, "sync response is ok");
+
+  const syncCall = env.fetchLog.find((f) => f.url.includes("/sync"));
+  assert(!!syncCall, "POST /sync was called");
+  if (syncCall) {
+    const body = JSON.parse(syncCall.options.body);
+    assert(!!body.messaging_contract, "messaging_contract field present in sync payload");
+    assert(
+      body.messaging_contract.conversationsQueryId === "messengerConversations.live123",
+      "live conversationsQueryId forwarded to sync"
+    );
+    assert(
+      body.messaging_contract.messagesQueryId === "messengerMessages.live456",
+      "live messagesQueryId forwarded to sync"
+    );
+  }
+}
+
+async function testAC5e_manualSyncNullContractWhenNotCaptured() {
+  console.log("\nAC5e: MANUAL_SYNC sends messaging_contract: null when nothing captured");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  loadBackground(env);
+
+  await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  const syncCall = env.fetchLog.find((f) => f.url.includes("/sync"));
+  if (syncCall) {
+    const body = JSON.parse(syncCall.options.body);
+    assert(body.messaging_contract === null, "messaging_contract is null when not captured");
+  }
+}
+
 // ─── Run ────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -407,6 +544,11 @@ async function main() {
   await testAC5b_manualSyncIncludesBearerToken();
   await testAC5c_manualSyncThreadsBrowserContext();
   await testAC6_manualRefresh();
+  await testAC7_messagingContractConversations();
+  await testAC7b_messagingContractMessages();
+  await testAC7c_messagingContractNoSecrets();
+  await testAC5d_manualSyncIncludesMessagingContract();
+  await testAC5e_manualSyncNullContractWhenNotCaptured();
 
   console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
   process.exit(failed > 0 ? 1 : 0);

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -61,10 +61,11 @@ _RETRYABLE_STATUS_CODES = frozenset({429, 999, 500, 502, 503, 504})
 _RATE_LIMIT_STATUS_CODES = frozenset({429, 999})
 _PLAYWRIGHT_NAV_RETRIES = 2
 
-# NOTE: These queryId hashes are extracted from LinkedIn's frontend JS bundle.
-# LinkedIn may rotate them without notice. If requests start returning 400/404,
-# update by inspecting XHR calls on linkedin.com/messaging/ in browser DevTools
-# and extracting the new queryId values from the graphql request URLs.
+# FALLBACK: These queryId hashes are extracted from LinkedIn's frontend JS bundle.
+# The chrome extension captures live queryIds from real browser traffic and
+# forwards them via the messaging_contract field in POST /sync — prefer those
+# over these values. Update here only if the extension has not yet captured fresh
+# ids and requests start returning HTTP 400 (see GitHub issue #37).
 _CONVERSATIONS_QUERY_ID = "messengerConversations.0d5e6781bbee71c3e51c8843c6519f48"
 _MESSAGES_QUERY_ID = "messengerMessages.21eabeb3ee872254060ef21b793ea7d0"
 


### PR DESCRIPTION
Files changed:
- chrome-extension/background.js: added MESSAGING_GRAPHQL_PATH constant; captureMessagingContract(url) function that extracts queryId hashes + variables shape keys from real LinkedIn messaging graphql XHR traffic (never stores cookies or auth); getCapturedMessagingContract() helper; onSendHeaders listener extended to call captureMessagingContract before early return; handleManualSync now includes messaging_contract in POST /sync payload.
- chrome-extension/test_background.mjs: added URL to VM context; 5 new tests: AC7 (conversations queryId captured from URL), AC7b (messages queryId captured), AC7c (no cookie/auth secrets in stored contract), AC5d (MANUAL_SYNC forwards messaging_contract when stored), AC5e (messaging_contract is null when not yet captured).
- libs/providers/linkedin/provider.py:64-69: updated comment to explicitly mark _CONVERSATIONS_QUERY_ID / _MESSAGES_QUERY_ID as FALLBACK values, pointing to the live extension capture path.

Tests: node chrome-extension/test_background.mjs → 72 passed, 0 failed (was 49). uv run pytest -q → 394 passed.

QA criteria met:
- background.js onSendHeaders: captures queryId/variablesShape without storing Cookie or raw auth
- handleManualSync: includes messaging_contract from freshest captured data
- test_background.mjs: covers conversations/messages contract capture and redaction
- provider.py:64-69: hardcoded queryIds explicitly documented as fallback-only

---
Task: #522 — Capture current LinkedIn messaging request contract in the extension
Opened automatically by mission-control dispatcher.