### PR TITLE
Normalize provider error responses for LinkedIn sync and send

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+import httpx
 import os
 import secrets
 from dataclasses import replace
@@ -51,6 +53,58 @@ def require_api_auth(authorization: str | None = Header(default=None)) -> None:
 class AuthCheckResponse(BaseModel):
     status: str
     error: Optional[str] = None
+
+
+def _provider_http_exception(exc: httpx.HTTPStatusError | ConnectionError) -> HTTPException:
+    if isinstance(exc, ConnectionError):
+        return HTTPException(
+            status_code=503,
+            detail=(
+                "LinkedIn upstream network error — retry shortly. "
+                "If this persists, refresh via POST /accounts/refresh and try again."
+            ),
+        )
+
+    response = exc.response
+    status_code = response.status_code if response is not None else None
+    safe_detail = redact_string(str(exc))
+
+    if status_code in (401, 403):
+        if status_code == 403:
+            detail = (
+                "LinkedIn rejected the session — re-authenticate via POST /accounts/refresh and retry."
+            )
+        else:
+            detail = (
+                "LinkedIn session expired — re-authenticate via POST /accounts/refresh and retry."
+            )
+        return HTTPException(status_code=401, detail=detail)
+
+    if status_code in (429, 999):
+        headers: dict[str, str] = {}
+        retry_after = response.headers.get("Retry-After") if response is not None else None
+        if retry_after:
+            headers["Retry-After"] = retry_after
+        detail = "LinkedIn upstream rate limit reached — retry later."
+        if retry_after:
+            detail = f"{detail} Retry-After: {retry_after}s."
+        return HTTPException(status_code=429, detail=detail, headers=headers or None)
+
+    if status_code in (400, 404):
+        return HTTPException(
+            status_code=502,
+            detail=(
+                "LinkedIn messaging contract drift detected upstream — refresh the request contract and retry."
+            ),
+        )
+
+    return HTTPException(
+        status_code=502,
+        detail=(
+            "LinkedIn upstream request failed — retry shortly. "
+            f"Upstream detail: {safe_detail}"
+        ),
+    )
 
 
 _X_LI_TRACK_DESC = "Browser-captured x-li-track header value (from Chrome extension)"
@@ -261,6 +315,8 @@ def sync_account(body: SyncIn):
             status_code=401,
             detail=detail,
         ) from exc
+    except (httpx.HTTPStatusError, ConnectionError) as exc:
+        raise _provider_http_exception(exc) from exc
     except NotImplementedError:
         raise HTTPException(
             status_code=501,
@@ -312,6 +368,8 @@ def send_message(body: SendIn):
             status_code=401,
             detail="LinkedIn session expired — re-authenticate via POST /accounts/refresh",
         ) from exc
