### PR TITLE
Build extension-first LinkedIn inbox sync MVP with backend ingest

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -6,13 +6,23 @@ import httpx
 import os
 import secrets
 from dataclasses import replace
+from datetime import datetime
 from typing import Optional
 
 from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
 from libs.core.cookies import cookies_to_account_auth, validate_li_at
-from libs.core.job_runner import run_send, run_sync, SendResult, SyncConfig, SyncResult
+from libs.core.job_runner import (
+    IngestMessage,
+    IngestThread,
+    SendResult,
+    SyncConfig,
+    SyncResult,
+    run_ingest,
+    run_send,
+    run_sync,
+)
 from libs.core.models import AccountAuth, BrowserContext, ProxyConfig
 from libs.core.redaction import configure_logging, redact_for_log, redact_string
 from libs.core.storage import Storage
@@ -182,6 +192,38 @@ class SendIn(BaseModel):
     csrf_token: str | None = Field(None, description=_CSRF_TOKEN_DESC)
 
 
+class IngestMessageIn(BaseModel):
+    platform_message_id: str = Field(..., min_length=1)
+    direction: str = Field(..., description="'in' or 'out'")
+    sender: str | None = None
+    text: str | None = None
+    sent_at: datetime
+    raw: dict | None = None
+
+    @model_validator(mode="after")
+    def _check_direction(self) -> IngestMessageIn:
+        if self.direction not in ("in", "out"):
+            raise ValueError("direction must be 'in' or 'out'")
+        return self
+
+
+class IngestThreadIn(BaseModel):
+    platform_thread_id: str = Field(..., min_length=1)
+    title: str | None = None
+    messages: list[IngestMessageIn] = Field(default_factory=list)
+
+
+class IngestIn(BaseModel):
+    account_id: int
+    threads: list[IngestThreadIn]
+    pages_fetched: int = Field(0, ge=0)
+    rate_limited: bool = False
+    messaging_contract: dict | None = Field(
+        None,
+        description="Captured messaging contract metadata (queryIds + capturedAt). No secrets.",
+    )
+
+
 class SyncIn(BaseModel):
     account_id: int
     limit_per_thread: int = Field(50, ge=1, le=MAX_MESSAGES_PER_PAGE, description="Messages per page")
@@ -327,6 +369,73 @@ def sync_account(body: SyncIn):
             status_code=422,
             detail=redact_string(str(e)),
         ) from None
+
+
+@app.post("/sync/ingest", dependencies=[Depends(require_api_auth)])
+def ingest_sync(body: IngestIn):
+    """Ingest extension-captured threads/messages.
+
+    The Chrome extension reads LinkedIn directly from the browser session
+    and POSTs normalized data here. This is the primary path for manual
+    Sync Now in the extension; the legacy /sync endpoint remains as
+    fallback. Storage dedupe semantics match run_sync.
+    """
+    try:
+        # Validate the account exists; reuse existing lookup helper.
+        storage.get_account_auth(body.account_id)
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=redact_string(str(e))) from e
+
+    threads = [
+        IngestThread(
+            platform_thread_id=t.platform_thread_id,
+            title=t.title,
+            messages=[
+                IngestMessage(
+                    platform_message_id=m.platform_message_id,
+                    direction=m.direction,
+                    sender=m.sender,
+                    text=m.text,
+                    sent_at=m.sent_at,
+                    raw=m.raw,
+                )
+                for m in t.messages
+            ],
+        )
+        for t in body.threads
+    ]
+    try:
+        result: SyncResult = run_ingest(
+            account_id=body.account_id,
+            storage=storage,
+            threads=threads,
+            pages_fetched=body.pages_fetched,
+            rate_limited=body.rate_limited,
+        )
+    except (ValueError, RuntimeError) as e:
+        raise HTTPException(status_code=422, detail=redact_string(str(e))) from None
+
+    contract_meta = body.messaging_contract or {}
+    logger.info(
+        "Ingest accepted: %s",
+        redact_for_log({
+            "account_id": body.account_id,
+            "synced_threads": result.synced_threads,
+            "messages_inserted": result.messages_inserted,
+            "messages_skipped_duplicate": result.messages_skipped_duplicate,
+            "pages_fetched": result.pages_fetched,
+            "rate_limited": result.rate_limited,
+            "contract_captured_at": contract_meta.get("capturedAt"),
+        }),
+    )
+    return {
+        "ok": True,
+        "synced_threads": result.synced_threads,
+        "messages_inserted": result.messages_inserted,
+        "messages_skipped_duplicate": result.messages_skipped_duplicate,
+        "pages_fetched": result.pages_fetched,
+        "rate_limited": result.rate_limited,
+    }
 
 
 @app.post("/send", dependencies=[Depends(require_api_auth)])

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -235,23 +235,277 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
 });
 
