### PR TITLE
Make LinkedIn extension loading deterministic with local preflight harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,41 @@ Security posture for local development:
 - set `DESEARCH_API_TOKEN` if other local processes should not be able to drive the API
 - configure the same bearer token in the Chrome extension popup when API auth is enabled
 
+## Chrome extension preflight
+
+Before validating the extension-button sync path, run the local API and launch or
+verify Chrome through the deterministic preflight harness:
+
+```bash
+uvicorn apps.api.main:app --host 127.0.0.1 --port 8899
+uv run python scripts/extension_preflight.py --launch
+```
+
+The preflight checks `GET /health` at `http://127.0.0.1:8899`, starts or verifies
+Chrome on CDP port `18800`, loads the unpacked extension from
+`chrome-extension/`, verifies the expected extension target through CDP, and
+opens <https://www.linkedin.com/messaging/> so the extension can capture the
+current messaging contract before `Sync Now`.
+
+Useful knobs:
+
+```bash
+uv run python scripts/extension_preflight.py --help
+uv run python scripts/extension_preflight.py \
+  --backend-url http://127.0.0.1:8899 \
+  --cdp-port 18800 \
+  --profile-dir ~/.desearch-linkedin-dms/chrome-profile \
+  --extension-path ./chrome-extension \
+  --launch
+```
+
+Use a Chrome profile that is signed in to LinkedIn for live validation. If you
+use a custom backend URL or API token, set the matching service URL/token in the
+extension popup before pressing `Refresh` or `Sync Now`. The harness prints only
+redacted operational status; it must not be used to dump LinkedIn session
+secrets, browser CSRF material, or local API auth values.
+
+
 ### API request and response shape
 
 `GET /health`

