### PR TITLE
Fix LinkedIn extension GraphQL variables for inbox sync

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -18,8 +18,87 @@ async function getConfig() {
   return result;
 }
 
-// Capture the live messaging GraphQL request contract (queryId + variables shape)
-// from real LinkedIn browser traffic. Stores only metadata — never cookies or auth.
+const SECRET_VARIABLE_KEY_PATTERN = /(cookie|csrf|authorization|password|secret|li_at|jsessionid|(?:auth|access|refresh|bearer)[_-]?token)/i;
+const SECRET_VARIABLE_VALUE_PATTERN = /(li_at=|JSESSIONID=|Authorization\s*[:=]|Bearer\s+)/i;
+const TIMESTAMP_VARIABLE_KEY_PATTERN = /(createdBefore|createdAfter|deliveredBefore|deliveredAfter|beforeTime|afterTime|timestamp)$/i;
+
+function stripOuterParens(value) {
+  const s = String(value || "").trim();
+  if (s.startsWith("(") && s.endsWith(")")) return s.slice(1, -1);
+  return s;
+}
+
+function splitTopLevel(value, delimiter) {
+  const out = [];
+  let current = "";
+  let depth = 0;
+  let quote = null;
+  const s = String(value || "");
+  for (let i = 0; i < s.length; i += 1) {
+    const ch = s[i];
+    const prev = s[i - 1];
+    if (quote) {
+      current += ch;
+      if (ch === quote && prev !== "\\") quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") depth += 1;
+    if (ch === ")" || ch === "]" || ch === "}") depth = Math.max(0, depth - 1);
+    if (ch === delimiter && depth === 0) {
+      if (current.trim()) out.push(current.trim());
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) out.push(current.trim());
+  return out;
+}
+
+function parseGraphQLVariables(variablesRaw) {
+  return splitTopLevel(stripOuterParens(variablesRaw), ",")
+    .map((part) => {
+      const idx = part.indexOf(":");
+      if (idx <= 0) return null;
+      const key = part.slice(0, idx).trim();
+      const rawValue = part.slice(idx + 1).trim();
+      return key ? { key, rawValue } : null;
+    })
+    .filter(Boolean);
+}
+
+function normalizeGraphQLScalar(rawValue) {
+  const s = String(rawValue ?? "").trim();
+  if (/^-?\d+$/.test(s)) return Number(s);
+  return s;
+}
+
+function isSecretVariable({ key, rawValue }) {
+  return SECRET_VARIABLE_KEY_PATTERN.test(key) || SECRET_VARIABLE_VALUE_PATTERN.test(rawValue || "");
+}
+
+function buildVariableTemplate(variablesRaw, kind) {
+  const pairs = parseGraphQLVariables(variablesRaw).filter((pair) => !isSecretVariable(pair));
+  const template = pairs.map(({ key, rawValue }) => {
+    if (key === "mailboxUrn") return { key, source: "mailboxUrn" };
+    if (key === "conversationUrn") return { key, source: "conversationUrn" };
+    if (key === "count") {
+      return { key, source: "count", defaultValue: normalizeGraphQLScalar(rawValue) || 20 };
+    }
+    if (TIMESTAMP_VARIABLE_KEY_PATTERN.test(key)) return { key, source: "now" };
+    return { key, value: normalizeGraphQLScalar(rawValue) };
+  });
+  const requiredDynamicKey = kind === "conversations" ? "mailboxUrn" : "conversationUrn";
+  return template.some((entry) => entry.key === requiredDynamicKey) ? template : [];
+}
+
+// Capture the live messaging GraphQL request contract (queryId + variables template)
+// from real LinkedIn browser traffic. Stores only safe metadata — never cookies or auth.
 async function captureMessagingContract(url) {
   try {
     const parsed = new URL(url);
@@ -28,23 +107,19 @@ async function captureMessagingContract(url) {
 
     if (!queryId) return;
 
-    // Extract key names only — shape without runtime identifying values.
-    const variablesShape = variablesRaw
-      .replace(/^\(|\)$/g, "")
-      .split(",")
-      .filter(Boolean)
-      .map((kv) => kv.split(":")[0].trim())
-      .filter(Boolean);
-
     const current = await chrome.storage.local.get({ messagingContract: {} });
     const contract = { ...(current.messagingContract || {}) };
 
     if (queryId.startsWith("messengerConversations.")) {
+      const variablesTemplate = buildVariableTemplate(variablesRaw, "conversations");
       contract.conversationsQueryId = queryId;
-      contract.conversationsVariablesShape = variablesShape;
+      contract.conversationsVariablesShape = variablesTemplate.map((v) => v.key);
+      contract.conversationsVariablesTemplate = variablesTemplate;
     } else if (queryId.startsWith("messengerMessages.")) {
+      const variablesTemplate = buildVariableTemplate(variablesRaw, "messages");
       contract.messagesQueryId = queryId;
-      contract.messagesVariablesShape = variablesShape;
+      contract.messagesVariablesShape = variablesTemplate.map((v) => v.key);
+      contract.messagesVariablesTemplate = variablesTemplate;
     } else {
       return;
     }
@@ -273,6 +348,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 const VOYAGER_ME_URL = "https://www.linkedin.com/voyager/api/me";
 const VOYAGER_BASE = "https://www.linkedin.com";
 const CONTRACT_FRESHNESS_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
+const INGEST_CONVERSATIONS_PER_PAGE = 20; // First-MVP first page only.
 const INGEST_MESSAGES_PER_THREAD = 20; // First-MVP first-page only.
 
 function isContractFresh(contract) {
@@ -284,8 +360,47 @@ function isContractFresh(contract) {
   return Date.now() - ts <= CONTRACT_FRESHNESS_MS;
 }
 
+function hasVariableTemplateRequiredKeys(template, requiredKeys) {
+  if (!Array.isArray(template) || template.length === 0) return false;
+  return requiredKeys.every((key) => template.some((entry) => entry && entry.key === key));
+}
+
 function hasRequiredContract(contract) {
-  return !!(contract && contract.conversationsQueryId && contract.messagesQueryId);
+  return !!(
+    contract &&
+    contract.conversationsQueryId &&
+    contract.messagesQueryId &&
+    hasVariableTemplateRequiredKeys(contract.conversationsVariablesTemplate, ["mailboxUrn", "count"]) &&
+    hasVariableTemplateRequiredKeys(contract.messagesVariablesTemplate, ["conversationUrn", "count"])
+  );
+}
+
+function renderGraphQLVariableValue(entry, replacements) {
+  if (entry.source === "mailboxUrn") return replacements.mailboxUrn;
+  if (entry.source === "conversationUrn") return replacements.conversationUrn;
+  if (entry.source === "count") return replacements.count ?? entry.defaultValue ?? entry.value;
+  if (entry.source === "now") return Date.now();
+  return entry.value;
+}
+
+function buildGraphQLVariables(template, replacements, label) {
+  if (!Array.isArray(template) || template.length === 0) {
+    throw new Error(
+      `Captured ${label} messaging contract is missing reusable variables. Open LinkedIn Messaging to refresh the request contract, then retry Sync.`
+    );
+  }
+  const parts = [];
+  for (const entry of template) {
+    if (!entry || !entry.key) continue;
+    const value = renderGraphQLVariableValue(entry, replacements);
+    if (value === undefined || value === null || value === "") {
+      throw new Error(
+        `Captured ${label} messaging contract is missing value for ${entry.key}. Open LinkedIn Messaging to refresh the request contract, then retry Sync.`
+      );
+    }
+    parts.push(`${entry.key}:${String(value)}`);
+  }
+  return `(${parts.join(",")})`;
 }
 
 function buildOperatorNextAction({ backendReady, accountReady, hasTrack, hasCsrf, hasContract, contractFresh, lastError, serviceUrl }) {
@@ -440,7 +555,11 @@ async function fetchVoyagerMe(captured) {
 }
 
 async function fetchConversationsPage(mailboxUrn, contract, captured) {
-  const variables = `(mailboxUrn:${mailboxUrn})`;
+  const variables = buildGraphQLVariables(
+    contract.conversationsVariablesTemplate,
+    { mailboxUrn, count: INGEST_CONVERSATIONS_PER_PAGE },
+    "conversations"
+  );
   const path = contract.endpointPath || "/voyager/api/voyagerMessagingGraphQL/graphql";
   const url = `${VOYAGER_BASE}${path}?queryId=${encodeURIComponent(contract.conversationsQueryId)}&variables=${encodeURIComponent(variables)}`;
   const resp = await fetch(url, {
@@ -454,7 +573,11 @@ async function fetchConversationsPage(mailboxUrn, contract, captured) {
 }
 
 async function fetchMessagesPage(conversationUrn, contract, captured) {
-  const variables = `(conversationUrn:${conversationUrn},count:${INGEST_MESSAGES_PER_THREAD})`;
+  const variables = buildGraphQLVariables(
+    contract.messagesVariablesTemplate,
+    { conversationUrn, count: INGEST_MESSAGES_PER_THREAD },
+    "messages"
+  );
   const path = contract.endpointPath || "/voyager/api/voyagerMessagingGraphQL/graphql";
   const url = `${VOYAGER_BASE}${path}?queryId=${encodeURIComponent(contract.messagesQueryId)}&variables=${encodeURIComponent(variables)}`;
   const resp = await fetch(url, {
@@ -565,9 +688,9 @@ async function handleManualSync() {
   }
 
   const contract = await getCapturedMessagingContract();
-  if (!contract || !contract.conversationsQueryId || !contract.messagesQueryId) {
+  if (!hasRequiredContract(contract)) {
     throw new Error(
-      "Messaging contract not captured. Open https://www.linkedin.com/messaging/ in this browser to record the request shape, then retry sync."
+      "Messaging contract variables not captured. Open https://www.linkedin.com/messaging/ in this browser to record the current request variables, then retry sync."
     );
   }
   if (!isContractFresh(contract)) {

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -34,8 +34,18 @@ function assert(cond, label) {
 const FRESH_CONTRACT = {
   conversationsQueryId: "messengerConversations.live123",
   messagesQueryId: "messengerMessages.live456",
-  conversationsVariablesShape: ["mailboxUrn", "count"],
-  messagesVariablesShape: ["conversationUrn", "count"],
+  conversationsVariablesShape: ["mailboxUrn", "count", "includeParticipants"],
+  messagesVariablesShape: ["conversationUrn", "count", "createdBefore"],
+  conversationsVariablesTemplate: [
+    { key: "mailboxUrn", source: "mailboxUrn" },
+    { key: "count", source: "count", defaultValue: 20 },
+    { key: "includeParticipants", value: "true" },
+  ],
+  messagesVariablesTemplate: [
+    { key: "conversationUrn", source: "conversationUrn" },
+    { key: "count", source: "count", defaultValue: 20 },
+    { key: "createdBefore", source: "now" },
+  ],
   endpointPath: "/voyager/api/voyagerMessagingGraphQL/graphql",
   capturedAt: new Date().toISOString(),
 };
@@ -455,12 +465,20 @@ async function testAC5_manualSyncReadsLinkedInAndIngests() {
   assert(!!convCall, "extension fetched conversations from LinkedIn GraphQL");
   if (convCall) {
     assert(convCall.url.includes(FRESH_CONTRACT.conversationsQueryId), "conversations queryId from captured contract");
+    const variables = decodeURIComponent(new URL(convCall.url).searchParams.get("variables") || "");
+    assert(variables.includes("mailboxUrn:urn:li:fsd_profile:42"), "conversations variables include runtime mailboxUrn");
+    assert(variables.includes("count:20"), "conversations variables include captured count requirement");
+    assert(variables.includes("includeParticipants:true"), "conversations variables reuse captured safe static fields");
   }
 
   const msgCalls = env.fetchLog.filter(f => f.url.includes("queryId=messengerMessages"));
   assert(msgCalls.length >= 1, "extension fetched at least one messages page from LinkedIn GraphQL");
   if (msgCalls.length >= 1) {
     assert(msgCalls[0].url.includes(FRESH_CONTRACT.messagesQueryId), "messages queryId from captured contract");
+    const variables = decodeURIComponent(new URL(msgCalls[0].url).searchParams.get("variables") || "");
+    assert(variables.includes("conversationUrn:urn:li:msg_conversation:1"), "messages variables include runtime conversationUrn");
+    assert(variables.includes("count:20"), "messages variables preserve first-page count behavior");
+    assert(/createdBefore:\d{10,}/.test(variables), "messages variables include required timestamp field when captured");
   }
 
   const ingestCall = findIngestCall(env);
@@ -549,7 +567,7 @@ async function testAC7_messagingContractConversations() {
   const headerListener = env.listeners.onSendHeaders[0];
   const url =
     "https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql" +
-    "?queryId=messengerConversations.abc123def456&variables=(mailboxUrn:urn:li:fsd_profile:42,count:20)";
+    "?queryId=messengerConversations.abc123def456&variables=(mailboxUrn:urn:li:fsd_profile:42,count:20,includeParticipants:true)";
 
   await headerListener.fn({
     url,
@@ -573,6 +591,21 @@ async function testAC7_messagingContractConversations() {
   assert(Array.isArray(contract.conversationsVariablesShape), "conversationsVariablesShape is an array");
   assert(contract.conversationsVariablesShape.includes("mailboxUrn"), "mailboxUrn key in shape");
   assert(contract.conversationsVariablesShape.includes("count"), "count key in shape");
+  assert(contract.conversationsVariablesShape.includes("includeParticipants"), "safe static key in shape");
+  assert(Array.isArray(contract.conversationsVariablesTemplate), "conversationsVariablesTemplate is an array");
+  assert(
+    contract.conversationsVariablesTemplate.some((v) => v.key === "mailboxUrn" && v.source === "mailboxUrn" && !Object.prototype.hasOwnProperty.call(v, "value")),
+    "mailboxUrn stored as runtime placeholder, not captured profile value"
+  );
+  assert(
+    contract.conversationsVariablesTemplate.some((v) => v.key === "count" && v.source === "count" && v.defaultValue === 20),
+    "count captured as reusable required variable"
+  );
+  assert(
+    contract.conversationsVariablesTemplate.some((v) => v.key === "includeParticipants" && v.value === "true"),
+    "safe static conversation variable captured"
+  );
+  assert(!JSON.stringify(contract).includes("urn:li:fsd_profile:42"), "mailboxUrn value not stored in contract");
 }
 
 async function testAC7b_messagingContractMessages() {
@@ -602,6 +635,16 @@ async function testAC7b_messagingContractMessages() {
   assert(contract.messagesVariablesShape.includes("conversationUrn"), "conversationUrn key in shape");
   assert(contract.messagesVariablesShape.includes("count"), "count key in shape");
   assert(contract.messagesVariablesShape.includes("createdBefore"), "createdBefore key in shape");
+  assert(Array.isArray(contract.messagesVariablesTemplate), "messagesVariablesTemplate is an array");
+  assert(
+    contract.messagesVariablesTemplate.some((v) => v.key === "conversationUrn" && v.source === "conversationUrn" && !Object.prototype.hasOwnProperty.call(v, "value")),
+    "conversationUrn stored as runtime placeholder"
+  );
+  assert(
+    contract.messagesVariablesTemplate.some((v) => v.key === "createdBefore" && v.source === "now"),
+    "createdBefore stored as dynamic timestamp metadata"
+  );
+  assert(!JSON.stringify(contract).includes("2-abc"), "conversationUrn value not stored in contract");
 }
 
 async function testAC7c_messagingContractNoSecrets() {
@@ -612,7 +655,7 @@ async function testAC7c_messagingContractNoSecrets() {
   const headerListener = env.listeners.onSendHeaders[0];
   const url =
     "https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql" +
-    "?queryId=messengerConversations.abc123&variables=(mailboxUrn:urn:li:fsd_profile:42)";
+    "?queryId=messengerConversations.abc123&variables=(mailboxUrn:urn:li:fsd_profile:42,count:20,csrfToken:ajax:csrf999,cookie:li_at=super-secret-li-at-token,authToken:super-secret-auth-token)";
 
   await headerListener.fn({
     url,
@@ -628,7 +671,35 @@ async function testAC7c_messagingContractNoSecrets() {
   const contractStr = JSON.stringify(contract);
   assert(!contractStr.includes("super-secret-li-at-token"), "li_at cookie value not in stored contract");
   assert(!contractStr.includes("js123"), "JSESSIONID value not in stored contract");
+  assert(!contractStr.includes("ajax:csrf999"), "csrf variable value not in stored contract");
+  assert(!contractStr.includes("super-secret-auth-token"), "auth token variable value not in stored contract");
   assert(!Object.prototype.hasOwnProperty.call(contract, "cookie"), "no cookie field on contract object");
+  assert(
+    !(contract.conversationsVariablesTemplate || []).some((v) => /cookie|csrf|authToken/i.test(v.key)),
+    "secret-like variable keys not stored in template"
+  );
+}
+
+async function testAC8e_manualSyncFailsWithLegacyShapeOnlyContract() {
+  console.log("\nAC8e: MANUAL_SYNC fails visibly when contract has only legacy variable shapes");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  env.storage.csrfToken = "SYNC_CSRF";
+  env.storage.messagingContract = {
+    conversationsQueryId: "messengerConversations.legacy",
+    messagesQueryId: "messengerMessages.legacy",
+    conversationsVariablesShape: ["mailboxUrn"],
+    messagesVariablesShape: ["conversationUrn", "count"],
+    endpointPath: "/voyager/api/voyagerMessagingGraphQL/graphql",
+    capturedAt: new Date().toISOString(),
+  };
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  assert(resp.ok === false, "sync response is not ok when contract lacks reusable variable template");
+  assert(/(contract|variables|refresh)/i.test(resp.error || ""), "error tells operator to refresh captured variables");
+  const convCall = env.fetchLog.find(f => f.url.includes("queryId=messengerConversations"));
+  assert(!convCall, "LinkedIn GraphQL request was NOT made with legacy shape-only contract");
 }
 
 async function testAC8_manualSyncFailsWithoutContract() {
@@ -814,6 +885,7 @@ async function main() {
   await testAC8b_manualSyncFailsWithStaleContract();
   await testAC8c_manualSyncFailsWithoutCsrf();
   await testAC8d_extensionNeverLogsCookiesOrCsrf();
+  await testAC8e_manualSyncFailsWithLegacyShapeOnlyContract();
   await testAC10_operatorStatusReadyForSync();
   await testAC10b_operatorStatusGuidesMissingAndStaleContext();
   await testAC10c_operatorStatusGuidesBackendStart();

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -8,11 +8,11 @@ This file documents issues that are real in the current implementation, based on
 - `messengerConversations.0d5e6781bbee71c3e51c8843c6519f48`
 - `messengerMessages.21eabeb3ee872254060ef21b793ea7d0`
 
-These values are extracted from LinkedIn frontend traffic and may change without warning. When they change, thread listing or message fetch can fail even though cookies are still valid.
+These values are extracted from LinkedIn frontend traffic and may change without warning. When they change, the legacy backend provider path can fail even though cookies are still valid. The Chrome extension Sync Now path captures the live messaging GraphQL query IDs and safe variable templates from browser traffic instead; if that captured contract is missing or stale, refresh LinkedIn Messaging in the signed-in browser before retrying Sync Now.
 
 Impact:
-- sync can return 4xx or fail during provider execution
-- the service may appear broken until the query IDs are updated in source
+- legacy backend sync can return 4xx or fail during provider execution
+- extension Sync Now can return a contract-refresh error until live messaging traffic is captured again
 
 ## 2. `JSESSIONID` is effectively required for sync
 


### PR DESCRIPTION
Problem: Extension Sync Now could hit LinkedIn GraphQL 400s because it reused captured queryIds but rebuilt conversations with only mailboxUrn, dropping required variables from the live messengerConversations/messengerMessages contract. Root cause: chrome-extension/background.js stored variable key names only, not a safe reusable variable template, so the runtime could not reconstruct count/static fields/timestamp pagination fields. Fix: chrome-extension/background.js:21-130 now parses top-level GraphQL variables, stores safe conversations/messages variable templates with runtime placeholders for mailboxUrn/conversationUrn, captures count/static fields, treats timestamp fields like createdBefore as dynamic now-values, and filters cookie/csrf/auth-token-like variables. chrome-extension/background.js:363-404 now requires reusable templates before sync and produces operator-facing refresh errors for legacy shape-only contracts. chrome-extension/background.js:557-582 now builds conversations/messages URLs from the captured templates, including count and captured safe static/timestamp fields, instead of sending mailboxUrn-only conversations variables. Tests added/modified: chrome-extension/test_background.mjs:34-51 updates FRESH_CONTRACT to model richer templates; :465-481 asserts outgoing conversations/messages GraphQL variables include mailboxUrn/conversationUrn, count, safe static includeParticipants, and createdBefore; :580-681 proves capture stores templates, uses placeholders instead of profile/conversation values, and excludes cookie/csrf/auth token values; :683-704 adds legacy shape-only contract failure coverage. Docs: docs/known-issues.md:11-15 clarifies hardcoded queryIds are legacy backend risk while extension Sync Now now uses captured live queryIds/templates and requires recapture when stale/missing. Validation: initial node chrome-extension/test_background.mjs failed with the new regression assertions before the implementation; final node chrome-extension/test_background.mjs passed 135/135; final uv run pytest passed 425/425. Production expectation: after the operator opens LinkedIn Messaging to recapture the live contract, Sync Now should issue current GraphQL variables and reach /sync/ingest when LinkedIn returns conversations/messages; if the contract is missing/stale/legacy shape-only, it now fails before the LinkedIn GraphQL request with a clear refresh-contract error. Noteworthy: no LinkedIn send/modify/logout/password/2FA/CAPTCHA automation was performed; no raw cookies, csrf-token, x-li-track, li_at, JSESSIONID, or auth token values are persisted in the contract tests.

---
Task: #1197 — Fix LinkedIn extension GraphQL variables for inbox sync
Opened automatically by mission-control dispatcher.