+// ─── Extension-first inbox read (task #524) ─────────────────────────────────
+// Manual Sync Now drives the LinkedIn read path from the browser, then POSTs
+// normalized data to /sync/ingest. The legacy backend /sync remains as a
+// fallback path but is no longer used for manual sync.
+
+const VOYAGER_ME_URL = "https://www.linkedin.com/voyager/api/me";
+const VOYAGER_BASE = "https://www.linkedin.com";
+const CONTRACT_FRESHNESS_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
+const INGEST_MESSAGES_PER_THREAD = 20; // First-MVP first-page only.
+
+function isContractFresh(contract) {
+  if (!contract) return false;
+  if (!contract.conversationsQueryId || !contract.messagesQueryId) return false;
+  if (!contract.capturedAt) return true; // present but undated → accept
+  const ts = Date.parse(contract.capturedAt);
+  if (Number.isNaN(ts)) return true;
+  return Date.now() - ts <= CONTRACT_FRESHNESS_MS;
+}
+
+function buildLinkedInHeaders(captured) {
+  const headers = {
+    "Accept": "application/graphql,application/vnd.linkedin.normalized+json+2.1",
+    "x-restli-protocol-version": "2.0.0",
+    "csrf-token": captured.csrf_token,
+  };
+  if (captured.x_li_track) headers["x-li-track"] = captured.x_li_track;
+  return headers;
+}
+
+function extractProfileId(data) {
+  if (!data || typeof data !== "object") return null;
+  if (data.plainId) return String(data.plainId);
+  if (data.entityUrn) return String(data.entityUrn);
+  if (data.publicIdentifier) return String(data.publicIdentifier);
+  const inner = data.data;
+  if (inner && typeof inner === "object") {
+    if (inner.plainId) return String(inner.plainId);
+    if (inner["*miniProfile"]) return String(inner["*miniProfile"]);
+    if (inner.entityUrn) return String(inner.entityUrn);
+  }
+  if (Array.isArray(data.included)) {
+    for (const item of data.included) {
+      if (item && typeof item === "object" && item.dashEntityUrn && String(item.dashEntityUrn).includes("fsd_profile")) {
+        return String(item.dashEntityUrn);
+      }
+    }
+  }
+  return null;
+}
+
+function buildMailboxUrn(profileId) {
+  const s = String(profileId);
+  return s.includes("fsd_profile:") ? s : `urn:li:fsd_profile:${s}`;
+}
+
+async function fetchVoyagerMe(captured) {
+  const resp = await fetch(VOYAGER_ME_URL, {
+    method: "GET",
+    headers: buildLinkedInHeaders(captured),
+    credentials: "include",
+  });
+  if (!resp.ok) {
+    throw new Error(`LinkedIn /voyager/api/me failed (${resp.status}). Refresh LinkedIn and retry.`);
+  }
+  const data = await resp.json();
+  const pid = extractProfileId(data);
+  if (!pid) {
+    throw new Error("LinkedIn /voyager/api/me returned no profile id. Open LinkedIn and retry.");
+  }
+  return pid;
+}
+
+async function fetchConversationsPage(mailboxUrn, contract, captured) {
+  const variables = `(mailboxUrn:${mailboxUrn})`;
+  const path = contract.endpointPath || "/voyager/api/voyagerMessagingGraphQL/graphql";
+  const url = `${VOYAGER_BASE}${path}?queryId=${encodeURIComponent(contract.conversationsQueryId)}&variables=${encodeURIComponent(variables)}`;
+  const resp = await fetch(url, {
+    method: "GET",
+    headers: buildLinkedInHeaders(captured),
+    credentials: "include",
+  });
+  if (resp.status === 429 || resp.status === 999) return { rateLimited: true, data: null };
+  if (!resp.ok) throw new Error(`LinkedIn conversations request failed (${resp.status}).`);
+  return { rateLimited: false, data: await resp.json() };
+}
+
+async function fetchMessagesPage(conversationUrn, contract, captured) {
+  const variables = `(conversationUrn:${conversationUrn},count:${INGEST_MESSAGES_PER_THREAD})`;
+  const path = contract.endpointPath || "/voyager/api/voyagerMessagingGraphQL/graphql";
+  const url = `${VOYAGER_BASE}${path}?queryId=${encodeURIComponent(contract.messagesQueryId)}&variables=${encodeURIComponent(variables)}`;
+  const resp = await fetch(url, {
+    method: "GET",
+    headers: buildLinkedInHeaders(captured),
+    credentials: "include",
+  });
+  if (resp.status === 429 || resp.status === 999) return { rateLimited: true, data: null };
+  if (!resp.ok) throw new Error(`LinkedIn messages request failed (${resp.status}).`);
+  return { rateLimited: false, data: await resp.json() };
+}
+
+function parseConversations(data) {
+  const out = [];
+  if (!data || typeof data !== "object") return out;
+  const inner = data.data || {};
+  const conv = inner.messengerConversationsBySyncToken || inner.messengerConversations || {};
+  const elements = Array.isArray(conv.elements) ? conv.elements : [];
+  for (const elem of elements) {
+    if (!elem || typeof elem !== "object") continue;
+    const urn = elem.entityUrn || elem.conversationUrn || elem.backendConversationUrn;
+    if (!urn) continue;
+    let title = null;
+    if (typeof elem.conversationName === "string" && elem.conversationName.trim()) {
+      title = elem.conversationName.trim();
+    } else {
+      const names = [];
+      const parts = Array.isArray(elem.conversationParticipants) ? elem.conversationParticipants : [];
+      for (const p of parts) {
+        const profile = (p && (p.participantProfile || p.profile)) || {};
+        const first = profile.firstName || "";
+        const last = profile.lastName || "";
+        const full = `${first} ${last}`.trim();
+        if (full) names.push(full);
+      }
+      title = names.length ? names.join(", ") : null;
+    }
+    out.push({ platform_thread_id: String(urn), title });
+  }
+  return out;
+}
+
+function parseMessages(data, myProfileId) {
+  const out = [];
+  if (!data || typeof data !== "object") return out;
+  const inner = data.data || {};
+  const msg = inner.messengerMessagesBySyncToken || inner.messengerMessages || {};
+  const elements = Array.isArray(msg.elements) ? msg.elements : [];
+  for (const event of elements) {
+    if (!event || typeof event !== "object") continue;
+    const id = event.entityUrn || event.backendUrn || event.dashEntityUrn;
+    if (!id) continue;
+
+    let text = null;
+    const body = event.eventContent || event.body;
+    if (body && typeof body === "object") {
+      if (body.attributedBody && typeof body.attributedBody === "object") {
+        text = body.attributedBody.text || null;
+      }
+      if (!text) text = body.text || body.body || null;
+    } else if (typeof body === "string") {
+      text = body;
+    }
+
+    let senderUrn = null;
+    let senderName = null;
+    const sender = event.sender || event.from;
+    if (sender && typeof sender === "object") {
+      const profile = sender.participantProfile || sender.profile || {};
+      senderUrn = profile.entityUrn || profile.publicIdentifier || null;
+      const first = profile.firstName || "";
+      const last = profile.lastName || "";
+      const full = `${first} ${last}`.trim();
+      senderName = full || senderUrn || null;
+    }
+
+    let direction = "in";
+    if (myProfileId && senderUrn) {
+      const me = String(myProfileId);
+      const su = String(senderUrn);
+      if (su === me || su.endsWith(`:${me}`) || me.endsWith(`:${su}`)) {
+        direction = "out";
+      }
+    }
+
+    let sentAt = new Date().toISOString();
+    const createdAt = event.createdAt ?? event.deliveredAt;
+    if (typeof createdAt === "number") {
+      sentAt = new Date(createdAt).toISOString();
+    }
+
+    out.push({
+      platform_message_id: String(id),
+      direction,
+      sender: senderName,
+      text,
+      sent_at: sentAt,
+    });
+  }
+  out.sort((a, b) => (a.sent_at < b.sent_at ? -1 : 1));
+  return out;
+}
+
 async function handleManualSync() {
   const config = await getConfig();
   if (!config.accountId) {
     throw new Error("No account registered. Log in to LinkedIn first.");
   }
 
+  const contract = await getCapturedMessagingContract();
+  if (!contract || !contract.conversationsQueryId || !contract.messagesQueryId) {
+    throw new Error(
+      "Messaging contract not captured. Open https://www.linkedin.com/messaging/ in this browser to record the request shape, then retry sync."
+    );
+  }
+  if (!isContractFresh(contract)) {
+    throw new Error(
+      "Messaging contract is stale. Open https://www.linkedin.com/messaging/ in this browser to refresh the captured contract, then retry sync."
+    );
+  }
+
   const captured = await getCapturedHeaders();
-  const messagingContract = await getCapturedMessagingContract();
-  const resp = await fetch(`${config.serviceUrl}/sync`, {
+  if (!captured.csrf_token) {
+    throw new Error(
+      "csrf-token not yet captured from LinkedIn. Open https://www.linkedin.com/ in this browser, then retry sync."
+    );
+  }
+
+  const profileId = await fetchVoyagerMe(captured);
+  const mailboxUrn = buildMailboxUrn(profileId);
+
+  let pagesFetched = 0;
+  let rateLimited = false;
+
+  const convResult = await fetchConversationsPage(mailboxUrn, contract, captured);
+  if (convResult.rateLimited) {
+    rateLimited = true;
+  } else {
+    pagesFetched += 1;
+  }
+  const threadsRaw = convResult.data ? parseConversations(convResult.data) : [];
+
+  const ingestThreads = [];
+  for (const t of threadsRaw) {
+    let messages = [];
+    if (!rateLimited) {
+      const mr = await fetchMessagesPage(t.platform_thread_id, contract, captured);
+      if (mr.rateLimited) {
+        rateLimited = true;
+      } else {
+        pagesFetched += 1;
+        messages = parseMessages(mr.data, profileId);
+      }
+    }
+    ingestThreads.push({
+      platform_thread_id: t.platform_thread_id,
+      title: t.title,
+      messages,
+    });
+  }
+
+  const safeContract = {
+    conversationsQueryId: contract.conversationsQueryId,
+    messagesQueryId: contract.messagesQueryId,
+    endpointPath: contract.endpointPath || null,
+    capturedAt: contract.capturedAt || null,
+  };
+
+  const resp = await fetch(`${config.serviceUrl}/sync/ingest`, {
     method: "POST",
     headers: buildServiceHeaders(config),
-    body: JSON.stringify({ account_id: config.accountId, ...captured, messaging_contract: messagingContract }),
+    body: JSON.stringify({
+      account_id: config.accountId,
+      threads: ingestThreads,
+      pages_fetched: pagesFetched,
+      rate_limited: rateLimited,
+      messaging_contract: safeContract,
+    }),
   });
 
   if (!resp.ok) {
     const detail = await resp.text();
-    throw new Error(`Sync failed (${resp.status}): ${detail}`);
+    throw new Error(`Ingest failed (${resp.status}): ${detail}`);
   }
 
   const data = await resp.json();

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -93,8 +93,10 @@ btnSync.addEventListener("click", async () => {
     const resp = await chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
     if (resp.ok) {
       const d = resp.data;
+      const dupes = d.messages_skipped_duplicate ?? 0;
+      const rate = d.rate_limited ? " (rate-limited)" : "";
       showResult(
-        `Synced ${d.synced_threads} threads, ${d.messages_inserted} new messages.`
+        `Synced ${d.synced_threads} threads, ${d.messages_inserted} new, ${dupes} duplicates skipped${rate}.`,
       );
     } else {
       showResult(resp.error || "Sync failed.", true);

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -7,8 +7,10 @@
  *   AC2 – cookie capture registers a new account via POST /accounts
  *   AC3 – cookie change on existing account triggers POST /accounts/refresh
  *   AC4 – header capture stores xLiTrack / csrfToken
- *   AC5 – MANUAL_SYNC message triggers POST /sync
- *   AC6 – MANUAL_REFRESH message triggers refresh or register
+ *   AC5 – MANUAL_SYNC reads LinkedIn from the browser and POSTs /sync/ingest
+ *   AC6 – MANUAL_REFRESH triggers refresh or register
+ *   AC7 – messaging contract capture from real traffic
+ *   AC8 – MANUAL_SYNC fails visibly without contract / csrf
  */
 
 import { readFileSync } from "fs";
@@ -29,9 +31,18 @@ function assert(cond, label) {
   }
 }
 
+const FRESH_CONTRACT = {
+  conversationsQueryId: "messengerConversations.live123",
+  messagesQueryId: "messengerMessages.live456",
+  conversationsVariablesShape: ["mailboxUrn", "count"],
+  messagesVariablesShape: ["conversationUrn", "count"],
+  endpointPath: "/voyager/api/voyagerMessagingGraphQL/graphql",
+  capturedAt: new Date().toISOString(),
+};
+
 // ─── Build mock chrome + fetch environment ──────────────────────────────────
 
-function buildEnv() {
+function buildEnv({ linkedinResponses } = {}) {
   const storage = {};
   const listeners = {
     cookieChanged: [],
@@ -46,7 +57,6 @@ function buildEnv() {
         addListener: (fn) => listeners.cookieChanged.push(fn),
       },
       get: (query, cb) => {
-        // Return a fake JSESSIONID when asked
         if (query.name === "JSESSIONID") {
           if (cb) cb({ value: '"fake-jsessionid-123"' });
           else return Promise.resolve({ value: '"fake-jsessionid-123"' });
@@ -93,28 +103,130 @@ function buildEnv() {
     },
   };
 
-  // Mock fetch
+  const lr = linkedinResponses || {};
+
+  // Mock fetch — handles LinkedIn voyager + service URLs.
   const fakeFetch = (url, options) => {
     fetchLog.push({ url, options });
-    // Return different responses based on URL
-    if (url.includes("/accounts/refresh")) {
+    const u = String(url);
+
+    if (u.startsWith("https://www.linkedin.com/voyager/api/me")) {
+      const me = lr.me === undefined ? { plainId: "42" } : lr.me;
+      if (me === "__error__") {
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve("expired"),
+        });
+      }
       return Promise.resolve({
         ok: true,
+        status: 200,
+        json: () => Promise.resolve(me),
+        text: () => Promise.resolve(JSON.stringify(me)),
+      });
+    }
+
+    if (u.includes("/voyagerMessagingGraphQL/graphql")) {
+      const isConv = u.includes("queryId=messengerConversations");
+      const isMsg = u.includes("queryId=messengerMessages");
+      let body;
+      if (isConv) {
+        body = lr.conversations === undefined
+          ? {
+              data: {
+                messengerConversationsBySyncToken: {
+                  elements: [
+                    {
+                      entityUrn: "urn:li:msg_conversation:1",
+                      conversationName: null,
+                      conversationParticipants: [
+                        { participantProfile: { entityUrn: "urn:li:fsd_profile:99", firstName: "Alice", lastName: "Example" } },
+                      ],
+                    },
+                    {
+                      entityUrn: "urn:li:msg_conversation:2",
+                      conversationName: "Group Chat",
+                      conversationParticipants: [],
+                    },
+                  ],
+                  metadata: {},
+                },
+              },
+            }
+          : lr.conversations;
+      } else if (isMsg) {
+        body = lr.messages === undefined
+          ? {
+              data: {
+                messengerMessagesBySyncToken: {
+                  elements: [
+                    {
+                      entityUrn: "urn:li:event:1",
+                      sender: { participantProfile: { entityUrn: "urn:li:fsd_profile:99", firstName: "Alice", lastName: "Example" } },
+                      eventContent: { attributedBody: { text: "Hi there" } },
+                      createdAt: 1714200000000,
+                    },
+                    {
+                      entityUrn: "urn:li:event:2",
+                      sender: { participantProfile: { entityUrn: "urn:li:fsd_profile:42", firstName: "Me", lastName: "" } },
+                      eventContent: { attributedBody: { text: "Hello" } },
+                      createdAt: 1714200060000,
+                    },
+                  ],
+                },
+              },
+            }
+          : lr.messages;
+      } else {
+        body = {};
+      }
+      if (body && body.__error__) {
+        return Promise.resolve({
+          ok: false,
+          status: body.__error__,
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve("err"),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(JSON.stringify(body)),
+      });
+    }
+
+    if (u.includes("/sync/ingest")) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          ok: true,
+          synced_threads: 2,
+          messages_inserted: 4,
+          messages_skipped_duplicate: 0,
+          pages_fetched: 3,
+          rate_limited: false,
+        }),
+        text: () => Promise.resolve("ok"),
+      });
+    }
+
+    if (u.includes("/accounts/refresh")) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
         json: () => Promise.resolve({ ok: true, account_id: 1 }),
         text: () => Promise.resolve("ok"),
       });
     }
-    if (url.includes("/accounts")) {
+    if (u.includes("/accounts")) {
       return Promise.resolve({
         ok: true,
+        status: 200,
         json: () => Promise.resolve({ account_id: 42 }),
-        text: () => Promise.resolve("ok"),
-      });
-    }
-    if (url.includes("/sync")) {
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ ok: true, synced_threads: 3, messages_inserted: 15, messages_skipped_duplicate: 0, pages_fetched: 3 }),
         text: () => Promise.resolve("ok"),
       });
     }