--- a/scripts/extension_preflight.py
+++ b/scripts/extension_preflight.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Deterministic local preflight for the LinkedIn DMs Chrome extension.
+
+The script verifies the local API, optionally launches Chrome with the unpacked
+extension source, checks CDP for the expected extension target, and opens
+LinkedIn messaging so the extension can capture the current browser contract.
+It intentionally prints only operational status and never dumps cookies,
+headers, authorization values, or response bodies.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urljoin, urlparse
+from urllib.request import Request, urlopen
+
+EXTENSION_NAME = "Desearch LinkedIn DMs Bridge"
+DEFAULT_BACKEND_URL = "http://127.0.0.1:8899"
+EXTENSION_DEFAULT_BACKEND_URL = "http://localhost:8899"
+DEFAULT_CDP_HOST = "127.0.0.1"
+DEFAULT_CDP_PORT = 18800
+LINKEDIN_MESSAGING_URL = "https://www.linkedin.com/messaging/"
+SENSITIVE_TERMS = (
+    "li_at",
+    "JSESSIONID",
+    "csrf-token",
+    "csrf_token",
+    "Authorization",
+    "Bearer",
+    "cookie",
+    "token",
+)
+
+
+class PreflightError(Exception):
+    """Expected preflight failure with an operator-safe message."""
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def default_extension_path() -> Path:
+    return repo_root() / "chrome-extension"
+
+
+def default_profile_dir() -> Path:
+    return Path.home() / ".desearch-linkedin-dms" / "chrome-profile"
+
+
+def sanitize_for_output(value: Any) -> str:
+    """Return a conservative, single-line status string safe for operator logs."""
+    text = str(value).replace("\n", " ").replace("\r", " ")
+    if any(term.lower() in text.lower() for term in SENSITIVE_TERMS):
+        return "redacted sensitive details"
+    return text[:240]
+
+
+def normalize_url(url: str) -> str:
+    trimmed = url.strip().rstrip("/")
+    parsed = urlparse(trimmed)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise PreflightError(f"Invalid backend URL: {sanitize_for_output(url)}")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise PreflightError("Backend URL must be a plain local API base URL without credentials, query, or fragment.")
+    return trimmed
+
+
+def fetch_json(url: str, timeout_s: float = 5.0) -> Any:
+    request = Request(url, headers={"Accept": "application/json"})
+    with urlopen(request, timeout=timeout_s) as response:  # noqa: S310 - local operator URL/CDP only.
+        raw = response.read(1024 * 1024)
+    if not raw:
+        return None
+    return json.loads(raw.decode("utf-8"))
+
+
+def request_json(url: str, method: str = "GET", timeout_s: float = 5.0) -> Any:
+    request = Request(url, method=method, headers={"Accept": "application/json"})
+    with urlopen(request, timeout=timeout_s) as response:  # noqa: S310 - local CDP endpoint.
+        raw = response.read(1024 * 1024)
+    if not raw:
+        return None
+    return json.loads(raw.decode("utf-8"))
+
+
+def health_url(backend_url: str) -> str:
+    return urljoin(f"{backend_url}/", "health")
+
+
+def check_backend_health(backend_url: str, timeout_s: float) -> None:
+    url = health_url(backend_url)
+    try:
+        data = fetch_json(url, timeout_s=timeout_s)
+    except (HTTPError, URLError, OSError, json.JSONDecodeError) as exc:
+        raise PreflightError(
+            f"Backend health failed for {url}. Start the API with: "
+            "uvicorn apps.api.main:app --host 127.0.0.1 --port 8899 "
+            f"({sanitize_for_output(exc)})"
+        ) from exc
+
+    if not isinstance(data, dict) or data.get("ok") is not True:
+        raise PreflightError(
+            f"Backend health failed for {url}: expected JSON {{'ok': true}}; "
+            "received non-OK health response."
+        )
+
+
+def cdp_base_url(host: str, port: int) -> str:
+    return f"http://{host}:{port}"
+
+
+def check_cdp_reachable(host: str, port: int, timeout_s: float) -> dict[str, Any]:
+    url = f"{cdp_base_url(host, port)}/json/version"
+    try:
+        data = fetch_json(url, timeout_s=timeout_s)
+    except (HTTPError, URLError, OSError, json.JSONDecodeError) as exc:
+        raise PreflightError(
+            f"Chrome CDP is not reachable on {host}:{port}. Run with --launch "
+            "or start Chrome with --remote-debugging-port set. "
+            f"({sanitize_for_output(exc)})"
+        ) from exc
+    if not isinstance(data, dict):
+        raise PreflightError(f"Chrome CDP returned an invalid /json/version response on {host}:{port}.")
+    return data
+
+
+def extension_id_for_path(extension_path: Path) -> str:
+    """Return Chromium's deterministic unpacked-extension id for a path.
+
+    Chromium maps the first 16 SHA-256 bytes of the absolute extension path to
+    letters a-p. This is the same id Chrome uses for unpacked extensions that do
+    not declare a manifest `key`, letting the preflight verify the specific local
+    source path instead of accepting any background.js service worker.
+    """
+    digest = hashlib.sha256(str(extension_path.resolve()).encode("utf-8")).digest()[:16]
+    return "".join(chr(ord("a") + nibble) for byte in digest for nibble in (byte >> 4, byte & 0x0F))
+
+
+def load_manifest_name(extension_path: Path) -> str:
+    manifest_path = extension_path / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PreflightError(f"Cannot read extension manifest at {manifest_path}: {sanitize_for_output(exc)}") from exc
+    name = manifest.get("name")
+    if name != EXTENSION_NAME:
+        raise PreflightError(
+            f"Extension manifest name mismatch at {manifest_path}: expected {EXTENSION_NAME!r}."
+        )
+    return name
+
+
+def list_cdp_targets(host: str, port: int, timeout_s: float) -> list[dict[str, Any]]:
+    url = f"{cdp_base_url(host, port)}/json/list"
+    try:
+        data = fetch_json(url, timeout_s=timeout_s)
+    except (HTTPError, URLError, OSError, json.JSONDecodeError) as exc:
+        raise PreflightError(f"Could not list Chrome CDP targets on {host}:{port}: {sanitize_for_output(exc)}") from exc
+    if not isinstance(data, list):
+        raise PreflightError(f"Chrome CDP /json/list returned an invalid target list on {host}:{port}.")
+    return [target for target in data if isinstance(target, dict)]
+
+
+def target_matches_extension(target: dict[str, Any], extension_id: str) -> bool:
+    url = str(target.get("url") or "")
+    return url.startswith(f"chrome-extension://{extension_id}/")
+
+
+def find_extension_target(targets: list[dict[str, Any]], extension_id: str) -> dict[str, Any] | None:
+    for target in targets:
+        if target_matches_extension(target, extension_id):
+            return target
+    return None
+
+
+def open_cdp_url(host: str, port: int, target_url: str, timeout_s: float = 5.0) -> Any:
+    encoded = quote(target_url, safe=":/?=&%#")
+    endpoint = f"{cdp_base_url(host, port)}/json/new?{encoded}"
+    try:
+        return request_json(endpoint, method="PUT", timeout_s=timeout_s)
+    except HTTPError as exc:
+        if exc.code not in {404, 405}:
+            raise
+        return request_json(endpoint, method="GET", timeout_s=timeout_s)
+
+
+def wake_extension_target(host: str, port: int, extension_id: str, timeout_s: float) -> None:
+    try:
+        open_cdp_url(host, port, f"chrome-extension://{extension_id}/popup.html", timeout_s=timeout_s)
+    except (HTTPError, URLError, OSError, json.JSONDecodeError):
+        # Best effort only. The subsequent target check produces the actionable error.
+        return
+
+
+def verify_extension_loaded(
+    host: str,
+    port: int,
+    extension_path: Path,
+    extension_id: str | None,
+    timeout_s: float,
+    wake: bool = True,
+) -> tuple[str, dict[str, Any]]:
+    load_manifest_name(extension_path)
+    expected_id = extension_id or extension_id_for_path(extension_path)
+
+    target = find_extension_target(list_cdp_targets(host, port, timeout_s), expected_id)
+    if not target and wake:
+        wake_extension_target(host, port, expected_id, timeout_s)
+        target = find_extension_target(list_cdp_targets(host, port, timeout_s), expected_id)
+
+    if not target:
+        raise PreflightError(
+            f"{EXTENSION_NAME} extension is not loaded from {extension_path.resolve()} in Chrome CDP {host}:{port}. "
+            "Launch Chrome with --load-extension pointing at that directory, or rerun this preflight with --launch. "
+            f"Expected extension id: {expected_id}."
+        )
+    return expected_id, target
+
+
+def find_chrome_binary(explicit: str | None) -> str:
+    if explicit:
+        path = Path(explicit).expanduser()
+        if not path.exists():
+            raise PreflightError(f"Chrome binary not found: {path}")
+        return str(path)
+
+    candidates: list[str] = []
+    if platform.system() == "Darwin":
+        candidates.extend(
+            [
+                "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+                str(Path.home() / "Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+                "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            ]
+        )
+    candidates.extend(["google-chrome", "google-chrome-stable", "chromium", "chromium-browser"])
+
+    for candidate in candidates:
+        if os.path.isabs(candidate):
+            if Path(candidate).exists():
+                return candidate
+        else:
+            from shutil import which
+
+            resolved = which(candidate)
+            if resolved:
+                return resolved
+    raise PreflightError("Chrome binary not found. Pass --chrome-binary explicitly.")
+
+
+def launch_chrome(
+    chrome_binary: str | None,
+    host: str,
+    port: int,
+    profile_dir: Path,
+    extension_path: Path,
+    open_messaging: bool,
+) -> subprocess.Popen[Any]:
+    binary = find_chrome_binary(chrome_binary)
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    extension_arg = str(extension_path.resolve())
+    args = [
+        binary,
+        f"--remote-debugging-address={host}",
+        f"--remote-debugging-port={port}",
+        f"--user-data-dir={profile_dir.expanduser().resolve()}",
+        f"--disable-extensions-except={extension_arg}",
+        f"--load-extension={extension_arg}",
+        "--no-first-run",
+        "--no-default-browser-check",
+    ]
+    if open_messaging:
+        args.append(LINKEDIN_MESSAGING_URL)
+    return subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)  # noqa: S603
+
+
+def ensure_chrome(
+    launch: bool,
+    chrome_binary: str | None,
+    host: str,
+    port: int,
+    profile_dir: Path,
+    extension_path: Path,
+    timeout_s: float,
+    open_messaging: bool,
+) -> dict[str, Any]:
+    try:
+        return check_cdp_reachable(host, port, timeout_s=min(timeout_s, 2.0))
+    except PreflightError:
+        if not launch:
+            raise
+
+    launch_chrome(chrome_binary, host, port, profile_dir, extension_path, open_messaging)
+    deadline = time.monotonic() + max(timeout_s, 1.0)
+    last_error: PreflightError | None = None
+    while time.monotonic() < deadline:
+        try:
+            return check_cdp_reachable(host, port, timeout_s=1.0)
+        except PreflightError as exc:
+            last_error = exc
+            time.sleep(0.25)
+    raise PreflightError(
+        f"Launched Chrome but CDP did not become reachable on {host}:{port}. "
+        f"Last status: {sanitize_for_output(last_error or 'unknown')}"
+    )
+
+
+def maybe_open_messaging(host: str, port: int, timeout_s: float) -> None:
+    try:
+        open_cdp_url(host, port, LINKEDIN_MESSAGING_URL, timeout_s=timeout_s)
+    except (HTTPError, URLError, OSError, json.JSONDecodeError) as exc:
+        raise PreflightError(
+            f"Could not open {LINKEDIN_MESSAGING_URL} through CDP on {host}:{port}: {sanitize_for_output(exc)}"
+        ) from exc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Preflight/launch a local Chrome profile with the unpacked "
+            "Desearch LinkedIn DMs Bridge extension loaded."
+        ),
+        epilog=(
+            "Typical use: uv run python scripts/extension_preflight.py --launch. "
+            f"The run checks backend /health, verifies the extension target through CDP, "
+            f"and opens {LINKEDIN_MESSAGING_URL} for messaging contract capture. "
+            "No LinkedIn session secrets or local API auth values are printed."
+        ),
+    )
+    parser.add_argument("--backend-url", default=DEFAULT_BACKEND_URL, help="Local API base URL to health-check (default: %(default)s).")
+    parser.add_argument("--cdp-host", default=DEFAULT_CDP_HOST, help="Chrome DevTools Protocol host (default: %(default)s).")
+    parser.add_argument("--cdp-port", type=int, default=DEFAULT_CDP_PORT, help="Chrome DevTools Protocol port (default: %(default)s).")
+    parser.add_argument(
+        "--profile-dir",
+        type=Path,
+        default=default_profile_dir(),
+        help="Chrome user-data-dir for --launch (default: %(default)s). Use a signed-in profile for live validation.",
+    )
+    parser.add_argument(
+        "--extension-path",
+        type=Path,
+        default=default_extension_path(),
+        help="Unpacked extension source directory to load/verify (default: %(default)s).",
+    )
+    parser.add_argument("--extension-id", help="Override the deterministic unpacked extension id when verifying an already-loaded profile.")
+    parser.add_argument("--chrome-binary", help="Chrome/Chromium executable path for --launch.")
+    parser.add_argument("--launch", action="store_true", help="Launch Chrome if CDP is not already reachable on the requested host/port.")
+    parser.add_argument("--timeout", type=float, default=15.0, help="Seconds to wait for local backend/CDP operations (default: %(default)s).")
+    parser.add_argument(
+        "--no-open-messaging",
+        action="store_true",
+        help=f"Do not open {LINKEDIN_MESSAGING_URL} after verifying the extension.",
+    )
+    parser.add_argument(
+        "--no-extension-wake",
+        action="store_true",
+        help="Do not open the extension popup page to wake a dormant MV3 service worker before target verification.",
+    )
+    return parser
+
+
+def print_status(message: str) -> None:
+    print(message, flush=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        backend_url = normalize_url(args.backend_url)
+        extension_path = args.extension_path.expanduser().resolve()
+        profile_dir = args.profile_dir.expanduser()
+        open_messaging = not args.no_open_messaging
+
+        check_backend_health(backend_url, timeout_s=args.timeout)
+        print_status(f"OK Backend health OK: {health_url(backend_url)}")
+
+        browser_info = ensure_chrome(
+            launch=args.launch,
+            chrome_binary=args.chrome_binary,
+            host=args.cdp_host,
+            port=args.cdp_port,
+            profile_dir=profile_dir,
+            extension_path=extension_path,
+            timeout_s=args.timeout,
+            open_messaging=open_messaging,
+        )
+        browser_name = sanitize_for_output(browser_info.get("Browser", "Chrome"))
+        print_status(f"OK Chrome CDP reachable: {args.cdp_host}:{args.cdp_port} ({browser_name})")
+
+        extension_id, target = verify_extension_loaded(
+            host=args.cdp_host,
+            port=args.cdp_port,
+            extension_path=extension_path,
+            extension_id=args.extension_id,
+            timeout_s=args.timeout,
+            wake=not args.no_extension_wake,
+        )
+        target_type = sanitize_for_output(target.get("type", "target"))
+        print_status(f"OK Extension loaded: {EXTENSION_NAME} ({target_type}, id={extension_id})")
+
+        if backend_url in {DEFAULT_BACKEND_URL, EXTENSION_DEFAULT_BACKEND_URL}:
+            print_status(f"OK Extension backend default matches local API: {EXTENSION_DEFAULT_BACKEND_URL}")
+        else:
+            print_status(
+                "ACTION Custom backend URL checked. Set the same service URL in the extension popup before Sync Now."
+            )
+
+        if open_messaging:
+            maybe_open_messaging(args.cdp_host, args.cdp_port, timeout_s=args.timeout)
+            print_status(f"OK Opened LinkedIn messaging for contract capture: {LINKEDIN_MESSAGING_URL}")
+        else:
+            print_status(f"ACTION Open LinkedIn messaging before Sync Now: {LINKEDIN_MESSAGING_URL}")
+
+        print_status("OK Preflight complete. If signed in, use the extension popup Refresh/Sync Now flow next.")
+        return 0
+    except PreflightError as exc:
+        print_status(f"FAIL {sanitize_for_output(exc)}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_extension_preflight.py
+++ b/tests/test_extension_preflight.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from urllib.error import URLError
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "extension_preflight.py"
+
+
+def load_preflight_module():
+    spec = importlib.util.spec_from_file_location("extension_preflight", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_help_documents_operational_knobs(capsys):
+    preflight = load_preflight_module()
+
+    with pytest.raises(SystemExit) as exc:
+        preflight.main(["--help"])
+
+    assert exc.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "--cdp-port" in help_text
+    assert "--profile-dir" in help_text
+    assert "--extension-path" in help_text
+    assert "--backend-url" in help_text
+    assert "https://www.linkedin.com/messaging/" in help_text
+
+
+def test_backend_health_failure_is_clear_and_redacted(monkeypatch, capsys, tmp_path):
+    preflight = load_preflight_module()
+
+    def fail_fetch_json(_url, timeout_s=5.0):
+        raise URLError("connection refused li_at=secret JSESSIONID=secret Authorization: Bearer secret")
+
+    monkeypatch.setattr(preflight, "fetch_json", fail_fetch_json)
+
+    code = preflight.main([
+        "--no-open-messaging",
+        "--profile-dir",
+        str(tmp_path / "profile"),
+    ])
+
+    output = capsys.readouterr().out
+    assert code == 1
+    assert "Backend health failed" in output
+    assert "127.0.0.1:8899" in output
+    assert "li_at" not in output
+    assert "JSESSIONID" not in output
+    assert "Authorization" not in output
+    assert "secret" not in output
+
+
+def test_missing_extension_target_fails_with_loaded_message(monkeypatch, capsys, tmp_path):
+    preflight = load_preflight_module()
+
+    def fake_fetch_json(url, timeout_s=5.0):
+        if url.endswith("/health"):
+            return {"ok": True}
+        if url.endswith("/json/list"):
+            return []
+        if url.endswith("/json/version"):
+            return {"Browser": "Chrome/125"}
+        raise AssertionError(url)
+
+    monkeypatch.setattr(preflight, "fetch_json", fake_fetch_json)
+
+    code = preflight.main([
+        "--no-open-messaging",
+        "--profile-dir",
+        str(tmp_path / "profile"),
+    ])
+
+    output = capsys.readouterr().out
+    assert code == 1
+    assert "extension is not loaded" in output
+    assert "Desearch LinkedIn DMs Bridge" in output
+
+
+def test_success_verifies_expected_extension_target_and_opens_messaging(monkeypatch, capsys, tmp_path):
+    preflight = load_preflight_module()
+    extension_path = ROOT / "chrome-extension"
+    expected_id = preflight.extension_id_for_path(extension_path)
+    opened = []
+
+    def fake_fetch_json(url, timeout_s=5.0):
+        if url.endswith("/health"):
+            return {"ok": True}
+        if url.endswith("/json/version"):
+            return {"Browser": "Chrome/125"}
+        if url.endswith("/json/list"):
+            return [
+                {
+                    "type": "service_worker",
+                    "url": f"chrome-extension://{expected_id}/background.js",
+                    "title": "Service Worker chrome-extension background.js",
+                }
+            ]
+        raise AssertionError(url)
+
+    def fake_open_cdp_url(host, port, target_url, timeout_s=5.0):
+        opened.append((host, port, target_url))
+        return {"id": "target-1", "url": target_url}
+
+    monkeypatch.setattr(preflight, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(preflight, "open_cdp_url", fake_open_cdp_url)
+
+    code = preflight.main([
+        "--profile-dir",
+        str(tmp_path / "profile"),
+    ])
+
+    output = capsys.readouterr().out
+    assert code == 0
+    assert "Backend health OK" in output
+    assert "Extension loaded" in output
+    assert opened == [("127.0.0.1", 18800, "https://www.linkedin.com/messaging/")]


### PR DESCRIPTION
Files changed: README.md adds operator runbook for deterministic Chrome extension preflight; scripts/extension_preflight.py adds backend health check, optional Chrome launcher, deterministic unpacked-extension ID verification via CDP, extension-target failure messaging, LinkedIn messaging open step, and conservative secret-safe output; tests/test_extension_preflight.py adds coverage for help text, backend failure redaction, missing extension target failure, and successful target verification plus messaging open. Tests added/modified: new tests/test_extension_preflight.py verifies the new harness behavior. Verification: node chrome-extension/test_background.mjs => 88 passed, 0 failed; uv run pytest tests/test_api_refresh.py tests/test_sync_send.py tests/test_browser_context.py tests/test_storage.py -q => 135 passed; uv run pytest tests/test_extension_preflight.py -q => 4 passed; uv run python scripts/extension_preflight.py --help confirmed documented flags; uv run python scripts/extension_preflight.py --no-open-messaging fails clearly at backend health when local API is absent. Noteworthy: chrome-extension/manifest.json remains unchanged with Desearch LinkedIn DMs Bridge at line 3 and LinkedIn plus local backend host permissions at lines 12-13. Commit: ab17cd2 feat(#1156): add deterministic extension preflight harness.

---
Task: #1156 — Make LinkedIn extension loading deterministic with local preflight harness
Opened automatically by mission-control dispatcher.