### PR TITLE
Fix extension sync for LinkedIn GraphQL contracts without count

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -370,8 +370,8 @@ function hasRequiredContract(contract) {
     contract &&
     contract.conversationsQueryId &&
     contract.messagesQueryId &&
-    hasVariableTemplateRequiredKeys(contract.conversationsVariablesTemplate, ["mailboxUrn", "count"]) &&
-    hasVariableTemplateRequiredKeys(contract.messagesVariablesTemplate, ["conversationUrn", "count"])
+    hasVariableTemplateRequiredKeys(contract.conversationsVariablesTemplate, ["mailboxUrn"]) &&
+    hasVariableTemplateRequiredKeys(contract.messagesVariablesTemplate, ["conversationUrn"])
   );
 }
 

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -50,6 +50,21 @@ const FRESH_CONTRACT = {
   capturedAt: new Date().toISOString(),
 };
 
+const FRESH_MINIMAL_NO_COUNT_CONTRACT = {
+  conversationsQueryId: "messengerConversations.liveNoCount123",
+  messagesQueryId: "messengerMessages.liveNoCount456",
+  conversationsVariablesShape: ["mailboxUrn"],
+  messagesVariablesShape: ["conversationUrn"],
+  conversationsVariablesTemplate: [
+    { key: "mailboxUrn", source: "mailboxUrn" },
+  ],
+  messagesVariablesTemplate: [
+    { key: "conversationUrn", source: "conversationUrn" },
+  ],
+  endpointPath: "/voyager/api/voyagerMessagingGraphQL/graphql",
+  capturedAt: new Date().toISOString(),
+};
+
 // ─── Build mock chrome + fetch environment ──────────────────────────────────
 
 function buildEnv({ linkedinResponses } = {}) {
@@ -507,6 +522,33 @@ async function testAC5_manualSyncReadsLinkedInAndIngests() {
   }
 }
 