@@ -126,20 +238,42 @@ function buildEnv() {
 
 function loadBackground(env) {
   const code = readFileSync("chrome-extension/background.js", "utf8");
+  const consoleCalls = [];
+  const recordingConsole = {
+    log: (...args) => { consoleCalls.push(["log", ...args]); console.log(...args); },
+    info: (...args) => { consoleCalls.push(["info", ...args]); console.info(...args); },
+    warn: (...args) => { consoleCalls.push(["warn", ...args]); console.warn(...args); },
+    error: (...args) => { consoleCalls.push(["error", ...args]); console.error(...args); },
+    debug: (...args) => { consoleCalls.push(["debug", ...args]); },
+  };
+  env.consoleCalls = consoleCalls;
   const ctx = createContext({
     chrome: env.chrome,
     fetch: env.fakeFetch,
-    console,
+    console: recordingConsole,
     Promise,
     Date,
     JSON,
     Error,
     setTimeout,
-    URL, // needed for URL parsing in captureMessagingContract
+    URL,
+    encodeURIComponent,
   });
   const script = new Script(code, { filename: "background.js" });
   script.runInContext(ctx);
   return ctx;
+}
+
+function findIngestCall(env) {
+  return env.fetchLog.find((f) => f.url.includes("/sync/ingest"));
+}
+
+function findLegacySyncCall(env) {
+  return env.fetchLog.find(
+    (f) =>
+      (f.url.endsWith("/sync") || f.url.match(/\/sync(\?|$)/)) &&
+      !f.url.includes("/sync/ingest"),
+  );
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -161,14 +295,11 @@ async function testAC1_loads() {
 async function testAC2_newAccountRegistration() {
   console.log("\nAC2: Cookie capture registers new account (no accountId stored)");
   const env = buildEnv();
-  // Seed previously-captured headers so registration forwards them (issue #54).
   env.storage.xLiTrack = '{"clientVersion":"1.13.42912"}';
   env.storage.csrfToken = "ajax:CSRF123";
-  // No accountId in storage → should call POST /accounts
   loadBackground(env);
 
   const cookieListener = env.listeners.cookieChanged[0];
-  // Simulate li_at cookie change
   await new Promise((resolve) => {
     cookieListener({
       cookie: { domain: ".linkedin.com", name: "li_at", value: "new-li-at-value" },
@@ -177,7 +308,7 @@ async function testAC2_newAccountRegistration() {
     setTimeout(resolve, 50);
   });
 
-  const accountCall = env.fetchLog.find(f => f.url.includes("/accounts") && !f.url.includes("/refresh"));
+  const accountCall = env.fetchLog.find(f => f.url.endsWith("/accounts"));
   assert(!!accountCall, "POST /accounts was called");
   if (accountCall) {
     const body = JSON.parse(accountCall.options.body);
@@ -194,7 +325,7 @@ async function testAC2_newAccountRegistration() {
 async function testAC3_cookieRefresh() {
   console.log("\nAC3: Cookie change triggers POST /accounts/refresh");
   const env = buildEnv();
-  env.storage.accountId = 1; // Existing account
+  env.storage.accountId = 1;
   env.storage.xLiTrack = "TRACK_FOR_REFRESH";
   env.storage.csrfToken = "CSRF_FOR_REFRESH";
   loadBackground(env);
@@ -278,7 +409,6 @@ async function testAC4_headerCapture() {
   const headerListener = env.listeners.onSendHeaders[0];
   assert(headerListener.filter.urls[0] === "https://www.linkedin.com/voyager/api/*", "filter matches voyager API pattern");
 
-  // Simulate a request with both headers
   await headerListener.fn({
     requestHeaders: [
       { name: "x-li-track", value: '{"clientVersion":"1.13.42912"}' },
@@ -291,7 +421,6 @@ async function testAC4_headerCapture() {
   assert(env.storage.csrfToken === "ajax:abc123", "csrfToken stored");
   assert(!!env.storage.headersUpdatedAt, "headersUpdatedAt stored");
 
-  // Simulate partial update: only one header present (case-insensitive name)
   await headerListener.fn({
     requestHeaders: [
       { name: "X-LI-TRACK", value: '{"clientVersion":"1.13.42913"}' },
@@ -302,79 +431,100 @@ async function testAC4_headerCapture() {
   assert(env.storage.csrfToken === "ajax:abc123", "csrfToken preserved when not present in later request");
 }
 
-async function testAC5_manualSync() {
-  console.log("\nAC5: MANUAL_SYNC triggers POST /sync");
+async function testAC5_manualSyncReadsLinkedInAndIngests() {
+  console.log("\nAC5: MANUAL_SYNC reads LinkedIn from the browser and POSTs /sync/ingest");
   const env = buildEnv();
   env.storage.accountId = 1;
   env.storage.xLiTrack = "SYNC_TRACK";
   env.storage.csrfToken = "SYNC_CSRF";
+  env.storage.messagingContract = FRESH_CONTRACT;
   loadBackground(env);
 
   const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
-  assert(resp.ok === true, "sync response is ok");
-  assert(resp.data.synced_threads === 3, "sync result contains synced_threads");
-  assert(resp.data.messages_inserted === 15, "sync result contains messages_inserted");
-
-  const syncCall = env.fetchLog.find(f => f.url.includes("/sync"));
-  assert(!!syncCall, "POST /sync was called");
-  if (syncCall) {
-    const body = JSON.parse(syncCall.options.body);
-    assert(body.account_id === 1, "account_id passed to sync");
-    assert(body.x_li_track === "SYNC_TRACK", "x_li_track forwarded on manual sync");
-    assert(body.csrf_token === "SYNC_CSRF", "csrf_token forwarded on manual sync");
+  assert(resp.ok === true, `sync response is ok (got: ${JSON.stringify(resp)})`);
+  if (resp.ok) {
+    assert(resp.data.synced_threads === 2, "ingest result contains synced_threads");
+    assert(resp.data.messages_inserted === 4, "ingest result contains messages_inserted");
+    assert(resp.data.messages_skipped_duplicate === 0, "ingest result contains messages_skipped_duplicate");
   }
-}
 
-async function testAC5c_manualSyncWithoutCapturedHeaders() {
-  console.log("\nAC5c: MANUAL_SYNC sends null when nothing captured yet");
-  const env = buildEnv();
-  env.storage.accountId = 1;
-  loadBackground(env);
+  const meCall = env.fetchLog.find(f => f.url.startsWith("https://www.linkedin.com/voyager/api/me"));
+  assert(!!meCall, "extension fetched LinkedIn /voyager/api/me directly");
 
-  await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
-  const syncCall = env.fetchLog.find(f => f.url.includes("/sync"));
-  if (syncCall) {
-    const body = JSON.parse(syncCall.options.body);
-    assert(body.x_li_track === null, "x_li_track is null when not captured");
-    assert(body.csrf_token === null, "csrf_token is null when not captured");
+  const convCall = env.fetchLog.find(f => f.url.includes("queryId=messengerConversations"));
+  assert(!!convCall, "extension fetched conversations from LinkedIn GraphQL");
+  if (convCall) {
+    assert(convCall.url.includes(FRESH_CONTRACT.conversationsQueryId), "conversations queryId from captured contract");
+  }
+
+  const msgCalls = env.fetchLog.filter(f => f.url.includes("queryId=messengerMessages"));
+  assert(msgCalls.length >= 1, "extension fetched at least one messages page from LinkedIn GraphQL");
+  if (msgCalls.length >= 1) {
+    assert(msgCalls[0].url.includes(FRESH_CONTRACT.messagesQueryId), "messages queryId from captured contract");
+  }
+
+  const ingestCall = findIngestCall(env);
+  assert(!!ingestCall, "POST /sync/ingest was called");
+  const legacy = findLegacySyncCall(env);
+  assert(!legacy, "legacy POST /sync was NOT called for manual Sync Now");
+
+  if (ingestCall) {
+    const body = JSON.parse(ingestCall.options.body);
+    assert(body.account_id === 1, "account_id in ingest payload");
+    assert(Array.isArray(body.threads), "threads array present in ingest payload");
+    assert(body.threads.length === 2, "two threads from mocked LinkedIn response");
+    const t = body.threads[0];
+    assert(typeof t.platform_thread_id === "string" && t.platform_thread_id.length > 0, "thread platform_thread_id present");
+    assert(Array.isArray(t.messages), "thread.messages array present");
+    if (t.messages.length) {
+      const m = t.messages[0];
+      assert(typeof m.platform_message_id === "string", "message platform_message_id present");
+      assert(m.direction === "in" || m.direction === "out", "message direction is 'in' or 'out'");
+      assert(typeof m.sent_at === "string", "message sent_at is an ISO string");
+    }
+    assert(typeof body.pages_fetched === "number" && body.pages_fetched >= 1, "pages_fetched count present");
+    assert(body.rate_limited === false, "rate_limited flag included");
+    assert(!!body.messaging_contract, "messaging_contract metadata forwarded");
+    assert(body.messaging_contract.conversationsQueryId === FRESH_CONTRACT.conversationsQueryId, "live conversationsQueryId forwarded");
   }
 }
 
 async function testAC5b_manualSyncIncludesBearerToken() {
-  console.log("\nAC5b: MANUAL_SYNC includes Authorization when apiToken is configured");
+  console.log("\nAC5b: MANUAL_SYNC includes Authorization on /sync/ingest when apiToken configured");
   const env = buildEnv();
   env.storage.accountId = 1;
   env.storage.apiToken = "local-api-token";
+  env.storage.csrfToken = "SYNC_CSRF";
+  env.storage.messagingContract = FRESH_CONTRACT;
   loadBackground(env);
 
   const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
   assert(resp.ok === true, "sync response is ok");
 
-  const syncCall = env.fetchLog.find(f => f.url.includes("/sync"));
-  assert(!!syncCall, "POST /sync was called");
-  if (syncCall) {
-    assert(syncCall.options.headers.Authorization === "Bearer local-api-token", "Authorization header included");
+  const ingestCall = findIngestCall(env);
+  assert(!!ingestCall, "POST /sync/ingest was called");
+  if (ingestCall) {
+    assert(ingestCall.options.headers.Authorization === "Bearer local-api-token", "Authorization header included on ingest");
   }
 }
 
-async function testAC5c_manualSyncThreadsBrowserContext() {
-  console.log("\nAC5c: MANUAL_SYNC threads captured x_li_track and csrf_token into payload");
+async function testAC5c_extensionDirectionForMyMessages() {
+  console.log("\nAC5c: messages from my profileId are normalized direction='out'");
   const env = buildEnv();
   env.storage.accountId = 1;
-  env.storage.xLiTrack = '{"clientVersion":"1.13.42912"}';
-  env.storage.csrfToken = "ajax:abc123";
+  env.storage.csrfToken = "SYNC_CSRF";
+  env.storage.messagingContract = FRESH_CONTRACT;
   loadBackground(env);
 
   const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
   assert(resp.ok === true, "sync response is ok");
 
-  const syncCall = env.fetchLog.find(f => f.url.includes("/sync"));
-  assert(!!syncCall, "POST /sync was called");
-  if (syncCall) {
-    const body = JSON.parse(syncCall.options.body);
-    assert(body.account_id === 1, "account_id passed to sync");
-    assert(body.x_li_track === '{"clientVersion":"1.13.42912"}', "x_li_track threaded into sync payload");
-    assert(body.csrf_token === "ajax:abc123", "csrf_token threaded into sync payload");
+  const ingestCall = findIngestCall(env);
+  if (ingestCall) {
+    const body = JSON.parse(ingestCall.options.body);
+    const allMessages = body.threads.flatMap((t) => t.messages);
+    const outMessages = allMessages.filter((m) => m.direction === "out");
+    assert(outMessages.length >= 1, "at least one message normalized as direction='out' for my profile id");
   }
 }
 
@@ -478,52 +628,86 @@ async function testAC7c_messagingContractNoSecrets() {
   const contractStr = JSON.stringify(contract);
   assert(!contractStr.includes("super-secret-li-at-token"), "li_at cookie value not in stored contract");
   assert(!contractStr.includes("js123"), "JSESSIONID value not in stored contract");
-  // The contract must not include any field named 'cookie'
   assert(!Object.prototype.hasOwnProperty.call(contract, "cookie"), "no cookie field on contract object");
 }
 
-async function testAC5d_manualSyncIncludesMessagingContract() {
-  console.log("\nAC5d: MANUAL_SYNC includes messaging_contract when previously captured");
+async function testAC8_manualSyncFailsWithoutContract() {
+  console.log("\nAC8: MANUAL_SYNC fails visibly when messaging contract is missing");
   const env = buildEnv();
   env.storage.accountId = 1;
+  env.storage.csrfToken = "SYNC_CSRF";
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  assert(resp.ok === false, "sync response is not ok when contract missing");
+  assert(/contract/i.test(resp.error || ""), "error message mentions contract");
+  const ingestCall = findIngestCall(env);
+  assert(!ingestCall, "POST /sync/ingest was NOT called when contract missing");
+}
+
+async function testAC8b_manualSyncFailsWithStaleContract() {
+  console.log("\nAC8b: MANUAL_SYNC fails when contract is stale (older than freshness window)");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  env.storage.csrfToken = "SYNC_CSRF";
+  // ~30 days old
   env.storage.messagingContract = {
-    conversationsQueryId: "messengerConversations.live123",
-    messagesQueryId: "messengerMessages.live456",
-    endpointPath: "/voyager/api/voyagerMessagingGraphQL/graphql",
-    capturedAt: "2026-04-27T10:00:00.000Z",
+    ...FRESH_CONTRACT,
+    capturedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString(),
   };
   loadBackground(env);
 
   const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
-  assert(resp.ok === true, "sync response is ok");
-
-  const syncCall = env.fetchLog.find((f) => f.url.includes("/sync"));
-  assert(!!syncCall, "POST /sync was called");
-  if (syncCall) {
-    const body = JSON.parse(syncCall.options.body);
-    assert(!!body.messaging_contract, "messaging_contract field present in sync payload");
-    assert(
-      body.messaging_contract.conversationsQueryId === "messengerConversations.live123",
-      "live conversationsQueryId forwarded to sync"
-    );
-    assert(
-      body.messaging_contract.messagesQueryId === "messengerMessages.live456",
-      "live messagesQueryId forwarded to sync"
-    );
-  }
+  assert(resp.ok === false, "sync response is not ok when contract is stale");
+  assert(/(stale|contract|refresh)/i.test(resp.error || ""), "error message hints at staleness");
 }
 
-async function testAC5e_manualSyncNullContractWhenNotCaptured() {
-  console.log("\nAC5e: MANUAL_SYNC sends messaging_contract: null when nothing captured");
+async function testAC8c_manualSyncFailsWithoutCsrf() {
+  console.log("\nAC8c: MANUAL_SYNC fails visibly when csrf-token has not been captured");
   const env = buildEnv();
   env.storage.accountId = 1;
+  env.storage.messagingContract = FRESH_CONTRACT;
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  assert(resp.ok === false, "sync response is not ok when csrf missing");
+  assert(/csrf/i.test(resp.error || ""), "error message mentions csrf");
+}
+
+async function testAC8d_extensionNeverLogsCookiesOrCsrf() {
+  console.log("\nAC8d: extension never logs cookie / csrf / li_at values during MANUAL_SYNC");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  env.storage.csrfToken = "ajax:super-secret-csrf-DO-NOT-LEAK";
+  env.storage.xLiTrack = '{"clientVersion":"1.13.42912"}';
+  env.storage.messagingContract = FRESH_CONTRACT;
   loadBackground(env);
 
   await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
-  const syncCall = env.fetchLog.find((f) => f.url.includes("/sync"));
-  if (syncCall) {
-    const body = JSON.parse(syncCall.options.body);
-    assert(body.messaging_contract === null, "messaging_contract is null when not captured");
+  const allLogs = env.consoleCalls.map((c) => c.slice(1).map(String).join(" ")).join("\n");
+  assert(!allLogs.includes("ajax:super-secret-csrf-DO-NOT-LEAK"), "csrf-token value not logged");
+  assert(!allLogs.includes("fake-li-at-token"), "li_at value not logged");
+  assert(!allLogs.toLowerCase().includes("cookie:"), "no 'cookie:' string emitted to console");
+}
+
+async function testAC9_csrfHeaderSentToLinkedIn() {
+  console.log("\nAC9: extension forwards captured csrf-token on LinkedIn requests");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  env.storage.csrfToken = "ajax:lnk-csrf";
+  env.storage.xLiTrack = '{"clientVersion":"1.13.42912"}';
+  env.storage.messagingContract = FRESH_CONTRACT;
+  loadBackground(env);
+
+  await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  const meCall = env.fetchLog.find(f => f.url.startsWith("https://www.linkedin.com/voyager/api/me"));
+  if (meCall) {
+    const headers = meCall.options.headers || {};
+    // Headers may use any casing; normalize.
+    const lower = Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+    assert(lower["csrf-token"] === "ajax:lnk-csrf", "csrf-token header sent to LinkedIn /me");
+  } else {
+    assert(false, "/me call missing");
   }
 }
 
@@ -539,16 +723,18 @@ async function main() {
   await testAC3_ignoresRemovedCookie();
   await testAC3_ignoresNonLinkedIn();
   await testAC4_headerCapture();
-  await testAC5_manualSync();
-  await testAC5c_manualSyncWithoutCapturedHeaders();
+  await testAC5_manualSyncReadsLinkedInAndIngests();
   await testAC5b_manualSyncIncludesBearerToken();
-  await testAC5c_manualSyncThreadsBrowserContext();
+  await testAC5c_extensionDirectionForMyMessages();
   await testAC6_manualRefresh();
   await testAC7_messagingContractConversations();
   await testAC7b_messagingContractMessages();
   await testAC7c_messagingContractNoSecrets();
-  await testAC5d_manualSyncIncludesMessagingContract();
-  await testAC5e_manualSyncNullContractWhenNotCaptured();
+  await testAC8_manualSyncFailsWithoutContract();
+  await testAC8b_manualSyncFailsWithStaleContract();
+  await testAC8c_manualSyncFailsWithoutCsrf();
+  await testAC8d_extensionNeverLogsCookiesOrCsrf();
+  await testAC9_csrfHeaderSentToLinkedIn();
 
   console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
   process.exit(failed > 0 ? 1 : 0);

--- a/libs/core/job_runner.py
+++ b/libs/core/job_runner.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional
 
 from libs.core.storage import Storage
 from libs.providers.linkedin.provider import LinkedInProvider
@@ -21,6 +21,23 @@ def _normalize_sent_at(dt: datetime) -> datetime:
     if dt.tzinfo is None:
         return dt.replace(tzinfo=timezone.utc)
     return dt
+
+
+@dataclass(frozen=True)
+class IngestMessage:
+    platform_message_id: str
+    direction: str  # "in" | "out"
+    sender: Optional[str]
+    text: Optional[str]
+    sent_at: datetime
+    raw: Optional[dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class IngestThread:
+    platform_thread_id: str
+    title: Optional[str]
+    messages: list[IngestMessage] = field(default_factory=list)
 
 
 @dataclass
@@ -142,6 +159,58 @@ def run_sync(
         messages_skipped_duplicate=messages_skipped,
         pages_fetched=pages_fetched,
         rate_limited=provider.rate_limit_encountered,
+    )
+
+
+def run_ingest(
+    *,
+    account_id: int,
+    storage: Storage,
+    threads: list[IngestThread],
+    pages_fetched: int = 0,
+    rate_limited: bool = False,
+) -> SyncResult:
+    """Persist normalized threads/messages captured by the Chrome extension.
+
+    Mirrors run_sync's storage path (upsert_thread + insert_message) so the
+    counts returned are SyncResult-compatible. The caller (extension) has
+    already done the LinkedIn read, so this function never touches the
+    network. Duplicate ``platform_message_id`` rows are silently skipped and
+    counted under ``messages_skipped_duplicate``.
+    """
+    synced_threads = 0
+    messages_inserted = 0
+    messages_skipped = 0
+
+    for t in threads:
+        thread_id = storage.upsert_thread(
+            account_id=account_id,
+            platform_thread_id=t.platform_thread_id,
+            title=t.title,
+        )
+        for m in t.messages:
+            inserted = storage.insert_message(
+                account_id=account_id,
+                thread_id=thread_id,
+                platform_message_id=m.platform_message_id,
+                direction=m.direction,
+                sender=m.sender,
+                text=m.text,
+                sent_at=_normalize_sent_at(m.sent_at),
+                raw=m.raw,
+            )
+            if inserted:
+                messages_inserted += 1
+            else:
+                messages_skipped += 1
+        synced_threads += 1
+
+    return SyncResult(
+        synced_threads=synced_threads,
+        messages_inserted=messages_inserted,
+        messages_skipped_duplicate=messages_skipped,
+        pages_fetched=pages_fetched,
+        rate_limited=rate_limited,
     )
 
 

--- a/tests/test_sync_send.py
+++ b/tests/test_sync_send.py
@@ -998,3 +998,244 @@ def test_provider_build_headers_falls_back_to_jsessionid():
     provider = LinkedInProvider(auth=auth)
     headers = provider._build_headers()
     assert headers["csrf-token"] == "ajax:session"
+
+
+# --- /sync/ingest tests (extension-first MVP) ---
+
+
+def _ingest_payload(account_id: int, **overrides):
+    body = {
+        "account_id": account_id,
+        "threads": [
+            {
+                "platform_thread_id": "urn:li:msg_conversation:1",
+                "title": "Alice Example",
+                "messages": [
+                    {
+                        "platform_message_id": "msg-1",
+                        "direction": "in",
+                        "sender": "Alice Example",
+                        "text": "Hi there",
+                        "sent_at": "2026-04-27T10:00:00+00:00",
+                    },
+                    {
+                        "platform_message_id": "msg-2",
+                        "direction": "out",
+                        "sender": "Me",
+                        "text": "Hello",
+                        "sent_at": "2026-04-27T10:01:00+00:00",
+                    },
+                ],
+            },
+            {
+                "platform_thread_id": "urn:li:msg_conversation:2",
+                "title": "Bob",
+                "messages": [
+                    {
+                        "platform_message_id": "msg-3",
+                        "direction": "in",
+                        "sender": "Bob",
+                        "text": "Yo",
+                        "sent_at": "2026-04-27T09:00:00+00:00",
+                    },
+                ],
+            },
+        ],
+        "pages_fetched": 3,
+        "rate_limited": False,
+    }
+    body.update(overrides)
+    return body
+
+
+def test_ingest_endpoint_404_for_unknown_account(db_path):
+    from unittest.mock import patch
+    from fastapi.testclient import TestClient
+    from apps.api.main import app
+
+    empty_storage = Storage(db_path=db_path)
+    empty_storage.migrate()
+    try:
+        with patch("apps.api.main.storage", empty_storage):
+            client = TestClient(app)
+            resp = client.post("/sync/ingest", json=_ingest_payload(1))
+        assert resp.status_code == 404
+    finally:
+        empty_storage.close()
+
+
+def test_ingest_endpoint_returns_counts(storage, account_id):
+    from unittest.mock import patch
+    from fastapi.testclient import TestClient
+    from apps.api.main import app
+
+    with patch("apps.api.main.storage", storage):
+        client = TestClient(app)
+        resp = client.post("/sync/ingest", json=_ingest_payload(account_id))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["synced_threads"] == 2
+    assert data["messages_inserted"] == 3
+    assert data["messages_skipped_duplicate"] == 0
+    assert data["pages_fetched"] == 3
+    assert data["rate_limited"] is False
+
+
+def test_ingest_endpoint_dedupe_on_repeat(storage, account_id):
+    """A second ingest with the same payload reports 0 inserts and N duplicates."""
+    from unittest.mock import patch
+    from fastapi.testclient import TestClient
+    from apps.api.main import app
+
+    with patch("apps.api.main.storage", storage):
+        client = TestClient(app)
+        first = client.post("/sync/ingest", json=_ingest_payload(account_id))
+        assert first.status_code == 200
+        assert first.json()["messages_inserted"] == 3
+
+        second = client.post("/sync/ingest", json=_ingest_payload(account_id))
+    assert second.status_code == 200
+    data = second.json()
+    assert data["messages_inserted"] == 0
+    assert data["messages_skipped_duplicate"] == 3
+    assert data["synced_threads"] == 2
+
+
+def test_ingest_endpoint_persists_threads_and_messages(storage, account_id):
+    from unittest.mock import patch
+    from fastapi.testclient import TestClient
+    from apps.api.main import app
+
+    with patch("apps.api.main.storage", storage):
+        client = TestClient(app)
+        resp = client.post("/sync/ingest", json=_ingest_payload(account_id))
+    assert resp.status_code == 200
+    threads = storage.list_threads(account_id=account_id)
+    titles = {t["platform_thread_id"]: t["title"] for t in threads}
+    assert titles == {
+        "urn:li:msg_conversation:1": "Alice Example",
+        "urn:li:msg_conversation:2": "Bob",
+    }
+    rows = storage._conn.execute(
+        "SELECT platform_message_id, direction, text FROM messages WHERE account_id=? ORDER BY platform_message_id",
+        (account_id,),
+    ).fetchall()
+    assert [r["platform_message_id"] for r in rows] == ["msg-1", "msg-2", "msg-3"]
+    assert [r["direction"] for r in rows] == ["in", "out", "in"]
+
+
+def test_ingest_endpoint_422_when_threads_missing(storage, account_id):
+    from unittest.mock import patch
+    from fastapi.testclient import TestClient
+    from apps.api.main import app
+
+    with patch("apps.api.main.storage", storage):
+        client = TestClient(app)
+        resp = client.post("/sync/ingest", json={"account_id": account_id})
+    assert resp.status_code == 422
+
+
+def test_ingest_endpoint_422_for_invalid_direction(storage, account_id):
+    from unittest.mock import patch
+    from fastapi.testclient import TestClient
+    from apps.api.main import app
+
+    body = _ingest_payload(account_id)
+    body["threads"][0]["messages"][0]["direction"] = "sideways"
+
+    with patch("apps.api.main.storage", storage):
+        client = TestClient(app)
+        resp = client.post("/sync/ingest", json=body)
+    assert resp.status_code == 422
+
+
+def test_ingest_endpoint_does_not_log_secrets(storage, account_id, caplog):
+    """Ingest must not log cookie / csrf values even if attached to payload metadata."""
+    import logging
+    from unittest.mock import patch
+    from fastapi.testclient import TestClient
+    from apps.api.main import app
+
+    body = _ingest_payload(account_id)
+    body["messaging_contract"] = {
+        "conversationsQueryId": "messengerConversations.live",
+        "messagesQueryId": "messengerMessages.live",
+        "endpointPath": "/voyager/api/voyagerMessagingGraphQL/graphql",
+        "capturedAt": "2026-04-27T10:00:00.000Z",
+    }
+    secret_li_at = "should-never-appear-li-at-secret"
+    secret_csrf = "ajax:should-never-appear-csrf"
+
+    with patch("apps.api.main.storage", storage):
+        client = TestClient(app)
+        with caplog.at_level(logging.DEBUG):
+            resp = client.post(
+                "/sync/ingest",
+                json=body,
+                headers={
+                    "x-li-at": secret_li_at,
+                    "x-csrf-token": secret_csrf,
+                },
+            )
+    assert resp.status_code == 200
+    blob = "\n".join(r.getMessage() for r in caplog.records)
+    assert secret_li_at not in blob
+    assert secret_csrf not in blob
+
+
+def test_ingest_endpoint_propagates_rate_limited_flag(storage, account_id):
+    from unittest.mock import patch
+    from fastapi.testclient import TestClient
+    from apps.api.main import app
+
+    body = _ingest_payload(account_id, rate_limited=True)
+
+    with patch("apps.api.main.storage", storage):
+        client = TestClient(app)
+        resp = client.post("/sync/ingest", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["rate_limited"] is True
+
+
+def test_ingest_helper_counts_inserts_and_duplicates(storage, account_id):
+    """Direct helper test: run_ingest stores threads/messages with dedupe semantics."""
+    from datetime import datetime, timezone
+
+    from libs.core.job_runner import IngestThread, IngestMessage, run_ingest
+
+    threads = [
+        IngestThread(
+            platform_thread_id="t1",
+            title="Tee One",
+            messages=[
+                IngestMessage(
+                    platform_message_id="m1",
+                    direction="in",
+                    sender="A",
+                    text="hi",
+                    sent_at=datetime(2026, 4, 27, tzinfo=timezone.utc),
+                    raw=None,
+                ),
+                IngestMessage(
+                    platform_message_id="m2",
+                    direction="out",
+                    sender=None,
+                    text="hey",
+                    sent_at=datetime(2026, 4, 27, 0, 1, tzinfo=timezone.utc),
+                    raw=None,
+                ),
+            ],
+        ),
+    ]
+    first = run_ingest(account_id=account_id, storage=storage, threads=threads, pages_fetched=1, rate_limited=False)
+    assert first.synced_threads == 1
+    assert first.messages_inserted == 2
+    assert first.messages_skipped_duplicate == 0
+    assert first.pages_fetched == 1
+    assert first.rate_limited is False
+
+    second = run_ingest(account_id=account_id, storage=storage, threads=threads, pages_fetched=1, rate_limited=True)
+    assert second.messages_inserted == 0
+    assert second.messages_skipped_duplicate == 2
+    assert second.rate_limited is True


### PR DESCRIPTION
Files changed: apps/api/main.py — added authenticated POST /sync/ingest with IngestIn/IngestThreadIn/IngestMessageIn models, account existence validation, redacted ingest logging, and SyncResult-compatible response fields; libs/core/job_runner.py — added IngestThread/IngestMessage dataclasses plus run_ingest(), reusing existing libs/core/storage.py upsert_thread and insert_message dedupe semantics without changing storage code; chrome-extension/background.js — switched MANUAL_SYNC to extension-first LinkedIn reads via /voyager/api/me plus messaging GraphQL using captured contract/headers, added missing-contract, stale-contract, and missing-csrf failures, normalized thread/message payloads, and POSTed /sync/ingest instead of legacy /sync; chrome-extension/popup.js — kept popup sync UX and now shows synced threads, new messages, duplicate skips, and rate-limit hint; tests/test_sync_send.py — added ingest endpoint/helper coverage for validation, dedupe/counts, persistence, rate_limited propagation, and redacted logging; chrome-extension/test_background.mjs — updated acceptance tests for browser-driven sync, ingest payload construction, no-secret logging, auth header forwarding, and missing/stale contract failure paths. Tests added or modified: tests/test_sync_send.py ingest suite covering 404 account validation, 422 payload validation, dedupe/count semantics, stored thread/message persistence, rate_limited passthrough, and no-secret logging; chrome-extension/test_background.mjs AC5/AC8/AC9 scenarios covering extension-first sync, ingest payload shape, legacy /sync not being used, Authorization forwarding, direction normalization, missing contract failure, stale contract failure, missing csrf failure, and no cookie/csrf/li_at console leakage. Verification result: git diff HEAD~1..HEAD --stat showed 6 changed files with real code changes; git log --oneline -3 showed top commit 59dc36a feat(#524): extension-first inbox sync ingest MVP; grep verification confirmed /sync/ingest, run_ingest, popup result text, and manual sync path updates; uv run pytest -q -> 417 passed; node chrome-extension/test_background.mjs -> 88 passed, 0 failed; git status --short -> clean after removing generated uv.lock from local verification. Anything noteworthy: manual Sync Now no longer depends on backend Python/httpx to initiate LinkedIn inbox reads; first-MVP scope intentionally stays low-volume at first conversations page plus first messages page per thread; backend ingest intentionally reuses existing storage dedupe primitives rather than duplicating storage logic; only safe messaging contract metadata is forwarded to ingest, with no raw cookies, csrf tokens, or message secrets logged.

---
Task: #524 — Build extension-first LinkedIn inbox sync MVP with backend ingest
Opened automatically by mission-control dispatcher.