### PR TITLE
Harden LinkedIn extension context refresh and operator status flow

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -83,10 +83,21 @@ function buildServiceHeaders(config) {
   return headers;
 }
 
-async function setStatus(status, error = null) {
+function redactOperatorText(value) {
+  if (!value) return value;
+  return String(value)
+    .replace(/(li_at=)[^;\s]+/gi, "$1[redacted]")
+    .replace(/(JSESSIONID=)[^;\s]+/gi, "$1[redacted]")
+    .replace(/(csrf-token|csrf_token|csrf)[:=]\s*[^;\s,}]+/gi, "$1=[redacted]")
+    .replace(/(Authorization[:=]\s*Bearer\s+)[^\s]+/gi, "$1[redacted]")
+    .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, "Bearer [redacted]");
+}
+
+async function setStatus(status, error = null, action = null) {
   await chrome.storage.local.set({
     lastStatus: status,
-    lastError: error,
+    lastError: error ? redactOperatorText(error) : null,
+    lastAction: action,
     lastUpdated: new Date().toISOString(),
   });
 }
@@ -127,8 +138,9 @@ chrome.cookies.onChanged.addListener(({ cookie, removed }) => {
           await registerAccount(config, cookies);
         }
       } catch (err) {
-        console.error("[desearch] cookie change handler error:", err);
-        await setStatus("error", err.message);
+        const error = redactOperatorText(err.message);
+        console.error("[desearch] cookie change handler error:", error);
+        await setStatus("error", error, "cookie");
       }
     });
   }
@@ -155,7 +167,7 @@ async function pushRefresh(config, cookies) {
   }
 
   console.log("[desearch] cookie refresh pushed successfully");
-  await setStatus("connected");
+  await setStatus("connected", null, "refresh");
 }
 
 async function registerAccount(config, cookies) {
@@ -181,7 +193,7 @@ async function registerAccount(config, cookies) {
   const data = await resp.json();
   await chrome.storage.local.set({ accountId: data.account_id });
   console.log("[desearch] account registered:", data.account_id);
-  await setStatus("connected");
+  await setStatus("connected", null, "refresh");
 }
 
 // ─── Header Capture ─────────────────────────────────────────────────────────
@@ -220,17 +232,35 @@ chrome.webRequest.onSendHeaders.addListener(
 // ─── Message handling (from popup) ──────────────────────────────────────────
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg.type === "OPERATOR_STATUS") {
+    buildOperatorStatus()
+      .then((status) => sendResponse({ ok: true, data: status }))
+      .catch((err) => sendResponse({ ok: false, error: redactOperatorText(err.message) }));
+    return true;
+  }
+
   if (msg.type === "MANUAL_SYNC") {
     handleManualSync()
-      .then((result) => sendResponse({ ok: true, data: result }))
-      .catch((err) => sendResponse({ ok: false, error: err.message }));
+      .then(async (result) => {
+        await setStatus("connected", null, "sync");
+        sendResponse({ ok: true, data: result });
+      })
+      .catch(async (err) => {
+        const error = redactOperatorText(err.message);
+        await setStatus("error", error, "sync");
+        sendResponse({ ok: false, error });
+      });
     return true; // keep channel open for async response
   }
 
   if (msg.type === "MANUAL_REFRESH") {
     handleManualRefresh()
       .then(() => sendResponse({ ok: true }))
-      .catch((err) => sendResponse({ ok: false, error: err.message }));
+      .catch(async (err) => {
+        const error = redactOperatorText(err.message);
+        await setStatus("error", error, "refresh");
+        sendResponse({ ok: false, error });
+      });
     return true;
   }
 });