+async function testAC5d_manualSyncNoCountContractOmitsSyntheticCount() {
+  console.log("\nAC5d: MANUAL_SYNC with live no-count contract does not synthesize count variables");
+  const env = buildEnv();
+  env.storage.accountId = 1;
+  env.storage.xLiTrack = "SYNC_TRACK";
+  env.storage.csrfToken = "SYNC_CSRF";
+  env.storage.messagingContract = FRESH_MINIMAL_NO_COUNT_CONTRACT;
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  assert(resp.ok === true, `sync response is ok for no-count contract (got: ${JSON.stringify(resp)})`);
+
+  const convCall = env.fetchLog.find(f => f.url.includes("queryId=messengerConversations"));
+  assert(!!convCall, "extension fetched conversations using minimal no-count contract");
+  if (convCall) {
+    const variables = decodeURIComponent(new URL(convCall.url).searchParams.get("variables") || "");
+    assert(variables === "(mailboxUrn:urn:li:fsd_profile:42)", `conversations variables omit synthetic count (got: ${variables})`);
+  }
+
+  const msgCall = env.fetchLog.find(f => f.url.includes("queryId=messengerMessages"));
+  assert(!!msgCall, "extension fetched messages using minimal no-count contract");
+  if (msgCall) {
+    const variables = decodeURIComponent(new URL(msgCall.url).searchParams.get("variables") || "");
+    assert(variables === "(conversationUrn:urn:li:msg_conversation:1)", `messages variables omit synthetic count (got: ${variables})`);
+  }
+}
+
 async function testAC5b_manualSyncIncludesBearerToken() {
   console.log("\nAC5b: MANUAL_SYNC includes Authorization on /sync/ingest when apiToken configured");
   const env = buildEnv();
@@ -645,6 +687,50 @@ async function testAC7b_messagingContractMessages() {
     "createdBefore stored as dynamic timestamp metadata"
   );
   assert(!JSON.stringify(contract).includes("2-abc"), "conversationUrn value not stored in contract");
+}
+
+async function testAC7d_messagingContractMinimalNoCountPassesReadiness() {
+  console.log("\nAC7d: Captures live no-count messaging contract and reports sync readiness");
+  const env = buildEnv();
+  env.storage.serviceUrl = "http://localhost:8899";
+  env.storage.accountId = 1;
+  loadBackground(env);
+
+  const headerListener = env.listeners.onSendHeaders[0];
+  const conversationsUrl =
+    "https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql" +
+    "?queryId=messengerConversations.noCountConvs&variables=(mailboxUrn:urn:li:fsd_profile:42)";
+  const messagesUrl =
+    "https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql" +
+    "?queryId=messengerMessages.noCountMsgs&variables=(conversationUrn:urn:li:msg_conversation:1)";
+
+  await headerListener.fn({
+    url: conversationsUrl,
+    requestHeaders: [
+      { name: "x-li-track", value: '{"clientVersion":"1.13.42912"}' },
+      { name: "csrf-token", value: "ajax:abc123" },
+    ],
+  });
+  await headerListener.fn({
+    url: messagesUrl,
+    requestHeaders: [
+      { name: "x-li-track", value: '{"clientVersion":"1.13.42912"}' },
+      { name: "csrf-token", value: "ajax:abc123" },
+    ],
+  });
+
+  const contract = env.storage.messagingContract;
+  assert(!!contract, "messagingContract stored after no-count requests");
+  assert(contract.conversationsQueryId === "messengerConversations.noCountConvs", "no-count conversations queryId captured");
+  assert(contract.messagesQueryId === "messengerMessages.noCountMsgs", "no-count messages queryId captured");
+  assert(JSON.stringify(contract.conversationsVariablesTemplate) === JSON.stringify([{ key: "mailboxUrn", source: "mailboxUrn" }]), "conversations no-count template stores only mailboxUrn placeholder");
+  assert(JSON.stringify(contract.messagesVariablesTemplate) === JSON.stringify([{ key: "conversationUrn", source: "conversationUrn" }]), "messages no-count template stores only conversationUrn placeholder");
+  assert(!JSON.stringify(contract).includes("count"), "no synthetic count stored for live no-count contract");
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "OPERATOR_STATUS" });
+  assert(resp.ok === true, "operator status response is ok for captured no-count contract");
+  assert(resp.data?.readyForSync === true, "readyForSync true for captured live no-count contract");
+  assert(Array.isArray(resp.data?.missing) && resp.data.missing.length === 0, "missing list empty for live no-count contract");
 }
 
 async function testAC7c_messagingContractNoSecrets() {
@@ -792,6 +878,51 @@ async function testAC10_operatorStatusReadyForSync() {
   assert(!statusStr.includes("do-not-leak-track"), "raw x-li-track value not exposed in status");
 }
 
+async function testAC10d_operatorStatusReadyForMinimalNoCountContract() {
+  console.log("\nAC10d: OPERATOR_STATUS is ready for #1252 minimal no-count contract");
+  const env = buildEnv();
+  env.storage.serviceUrl = "http://localhost:8899";
+  env.storage.accountId = 1;
+  env.storage.xLiTrack = '{"clientVersion":"1.13.42912"}';
+  env.storage.csrfToken = "ajax:csrf-present";
+  env.storage.headersUpdatedAt = new Date().toISOString();
+  env.storage.messagingContract = FRESH_MINIMAL_NO_COUNT_CONTRACT;
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "OPERATOR_STATUS" });
+  assert(resp.ok === true, "operator status response is ok");
+  const data = resp.data || {};
+  assert(data.readyForSync === true, "readyForSync true when minimal no-count contract and all other gates are present");
+  assert(data.messagingContract?.ready === true, "minimal no-count contract marked ready");
+  assert(data.messagingContract?.fresh === true, "minimal no-count contract marked fresh");
+  assert(Array.isArray(data.missing) && data.missing.length === 0, "missing list empty for minimal no-count contract");
+}
+
+async function testAC10e_operatorStatusRejectsLegacyShapeOnlyContract() {
+  console.log("\nAC10e: OPERATOR_STATUS rejects shape-only legacy contracts without reusable templates");
+  const env = buildEnv();
+  env.storage.serviceUrl = "http://localhost:8899";
+  env.storage.accountId = 1;
+  env.storage.xLiTrack = "TRACK_PRESENT";
+  env.storage.csrfToken = "CSRF_PRESENT";
+  env.storage.messagingContract = {
+    conversationsQueryId: "messengerConversations.legacy",
+    messagesQueryId: "messengerMessages.legacy",
+    conversationsVariablesShape: ["mailboxUrn"],
+    messagesVariablesShape: ["conversationUrn"],
+    endpointPath: "/voyager/api/voyagerMessagingGraphQL/graphql",
+    capturedAt: new Date().toISOString(),
+  };
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "OPERATOR_STATUS" });
+  assert(resp.ok === true, "operator status response is ok");
+  const data = resp.data || {};
+  assert(data.readyForSync === false, "readyForSync false for shape-only legacy contract");
+  assert(data.messagingContract?.ready === false, "shape-only legacy contract not marked ready");
+  assert((data.missing || []).includes("messaging contract"), "missing list names messaging contract for shape-only contract");
+}
+
 async function testAC10b_operatorStatusGuidesMissingAndStaleContext() {
   console.log("\nAC10b: OPERATOR_STATUS gives actionable missing/stale context guidance");
   const env = buildEnv();
@@ -875,11 +1006,13 @@ async function main() {
   await testAC3_ignoresNonLinkedIn();
   await testAC4_headerCapture();
   await testAC5_manualSyncReadsLinkedInAndIngests();
+  await testAC5d_manualSyncNoCountContractOmitsSyntheticCount();
   await testAC5b_manualSyncIncludesBearerToken();
   await testAC5c_extensionDirectionForMyMessages();
   await testAC6_manualRefresh();
   await testAC7_messagingContractConversations();
   await testAC7b_messagingContractMessages();
+  await testAC7d_messagingContractMinimalNoCountPassesReadiness();
   await testAC7c_messagingContractNoSecrets();
   await testAC8_manualSyncFailsWithoutContract();
   await testAC8b_manualSyncFailsWithStaleContract();
@@ -887,6 +1020,8 @@ async function main() {
   await testAC8d_extensionNeverLogsCookiesOrCsrf();
   await testAC8e_manualSyncFailsWithLegacyShapeOnlyContract();
   await testAC10_operatorStatusReadyForSync();
+  await testAC10d_operatorStatusReadyForMinimalNoCountContract();
+  await testAC10e_operatorStatusRejectsLegacyShapeOnlyContract();
   await testAC10b_operatorStatusGuidesMissingAndStaleContext();
   await testAC10c_operatorStatusGuidesBackendStart();
   await testAC9_csrfHeaderSentToLinkedIn();

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -9,8 +9,10 @@
  *   AC4 – header capture stores xLiTrack / csrfToken
  *   AC5 – MANUAL_SYNC reads LinkedIn from the browser and POSTs /sync/ingest
  *   AC6 – MANUAL_REFRESH triggers refresh or register
- *   AC7 – messaging contract capture from real traffic
+ *   AC7 – messaging contract capture from real traffic, including no-count templates
  *   AC8 – MANUAL_SYNC fails visibly without contract / csrf
+ *   AC9 – captured csrf-token is forwarded on LinkedIn browser reads
+ *   AC10 – OPERATOR_STATUS readiness, including #1252 minimal no-count and legacy shape-only rejection
  */
 
 import { readFileSync } from "fs";
@@ -31,7 +33,7 @@ function assert(cond, label) {
   }
 }
 
-const FRESH_CONTRACT = {
+const FRESH_RICH_WITH_COUNT_CONTRACT = {
   conversationsQueryId: "messengerConversations.live123",
   messagesQueryId: "messengerMessages.live456",
   conversationsVariablesShape: ["mailboxUrn", "count", "includeParticipants"],
@@ -50,6 +52,10 @@ const FRESH_CONTRACT = {
   capturedAt: new Date().toISOString(),
 };
 
+// Backward-compatible rich contract fixture: LinkedIn captured count in these templates.
+const FRESH_CONTRACT = FRESH_RICH_WITH_COUNT_CONTRACT;
+
+// Current #1252 live contract fixture: LinkedIn omitted count entirely.
 const FRESH_MINIMAL_NO_COUNT_CONTRACT = {
   conversationsQueryId: "messengerConversations.liveNoCount123",
   messagesQueryId: "messengerMessages.liveNoCount456",

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -13,6 +13,7 @@ These values are extracted from LinkedIn frontend traffic and may change without
 Impact:
 - legacy backend sync can return 4xx or fail during provider execution
 - extension Sync Now can return a contract-refresh error until live messaging traffic is captured again
+- operator note: when LinkedIn captures no-count templates, rerun Sync Now as-is; adding `count` manually can break the live GraphQL request
 
 ## 2. `JSESSIONID` is effectively required for sync
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -8,7 +8,7 @@ This file documents issues that are real in the current implementation, based on
 - `messengerConversations.0d5e6781bbee71c3e51c8843c6519f48`
 - `messengerMessages.21eabeb3ee872254060ef21b793ea7d0`
 
-These values are extracted from LinkedIn frontend traffic and may change without warning. When they change, the legacy backend provider path can fail even though cookies are still valid. The Chrome extension Sync Now path captures the live messaging GraphQL query IDs and safe variable templates from browser traffic instead; if that captured contract is missing or stale, refresh LinkedIn Messaging in the signed-in browser before retrying Sync Now.
+These values are extracted from LinkedIn frontend traffic and may change without warning. When they change, the legacy backend provider path can fail even though cookies are still valid. The Chrome extension Sync Now path captures the live messaging GraphQL query IDs and safe variable templates from browser traffic instead; if that captured contract is missing or stale, refresh LinkedIn Messaging in the signed-in browser before retrying Sync Now. Sync Now replays only variables captured in the live template: current no-count contracts using just `mailboxUrn` for conversations and `conversationUrn` for messages are valid, and operators should not force or synthesize `count` when LinkedIn omits it.
 
 Impact:
 - legacy backend sync can return 4xx or fail during provider execution


### PR DESCRIPTION
Problem / root cause: Live LinkedIn Messaging GraphQL traffic from #1252 omitted count in reusable variables (conversations=[mailboxUrn], messages=[conversationUrn]), but extension readiness required count, disabling Sync Now. Synthetic count probes returned HTTP 400, so injecting count was unsafe.

Fix: chrome-extension/background.js now treats the captured reusable template minimum as mailboxUrn for conversations and conversationUrn for messages. Query IDs and reusable templates are still required, freshness still applies, and buildGraphQLVariables continues rendering only entries present in the captured template, so no synthetic count is emitted when LinkedIn omitted it.

Files changed:
- chrome-extension/background.js: hasRequiredContract no longer requires count; required dynamic keys are mailboxUrn and conversationUrn only.
- chrome-extension/test_background.mjs: added rich-with-count plus minimal-no-count fixture coverage; added tests proving no-count URL variables omit synthetic count, captured no-count contracts store safe placeholders, operator readiness is true for the #1252 minimal contract, and shape-only legacy contracts remain rejected.
- docs/known-issues.md: documented that extension Sync Now accepts current no-count live templates as-is and operators should not force count when LinkedIn omits it.

Tests added/modified:
- AC5d verifies MANUAL_SYNC with minimal no-count contract generates variables exactly (mailboxUrn:...) and (conversationUrn:...) with no count.
- AC7d verifies live no-count GraphQL URLs are captured into safe reusable templates and pass readiness.
- AC10d verifies readyForSync=true for the #1252 minimal contract when backend/account/csrf/x-li-track/query IDs/templates are present.
- AC10e verifies shape-only legacy contracts without reusable templates still fail readiness.

Verification result:
- First ran node chrome-extension/test_background.mjs after adding tests only: reproduced failure (9 failing assertions) because count was still required.
- Ran node chrome-extension/test_background.mjs after fix: 158 passed, 0 failed.
- Ran uv run pytest: 425 passed in 11.03s.
- Ran git diff --check: passed.
- Committed changes: d50aadd fix(#1258): accept no-count LinkedIn GraphQL contracts.

Production expectation: After this PR is approved/merged, #1252 should rerun from the existing clean detached-worktree validation shape and prove real extension Sync Now stores non-empty threads/messages. Do not rerun #1252 as final proof until this PR is merged/approved.

---
Task: #1258 — Fix extension sync for LinkedIn GraphQL contracts without count
Opened automatically by mission-control dispatcher.