+    except (httpx.HTTPStatusError, ConnectionError) as exc:
+        raise _provider_http_exception(exc) from exc
     except NotImplementedError:
         raise HTTPException(
             status_code=501,

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -890,8 +890,8 @@ class LinkedInProvider:
         Raises:
           PermissionError: on 401 (session expired) or 403 (forbidden).
           ConnectionError: after exhausting network retries.
-          RuntimeError: after exhausting rate-limit back-off retries.
-          httpx.HTTPStatusError: on unexpected HTTP errors.
+          httpx.HTTPStatusError: after exhausting rate-limit back-off retries
+              or on unexpected HTTP errors.
         """
         if idempotency_key and idempotency_key in self._sent_keys:
             logger.info("Idempotency cache hit — returning cached message id")
@@ -955,12 +955,18 @@ class LinkedInProvider:
                 self.rate_limit_encountered = True
                 rate_limit_hits += 1
                 if rate_limit_hits > _MAX_RATE_LIMIT_RETRIES:
-                    raise RuntimeError(
-                        f"Rate-limited {rate_limit_hits} times, giving up"
+                    raise httpx.HTTPStatusError(
+                        str(resp.status_code), request=resp.request, response=resp,
                     )
                 backoff = min(
                     _BACKOFF_START_S * (2 ** (rate_limit_hits - 1)), _BACKOFF_MAX_S
                 )
+                retry_after = resp.headers.get("Retry-After")
+                if retry_after:
+                    try:
+                        backoff = max(backoff, float(retry_after))
+                    except (TypeError, ValueError):
+                        pass
                 logger.warning(
                     "Rate-limit: HTTP %d, account_id=%s, attempt %d/%d, backoff %.0fs",
                     resp.status_code,

--- a/tests/test_api_refresh.py
+++ b/tests/test_api_refresh.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import httpx
 from unittest.mock import patch
 
 import pytest
@@ -142,6 +143,76 @@ class TestRefreshValidation:
             json={"account_id": aid, "cookies": "JSESSIONID=ajax:tok123"},
         )
         assert resp.status_code == 422
+
+
+def _http_status_error(status_code: int, *, retry_after: str | None = None) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://www.linkedin.com/voyager/api/graphql")
+    headers = {"content-type": "application/json"}
+    if retry_after is not None:
+        headers["Retry-After"] = retry_after
+    response = httpx.Response(status_code, request=request, headers=headers, json={"status": status_code})
+    return httpx.HTTPStatusError(f"HTTP {status_code}", request=request, response=response)
+
+
+class TestProviderErrorNormalization:
+    @pytest.mark.parametrize("endpoint,patch_target", [("/sync", "apps.api.main.run_sync"), ("/send", "apps.api.main.run_send")])
+    @pytest.mark.parametrize("status_code", [401, 403])
+    def test_auth_http_errors_return_401_with_refresh_guidance(self, client, endpoint, patch_target, status_code):
+        aid = _create_account(client)
+        payload = {"account_id": aid}
+        if endpoint == "/send":
+            payload.update({"recipient": "urn:li:member:123", "text": "hello"})
+
+        with patch(patch_target, side_effect=_http_status_error(status_code)):
+            resp = client.post(endpoint, json=payload)
+
+        assert resp.status_code == 401
+        assert "POST /accounts/refresh" in resp.json()["detail"]
+
+    @pytest.mark.parametrize("endpoint,patch_target", [("/sync", "apps.api.main.run_sync"), ("/send", "apps.api.main.run_send")])
+    @pytest.mark.parametrize("status_code", [429, 999])
+    def test_rate_limit_http_errors_return_429_and_retry_after(self, client, endpoint, patch_target, status_code):
+        aid = _create_account(client)
+        payload = {"account_id": aid}
+        if endpoint == "/send":
+            payload.update({"recipient": "urn:li:member:123", "text": "hello"})
+
+        with patch(patch_target, side_effect=_http_status_error(status_code, retry_after="120")):
+            resp = client.post(endpoint, json=payload)
+
+        assert resp.status_code == 429
+        assert resp.headers["retry-after"] == "120"
+        assert "rate limit" in resp.json()["detail"].lower()
+
+    @pytest.mark.parametrize("endpoint,patch_target", [("/sync", "apps.api.main.run_sync"), ("/send", "apps.api.main.run_send")])
+    @pytest.mark.parametrize("status_code", [400, 404])
+    def test_contract_drift_http_errors_return_502(self, client, endpoint, patch_target, status_code):
+        aid = _create_account(client)
+        payload = {"account_id": aid}
+        if endpoint == "/send":
+            payload.update({"recipient": "urn:li:member:123", "text": "hello"})
+
+        with patch(patch_target, side_effect=_http_status_error(status_code)):
+            resp = client.post(endpoint, json=payload)
+
+        assert resp.status_code == 502
+        assert "contract" in resp.json()["detail"].lower()
+
+    @pytest.mark.parametrize("endpoint,patch_target", [("/sync", "apps.api.main.run_sync"), ("/send", "apps.api.main.run_send")])
+    def test_connection_errors_return_503_with_retry_guidance(self, client, endpoint, patch_target):
+        aid = _create_account(client)
+        payload = {"account_id": aid}
+        if endpoint == "/send":
+            payload.update({"recipient": "urn:li:member:123", "text": "hello"})
+
+        with patch(patch_target, side_effect=ConnectionError("GET failed after 3 network retries; li_at=secret csrf=secret")):
+            resp = client.post(endpoint, json=payload)
+
+        assert resp.status_code == 503
+        detail = resp.json()["detail"].lower()
+        assert "retry" in detail
+        assert "li_at" not in detail
+        assert "csrf" not in detail
 
 
 class TestSessionExpired401:

--- a/tests/test_send_message.py
+++ b/tests/test_send_message.py
@@ -63,13 +63,15 @@ def _make_provider(auth=None, proxy=None):
     return LinkedInProvider(auth=auth or SAMPLE_AUTH, proxy=proxy)
 
 
-def _make_mock_response(status_code=200, json_data=None):
+def _make_mock_response(status_code=200, json_data=None, headers=None):
     resp = MagicMock(spec=httpx.Response)
     resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.request = httpx.Request("POST", _MESSAGING_URL)
     resp.json.return_value = json_data or SAMPLE_LINKEDIN_SUCCESS_RESPONSE
     if status_code >= 400:
         resp.raise_for_status.side_effect = httpx.HTTPStatusError(
-            f"HTTP {status_code}", request=MagicMock(), response=resp
+            f"HTTP {status_code}", request=resp.request, response=resp
         )
     else:
         resp.raise_for_status.return_value = None
@@ -406,9 +408,10 @@ class TestSendMessageRateLimiting:
         client.post.return_value = _make_mock_response(429)
 
         provider = _make_provider()
-        with pytest.raises(RuntimeError, match="Rate-limited"):
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
             provider.send_message(recipient=SAMPLE_RECIPIENT, text="Hi")
 
+        assert exc_info.value.response.status_code == 429
         assert client.post.call_count == 6  # 5 retries + 1 final that triggers raise
 
 


### PR DESCRIPTION
Files changed:\n- apps/api/main.py — added shared provider error normalization helper and wired /sync + /send to catch provider httpx.HTTPStatusError and ConnectionError, mapping auth failures to 401, rate limits/999 to 429 with Retry-After passthrough, contract drift 400/404 to 502, and network failures to 503 with safe retry guidance.\n- libs/providers/linkedin/provider.py — changed exhausted send-path rate-limit handling to raise httpx.HTTPStatusError instead of RuntimeError and honor Retry-After when computing backoff, while preserving current main/PR #57 browser-context behavior.\n- tests/test_api_refresh.py — added API coverage for /sync and /send normalization of provider 401/403, 429/999, 400/404, and ConnectionError cases, including retry guidance and redaction expectations.\n- tests/test_send_message.py — updated send rate-limit helper expectations so exhausted send retries now surface as httpx.HTTPStatusError and mocks include request/headers needed for Retry-After behavior.\n\nTests added or modified:\n- tests/test_api_refresh.py::TestProviderErrorNormalization — verifies stable FastAPI responses for provider auth, rate-limit, contract-drift, and network failures across both /sync and /send.\n- tests/test_send_message.py::TestSendMessageRateLimiting::test_gives_up_after_max_rate_limit_retries — verifies repeated 429s now raise httpx.HTTPStatusError with the upstream status preserved.\n\nVerification result:\n- uv run pytest -q tests/test_api_refresh.py tests/test_send_message.py -> PASS (58 passed).\n- uv run pytest -q -> PASS (408 passed).\n- node chrome-extension/test_background.mjs -> PASS (72 passed, 0 failed).\n- uv run python -m compileall apps libs -> PASS.\n- uv run python scripts/validate_issue_43.py -> unavailable in this worktree (scripts/validate_issue_43.py does not exist here), so it could not be executed.\n\nAnything noteworthy:\n- Kept scope tight to #523 and preserved merged PR #57 browser-context threading/bootstrap behavior.\n- Provider/network response details are normalized at the API boundary so raw upstream failures no longer leak as generic 500s.\n- Redaction-sensitive coverage ensures error details do not expose li_at/csrf-style secrets.\n- No changes were made outside /tmp/mc-task-523-linkedin-dms.

---
Task: #523 — Normalize provider error responses for LinkedIn sync and send
Opened automatically by mission-control dispatcher.