@@ -252,6 +282,108 @@ function isContractFresh(contract) {
   const ts = Date.parse(contract.capturedAt);
   if (Number.isNaN(ts)) return true;
   return Date.now() - ts <= CONTRACT_FRESHNESS_MS;
+}
+
+function hasRequiredContract(contract) {
+  return !!(contract && contract.conversationsQueryId && contract.messagesQueryId);
+}
+
+function buildOperatorNextAction({ backendReady, accountReady, hasTrack, hasCsrf, hasContract, contractFresh, lastError, serviceUrl }) {
+  if (!backendReady) return "Set the backend Service URL, save config, then click Prepare Context.";
+  if (!accountReady) return "Log in to LinkedIn in this browser, then click Prepare Context.";
+  if (!hasCsrf && !hasTrack) return "Open LinkedIn in this browser to capture csrf-token and x-li-track, then click Prepare Context.";
+  if (!hasCsrf) return "Open LinkedIn in this browser to capture csrf-token, then click Prepare Context.";
+  if (!hasTrack) return "Open LinkedIn in this browser to capture x-li-track, then click Prepare Context.";
+  if (!hasContract) return "Open LinkedIn Messaging until conversations load to capture the messaging contract, then click Prepare Context and retry Sync.";
+  if (!contractFresh) return "Open LinkedIn Messaging to refresh the stale messaging contract, then click Prepare Context and retry Sync.";
+  if (/(fetch failed|failed to fetch|networkerror|econnrefused|connection refused)/i.test(lastError || "")) {
+    return `Start the backend at ${serviceUrl}, then click Prepare Context and retry Sync.`;
+  }
+  return "Ready for Sync Now.";
+}
+
+async function buildOperatorStatus() {
+  const config = await getConfig();
+  const captured = await getCapturedHeaders();
+  const contract = await getCapturedMessagingContract();
+  const meta = await chrome.storage.local.get({
+    headersUpdatedAt: null,
+    lastStatus: null,
+    lastError: null,
+    lastAction: null,
+    lastUpdated: null,
+  });
+
+  const serviceUrl = (config.serviceUrl || "").trim();
+  const backendReady = !!serviceUrl;
+  const accountReady = config.accountId !== null && config.accountId !== undefined;
+  const hasTrack = !!captured.x_li_track;
+  const hasCsrf = !!captured.csrf_token;
+  const hasContract = hasRequiredContract(contract);
+  const contractFresh = hasContract && isContractFresh(contract);
+
+  const missing = [];
+  if (!backendReady) missing.push("backend config");
+  if (!accountReady) missing.push("account id");
+  if (!hasTrack) missing.push("x-li-track");
+  if (!hasCsrf) missing.push("csrf-token");
+  if (!hasContract) missing.push("messaging contract");
+  else if (!contractFresh) missing.push("fresh messaging contract");
+
+  const lastError = redactOperatorText(meta.lastError || null);
+  const backendNeedsStart =
+    meta.lastStatus === "error" &&
+    backendReady &&
+    /(fetch failed|failed to fetch|networkerror|econnrefused|connection refused)/i.test(lastError || "");
+  if (backendNeedsStart) missing.push("backend reachable");
+
+  const readyForSync = missing.length === 0;
+  const nextAction = buildOperatorNextAction({
+    backendReady,
+    accountReady,
+    hasTrack,
+    hasCsrf,
+    hasContract,
+    contractFresh,
+    lastError,
+    serviceUrl,
+  });
+
+  return {
+    readyForSync,
+    missing,
+    nextAction,
+    backend: {
+      ready: backendReady,
+      serviceUrl,
+      needsStart: backendNeedsStart,
+    },
+    account: {
+      ready: accountReady,
+      accountId: config.accountId ?? null,
+    },
+    headers: {
+      xLiTrackCaptured: hasTrack,
+      csrfTokenCaptured: hasCsrf,
+      updatedAt: meta.headersUpdatedAt || null,
+    },
+    messagingContract: {
+      ready: hasContract,
+      fresh: contractFresh,
+      conversationsQueryIdCaptured: !!contract?.conversationsQueryId,
+      messagesQueryIdCaptured: !!contract?.messagesQueryId,
+      conversationsQueryId: contract?.conversationsQueryId || null,
+      messagesQueryId: contract?.messagesQueryId || null,
+      endpointPath: contract?.endpointPath || null,
+      capturedAt: contract?.capturedAt || null,
+    },
+    last: {
+      action: meta.lastAction || null,
+      status: meta.lastStatus || null,
+      error: lastError,
+      updatedAt: meta.lastUpdated || null,
+    },
+  };
 }
 
 function buildLinkedInHeaders(captured) {

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -41,7 +41,25 @@
 
     .status-label { color: #666; }
 
-    .status-value { font-weight: 500; }
+    .status-value {
+      font-weight: 500;
+      text-align: right;
+      max-width: 165px;
+      overflow-wrap: anywhere;
+    }
+
+    .status-row-wide {
+      display: block;
+      margin-top: 8px;
+    }
+
+    .status-row-wide .status-value {
+      display: block;
+      max-width: none;
+      text-align: left;
+      margin-top: 3px;
+      line-height: 1.35;
+    }
 
     .status-dot {
       display: inline-block;
@@ -122,6 +140,10 @@
       </span>
     </div>
     <div class="status-row">
+      <span class="status-label">Backend config</span>
+      <span class="status-value" id="backendStatus">—</span>
+    </div>
+    <div class="status-row">
       <span class="status-label">Account ID</span>
       <span class="status-value" id="accountId">—</span>
     </div>
@@ -132,6 +154,30 @@
     <div class="status-row">
       <span class="status-label">Headers captured</span>
       <span class="status-value" id="headersStatus">—</span>
+    </div>
+    <div class="status-row">
+      <span class="status-label">x-li-track</span>
+      <span class="status-value" id="trackStatus">—</span>
+    </div>
+    <div class="status-row">
+      <span class="status-label">csrf-token</span>
+      <span class="status-value" id="csrfStatus">—</span>
+    </div>
+    <div class="status-row">
+      <span class="status-label">Messaging contract</span>
+      <span class="status-value" id="contractStatus">—</span>
+    </div>
+    <div class="status-row">
+      <span class="status-label">Contract freshness</span>
+      <span class="status-value" id="contractFreshness">—</span>
+    </div>
+    <div class="status-row">
+      <span class="status-label">Last action</span>
+      <span class="status-value" id="lastActionStatus">—</span>
+    </div>
+    <div class="status-row-wide">
+      <span class="status-label">Next step</span>
+      <span class="status-value" id="nextAction">Checking readiness…</span>
     </div>
   </div>
 
@@ -147,7 +193,7 @@
 
   <div class="btn-row">
     <button class="btn-primary" id="btnSync">Sync Now</button>
-    <button class="btn-secondary" id="btnRefresh">Refresh Cookies</button>
+    <button class="btn-secondary" id="btnRefresh">Prepare Context</button>
   </div>
 
   <button class="btn-secondary" id="btnSaveConfig" style="width:100%">Save Config</button>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -2,9 +2,16 @@
 
 const statusDot = document.getElementById("statusDot");
 const statusLabel = document.getElementById("statusLabel");
+const backendStatusEl = document.getElementById("backendStatus");
 const accountIdEl = document.getElementById("accountId");
 const lastUpdatedEl = document.getElementById("lastUpdated");
 const headersStatusEl = document.getElementById("headersStatus");
+const trackStatusEl = document.getElementById("trackStatus");
+const csrfStatusEl = document.getElementById("csrfStatus");
+const contractStatusEl = document.getElementById("contractStatus");
+const contractFreshnessEl = document.getElementById("contractFreshness");
+const lastActionStatusEl = document.getElementById("lastActionStatus");
+const nextActionEl = document.getElementById("nextAction");
 const backendUrlInput = document.getElementById("backendUrl");
 const apiTokenInput = document.getElementById("apiToken");
 const resultEl = document.getElementById("result");
@@ -12,48 +19,75 @@ const btnSync = document.getElementById("btnSync");
 const btnRefresh = document.getElementById("btnRefresh");
 const btnSaveConfig = document.getElementById("btnSaveConfig");
 
+let readyForSync = false;
+let nextAction = "Prepare context before syncing.";
+let busy = false;
+
 // ─── Load state ──────────────────────────────────────────────────────────────
+
+function formatTime(value) {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleTimeString();
+}
+
+function shortQueryId(value) {
+  if (!value) return "missing";
+  return value.length > 26 ? `${value.slice(0, 23)}…` : value;
+}
+
+function updateButtonState() {
+  btnSync.disabled = busy || !readyForSync;
+  btnRefresh.disabled = busy;
+  btnSaveConfig.disabled = busy;
+  btnSync.title = readyForSync ? "" : nextAction;
+}
 
 async function loadState() {
   const state = await chrome.storage.local.get({
     serviceUrl: "http://localhost:8899",
     apiToken: "",
-    accountId: null,
-    lastStatus: null,
-    lastError: null,
-    lastUpdated: null,
-    xLiTrack: null,
-    csrfToken: null,
-    headersUpdatedAt: null,
   });
 
   backendUrlInput.value = state.serviceUrl;
   apiTokenInput.value = state.apiToken;
-  accountIdEl.textContent = state.accountId ?? "—";
+
+  let operatorStatus = null;
+  try {
+    const resp = await chrome.runtime.sendMessage({ type: "OPERATOR_STATUS" });
+    if (resp?.ok) operatorStatus = resp.data;
+  } catch (_) {
+    // Popup can still render config fields; background will surface real errors.
+  }
+
+  const last = operatorStatus?.last || {};
+  const backend = operatorStatus?.backend || {};
+  const account = operatorStatus?.account || {};
+  const headers = operatorStatus?.headers || {};
+  const contract = operatorStatus?.messagingContract || {};
+
+  readyForSync = !!operatorStatus?.readyForSync;
+  nextAction = operatorStatus?.nextAction || "Prepare context before syncing.";
 
   // Status indicator
-  if (state.lastStatus === "connected") {
+  if (last.status === "connected") {
     statusDot.className = "status-dot dot-connected";
     statusLabel.textContent = "Connected";
-  } else if (state.lastStatus === "error") {
+  } else if (last.status === "error") {
     statusDot.className = "status-dot dot-error";
-    statusLabel.textContent = state.lastError || "Error";
+    statusLabel.textContent = last.error || "Error";
   } else {
     statusDot.className = "status-dot dot-unknown";
     statusLabel.textContent = "Not connected";
   }
 
-  // Last updated
-  if (state.lastUpdated) {
-    const d = new Date(state.lastUpdated);
-    lastUpdatedEl.textContent = d.toLocaleTimeString();
-  } else {
-    lastUpdatedEl.textContent = "—";
-  }
+  backendStatusEl.textContent = backend.needsStart ? "Start backend" : (backend.ready ? "Configured" : "Set URL");
+  accountIdEl.textContent = account.accountId ?? "—";
+  lastUpdatedEl.textContent = formatTime(last.updatedAt);
 
-  // Headers
-  const hasTrack = !!state.xLiTrack;
-  const hasCsrf = !!state.csrfToken;
+  const hasTrack = !!headers.xLiTrackCaptured;
+  const hasCsrf = !!headers.csrfTokenCaptured;
   if (hasTrack && hasCsrf) {
     headersStatusEl.textContent = "x-li-track, csrf-token";
   } else if (hasTrack || hasCsrf) {
@@ -61,6 +95,29 @@ async function loadState() {
   } else {
     headersStatusEl.textContent = "—";
   }
+
+  const headerTime = formatTime(headers.updatedAt);
+  trackStatusEl.textContent = hasTrack ? `Captured ${headerTime}` : "Missing — open LinkedIn";
+  csrfStatusEl.textContent = hasCsrf ? `Captured ${headerTime}` : "Missing — open LinkedIn";
+
+  if (contract.ready) {
+    contractStatusEl.textContent = `${shortQueryId(contract.conversationsQueryId)} / ${shortQueryId(contract.messagesQueryId)}`;
+    contractFreshnessEl.textContent = contract.fresh
+      ? `Fresh ${formatTime(contract.capturedAt)}`
+      : "Stale — open Messaging";
+  } else if (contract.conversationsQueryIdCaptured || contract.messagesQueryIdCaptured) {
+    contractStatusEl.textContent = contract.conversationsQueryIdCaptured ? "Conversations only" : "Messages only";
+    contractFreshnessEl.textContent = "Incomplete — open Messaging";
+  } else {
+    contractStatusEl.textContent = "Missing — open Messaging";
+    contractFreshnessEl.textContent = "—";
+  }
+
+  const action = last.action ? `${last.action}: ` : "";
+  lastActionStatusEl.textContent = last.status ? `${action}${last.status}` : "—";
+  nextActionEl.textContent = nextAction;
+
+  updateButtonState();
 }
 
 // ─── Actions ─────────────────────────────────────────────────────────────────
@@ -71,8 +128,8 @@ function showResult(text, isError = false) {
 }
 
 function setButtonsDisabled(disabled) {
-  btnSync.disabled = disabled;
-  btnRefresh.disabled = disabled;
+  busy = disabled;
+  updateButtonState();
 }
 
 btnSaveConfig.addEventListener("click", async () => {
@@ -83,10 +140,16 @@ btnSaveConfig.addEventListener("click", async () => {
     return;
   }
   await chrome.storage.local.set({ serviceUrl: url, apiToken });
-  showResult("Config saved.");
+  showResult("Config saved. Click Prepare Context to register/refresh browser context.");
+  await loadState();
 });
 
 btnSync.addEventListener("click", async () => {
+  if (!readyForSync) {
+    showResult(nextAction, true);
+    return;
+  }
+
   setButtonsDisabled(true);
   showResult("Syncing...");
   try {
@@ -99,7 +162,7 @@ btnSync.addEventListener("click", async () => {
         `Synced ${d.synced_threads} threads, ${d.messages_inserted} new, ${dupes} duplicates skipped${rate}.`,
       );
     } else {
-      showResult(resp.error || "Sync failed.", true);
+      showResult(resp.error || "Sync failed. Check readiness above, then retry.", true);
     }
   } catch (err) {
     showResult(err.message, true);
@@ -110,13 +173,13 @@ btnSync.addEventListener("click", async () => {
 
 btnRefresh.addEventListener("click", async () => {
   setButtonsDisabled(true);
-  showResult("Refreshing cookies...");
+  showResult("Preparing browser context...");
   try {
     const resp = await chrome.runtime.sendMessage({ type: "MANUAL_REFRESH" });
     if (resp.ok) {
-      showResult("Cookies refreshed successfully.");
+      showResult("Context refreshed. If contract is missing/stale, open LinkedIn Messaging until conversations load, then retry Sync.");
     } else {
-      showResult(resp.error || "Refresh failed.", true);
+      showResult(resp.error || "Prepare Context failed. Start the backend or log in to LinkedIn, then retry.", true);
     }
   } catch (err) {
     showResult(err.message, true);

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -690,6 +690,86 @@ async function testAC8d_extensionNeverLogsCookiesOrCsrf() {
   assert(!allLogs.toLowerCase().includes("cookie:"), "no 'cookie:' string emitted to console");
 }
 
+
+async function testAC10_operatorStatusReadyForSync() {
+  console.log("\nAC10: OPERATOR_STATUS reports complete readiness without leaking secrets");
+  const env = buildEnv();
+  env.storage.serviceUrl = "http://localhost:8899";
+  env.storage.accountId = 1;
+  env.storage.xLiTrack = '{"clientVersion":"1.13.42912","secret":"do-not-leak-track"}';
+  env.storage.csrfToken = "ajax:super-secret-csrf-DO-NOT-LEAK";
+  env.storage.headersUpdatedAt = new Date().toISOString();
+  env.storage.messagingContract = FRESH_CONTRACT;
+  env.storage.lastStatus = "connected";
+  env.storage.lastUpdated = new Date().toISOString();
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "OPERATOR_STATUS" });
+  assert(resp.ok === true, "operator status response is ok");
+  const data = resp.data || {};
+  assert(data.readyForSync === true, "readyForSync true when backend config, account, csrf, x-li-track, and fresh contract are present");
+  assert(data.backend?.ready === true, "backend config ready reported");
+  assert(data.account?.ready === true && data.account.accountId === 1, "account readiness includes account id");
+  assert(data.headers?.csrfTokenCaptured === true, "csrf captured flag reported");
+  assert(data.headers?.xLiTrackCaptured === true, "x-li-track captured flag reported");
+  assert(data.messagingContract?.fresh === true, "contract freshness reported");
+  assert(data.messagingContract?.conversationsQueryId === FRESH_CONTRACT.conversationsQueryId, "safe conversations queryId exposed");
+  assert(data.messagingContract?.messagesQueryId === FRESH_CONTRACT.messagesQueryId, "safe messages queryId exposed");
+  assert(Array.isArray(data.missing) && data.missing.length === 0, "missing list empty when ready");
+  const statusStr = JSON.stringify(data);
+  assert(!statusStr.includes("ajax:super-secret-csrf-DO-NOT-LEAK"), "raw csrf-token not exposed in status");
+  assert(!statusStr.includes("do-not-leak-track"), "raw x-li-track value not exposed in status");
+}
+
+async function testAC10b_operatorStatusGuidesMissingAndStaleContext() {
+  console.log("\nAC10b: OPERATOR_STATUS gives actionable missing/stale context guidance");
+  const env = buildEnv();
+  env.storage.serviceUrl = "http://localhost:8899";
+  env.storage.accountId = 7;
+  env.storage.xLiTrack = "TRACK_PRESENT";
+  env.storage.csrfToken = "CSRF_PRESENT";
+  env.storage.messagingContract = {
+    ...FRESH_CONTRACT,
+    capturedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString(),
+  };
+  env.storage.lastStatus = "error";
+  env.storage.lastError = "fetch failed";
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "OPERATOR_STATUS" });
+  assert(resp.ok === true, "operator status response is ok");
+  const data = resp.data || {};
+  assert(data.readyForSync === false, "readyForSync false when contract is stale");
+  assert(data.messagingContract?.fresh === false, "stale contract freshness false");
+  assert((data.missing || []).includes("fresh messaging contract"), "missing list names fresh messaging contract");
+  assert(/messaging/i.test(data.nextAction || ""), "next action tells operator to open LinkedIn messaging");
+  assert(/prepare context|refresh/i.test(data.nextAction || ""), "next action tells operator to refresh/prepare context before retrying");
+  assert(data.last?.status === "error" && data.last?.error === "fetch failed", "last refresh/sync status exposed without secrets");
+}
+
+
+async function testAC10c_operatorStatusGuidesBackendStart() {
+  console.log("\nAC10c: OPERATOR_STATUS tells operator when backend must be started");
+  const env = buildEnv();
+  env.storage.serviceUrl = "http://localhost:8899";
+  env.storage.accountId = 9;
+  env.storage.xLiTrack = "TRACK_PRESENT";
+  env.storage.csrfToken = "CSRF_PRESENT";
+  env.storage.messagingContract = FRESH_CONTRACT;
+  env.storage.lastStatus = "error";
+  env.storage.lastError = "Failed to fetch Authorization: Bearer backend-token";
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "OPERATOR_STATUS" });
+  assert(resp.ok === true, "operator status response is ok");
+  const data = resp.data || {};
+  assert(data.readyForSync === false, "readyForSync false when backend was unreachable");
+  assert(data.backend?.needsStart === true, "backend status marks start needed");
+  assert((data.missing || []).includes("backend reachable"), "missing list names backend reachability");
+  assert(/start the backend/i.test(data.nextAction || ""), "next action tells operator to start backend");
+  assert(!JSON.stringify(data).includes("backend-token"), "authorization token not exposed in status");
+}
+
 async function testAC9_csrfHeaderSentToLinkedIn() {
   console.log("\nAC9: extension forwards captured csrf-token on LinkedIn requests");
   const env = buildEnv();
@@ -734,6 +814,9 @@ async function main() {
   await testAC8b_manualSyncFailsWithStaleContract();
   await testAC8c_manualSyncFailsWithoutCsrf();
   await testAC8d_extensionNeverLogsCookiesOrCsrf();
+  await testAC10_operatorStatusReadyForSync();
+  await testAC10b_operatorStatusGuidesMissingAndStaleContext();
+  await testAC10c_operatorStatusGuidesBackendStart();
   await testAC9_csrfHeaderSentToLinkedIn();
 
   console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);

--- a/tests/test_api_refresh.py
+++ b/tests/test_api_refresh.py
@@ -145,6 +145,65 @@ class TestRefreshValidation:
         assert resp.status_code == 422
 
 
+
+class TestRefreshPreservesBrowserContext:
+    def test_refresh_without_fresh_browser_headers_preserves_stored_context(self, client):
+        aid = _create_account(client)
+        import apps.api.main as api_mod
+
+        resp = client.post(
+            "/accounts/refresh",
+            json={
+                "account_id": aid,
+                "li_at": "AQEDCookieWithContext123",
+                "x_li_track": "TRACK_STORED",
+                "csrf_token": "CSRF_STORED",
+            },
+        )
+        assert resp.status_code == 200
+
+        resp = client.post(
+            "/accounts/refresh",
+            json={"account_id": aid, "li_at": "AQEDFreshCookieOnly456"},
+        )
+        assert resp.status_code == 200
+
+        auth = api_mod.storage.get_account_auth(aid)
+        assert auth.li_at == "AQEDFreshCookieOnly456"
+        assert auth.x_li_track == "TRACK_STORED"
+        assert auth.csrf_token == "CSRF_STORED"
+
+    def test_refresh_with_one_fresh_browser_header_preserves_the_other(self, client):
+        aid = _create_account(client)
+        import apps.api.main as api_mod
+
+        resp = client.post(
+            "/accounts/refresh",
+            json={
+                "account_id": aid,
+                "li_at": "AQEDCookieWithContext123",
+                "x_li_track": "TRACK_STORED",
+                "csrf_token": "CSRF_STORED",
+            },
+        )
+        assert resp.status_code == 200
+
+        resp = client.post(
+            "/accounts/refresh",
+            json={
+                "account_id": aid,
+                "li_at": "AQEDFreshCookieAndCsrf456",
+                "csrf_token": "CSRF_FRESH",
+            },
+        )
+        assert resp.status_code == 200
+
+        auth = api_mod.storage.get_account_auth(aid)
+        assert auth.li_at == "AQEDFreshCookieAndCsrf456"
+        assert auth.x_li_track == "TRACK_STORED"
+        assert auth.csrf_token == "CSRF_FRESH"
+
+
 def _http_status_error(status_code: int, *, retry_after: str | None = None) -> httpx.HTTPStatusError:
     request = httpx.Request("POST", "https://www.linkedin.com/voyager/api/graphql")
     headers = {"content-type": "application/json"}


### PR DESCRIPTION
Committed a46c592 feat(#1157): harden extension context readiness flow

Files changed:
- chrome-extension/background.js:86-103,235-265,287-385 — added redacted OPERATOR_STATUS readiness metadata, last action/status tracking, backend-start detection, and actionable next-step guidance.
- chrome-extension/popup.html:41-63,139-196 — added backend/account/header/contract/freshness/last action/next-step fields and renamed Refresh Cookies to Prepare Context.
- chrome-extension/popup.js:47-119,133-185 — popup now loads OPERATOR_STATUS, disables Sync Now until context is ready, and shows actionable Prepare Context / backend / messaging guidance.
- chrome-extension/test_background.mjs:695-819 — added operator readiness tests for ready state, stale contract guidance, backend-start guidance, and redaction.
- tests/test_api_refresh.py:149-207 — added backend refresh preservation tests covering apps/api/main.py:281-287 behavior when fresh payload is partial or missing browser headers.

Tests added/modified:
- testAC10_operatorStatusReadyForSync — verifies full readiness and no raw header secrets in status.
- testAC10b_operatorStatusGuidesMissingAndStaleContext — verifies stale contract is explicit/actionable and last status is exposed safely.
- testAC10c_operatorStatusGuidesBackendStart — verifies backend-unreachable state blocks sync and redacts bearer tokens.
- TestRefreshPreservesBrowserContext.test_refresh_without_fresh_browser_headers_preserves_stored_context — verifies cookie-only refresh preserves stored x_li_track/csrf_token.
- TestRefreshPreservesBrowserContext.test_refresh_with_one_fresh_browser_header_preserves_the_other — verifies partial fresh header refresh preserves the other stored header.

Verification:
- node chrome-extension/test_background.mjs => 113 passed, 0 failed.
- uv run pytest tests/test_api_refresh.py tests/test_sync_send.py tests/test_browser_context.py tests/test_storage.py -q => 137 passed in 7.95s.
- node --check chrome-extension/background.js && node --check chrome-extension/popup.js => passed.
- uv build => built sdist and wheel successfully.
- git status --short --branch => feature/task-1157 ahead 1, clean.

Noteworthy:
- Sync Now is disabled until backend config/reachability, account id, x-li-track, csrf-token, and fresh messaging contract are ready.
- Prepare Context remains safe because backend preservation behavior is covered; missing/stale contract and missing csrf remain explicit/actionable.
- No git push, gh pr create, or GitHub API calls were run; dispatcher should open the PR.

---
Task: #1157 — Harden LinkedIn extension context refresh and operator status flow
Opened automatically by mission-control dispatcher.