### PR TITLE
Fix LinkedIn extension conversations GraphQL 400 after no-count replay

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -521,21 +521,22 @@ function extractProfileId(data) {
 
   // For conversations, mailboxUrn must be the fsd_profile URN captured by LinkedIn
   // traffic. /voyager/api/me may also include a numeric plainId; prefer any
-  // fsd_profile URN so no-count contracts replay with the exact mailbox family.
+  // fsd_profile URN so no-count contracts replay with the exact mailbox family,
+  // but preserve the old plainId-first fallback when only non-fsd identifiers exist.
+  addCandidate(data.plainId);
   addCandidate(data.entityUrn);
+  addCandidate(data.publicIdentifier);
   const inner = data.data;
   if (inner && typeof inner === "object") {
-    addCandidate(inner.entityUrn);
+    addCandidate(inner.plainId);
     addCandidate(inner["*miniProfile"]);
+    addCandidate(inner.entityUrn);
   }
   if (Array.isArray(data.included)) {
     for (const item of data.included) {
       if (item && typeof item === "object") addCandidate(item.dashEntityUrn);
     }
   }
-  addCandidate(data.plainId);
-  addCandidate(data.publicIdentifier);
-  if (inner && typeof inner === "object") addCandidate(inner.plainId);
 
   return candidates.find((candidate) => candidate.includes("fsd_profile:")) || candidates[0] || null;
 }

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -513,23 +513,31 @@ function buildLinkedInHeaders(captured) {
 
 function extractProfileId(data) {
   if (!data || typeof data !== "object") return null;
-  if (data.plainId) return String(data.plainId);
-  if (data.entityUrn) return String(data.entityUrn);
-  if (data.publicIdentifier) return String(data.publicIdentifier);
+
+  const candidates = [];
+  const addCandidate = (value) => {
+    if (value !== undefined && value !== null && String(value).trim()) candidates.push(String(value));
+  };
+
+  // For conversations, mailboxUrn must be the fsd_profile URN captured by LinkedIn
+  // traffic. /voyager/api/me may also include a numeric plainId; prefer any
+  // fsd_profile URN so no-count contracts replay with the exact mailbox family.
+  addCandidate(data.entityUrn);
   const inner = data.data;
   if (inner && typeof inner === "object") {
-    if (inner.plainId) return String(inner.plainId);
-    if (inner["*miniProfile"]) return String(inner["*miniProfile"]);
-    if (inner.entityUrn) return String(inner.entityUrn);
+    addCandidate(inner.entityUrn);
+    addCandidate(inner["*miniProfile"]);
   }
   if (Array.isArray(data.included)) {
     for (const item of data.included) {
-      if (item && typeof item === "object" && item.dashEntityUrn && String(item.dashEntityUrn).includes("fsd_profile")) {
-        return String(item.dashEntityUrn);
-      }
+      if (item && typeof item === "object") addCandidate(item.dashEntityUrn);
     }
   }
-  return null;
+  addCandidate(data.plainId);
+  addCandidate(data.publicIdentifier);
+  if (inner && typeof inner === "object") addCandidate(inner.plainId);
+
+  return candidates.find((candidate) => candidate.includes("fsd_profile:")) || candidates[0] || null;
 }
 
 function buildMailboxUrn(profileId) {

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -164,29 +164,33 @@ function buildEnv({ linkedinResponses } = {}) {
       const isMsg = u.includes("queryId=messengerMessages");
       let body;
       if (isConv) {
-        body = lr.conversations === undefined
-          ? {
-              data: {
-                messengerConversationsBySyncToken: {
-                  elements: [
-                    {
-                      entityUrn: "urn:li:msg_conversation:1",
-                      conversationName: null,
-                      conversationParticipants: [
-                        { participantProfile: { entityUrn: "urn:li:fsd_profile:99", firstName: "Alice", lastName: "Example" } },
-                      ],
-                    },
-                    {
-                      entityUrn: "urn:li:msg_conversation:2",
-                      conversationName: "Group Chat",
-                      conversationParticipants: [],
-                    },
-                  ],
-                  metadata: {},
+        if (typeof lr.conversations === "function") {
+          body = lr.conversations(u, options || {});
+        } else {
+          body = lr.conversations === undefined
+            ? {
+                data: {
+                  messengerConversationsBySyncToken: {
+                    elements: [
+                      {
+                        entityUrn: "urn:li:msg_conversation:1",
+                        conversationName: null,
+                        conversationParticipants: [
+                          { participantProfile: { entityUrn: "urn:li:fsd_profile:99", firstName: "Alice", lastName: "Example" } },
+                        ],
+                      },
+                      {
+                        entityUrn: "urn:li:msg_conversation:2",
+                        conversationName: "Group Chat",
+                        conversationParticipants: [],
+                      },
+                    ],
+                    metadata: {},
+                  },
                 },
-              },
-            }
-          : lr.conversations;
+              }
+            : lr.conversations;
+        }
       } else if (isMsg) {
         body = lr.messages === undefined
           ? {
@@ -552,6 +556,45 @@ async function testAC5d_manualSyncNoCountContractOmitsSyntheticCount() {
   if (msgCall) {
     const variables = decodeURIComponent(new URL(msgCall.url).searchParams.get("variables") || "");
     assert(variables === "(conversationUrn:urn:li:msg_conversation:1)", `messages variables omit synthetic count (got: ${variables})`);
+  }
+}
+
+
+async function testAC5e_manualSync1252Attempt3NoCountUsesFsdProfileUrnFromMe() {
+  console.log("\nAC5e: #1252 Attempt #3 no-count conversations replay uses fsd_profile entityUrn from /me");
+  const expectedMailboxUrn = "urn:li:fsd_profile:ACoA-real-fsd-profile";
+  const wrongPlainMailboxUrn = "urn:li:fsd_profile:123456789";
+  const env = buildEnv({
+    linkedinResponses: {
+      me: {
+        plainId: "123456789",
+        entityUrn: expectedMailboxUrn,
+      },
+      conversations: (url) => {
+        const variables = decodeURIComponent(new URL(url).searchParams.get("variables") || "");
+        if (variables.includes(`mailboxUrn:${wrongPlainMailboxUrn}`)) return { __error__: 400 };
+        if (!variables.includes(`mailboxUrn:${expectedMailboxUrn}`)) return { __error__: 400 };
+        return { data: { messengerConversationsBySyncToken: { elements: [], metadata: {} } } };
+      },
+    },
+  });
+  env.storage.accountId = 1;
+  env.storage.xLiTrack = "SYNC_TRACK";
+  env.storage.csrfToken = "SYNC_CSRF";
+  env.storage.messagingContract = {
+    ...FRESH_MINIMAL_NO_COUNT_CONTRACT,
+    conversationsQueryId: "messengerConversations.1252Attempt3",
+  };
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  assert(resp.ok === true, `#1252 replay does not hit conversations HTTP 400 (got: ${JSON.stringify(resp)})`);
+
+  const convCall = env.fetchLog.find(f => f.url.includes("queryId=messengerConversations"));
+  assert(!!convCall, "extension fetched conversations for #1252 no-count replay");
+  if (convCall) {
+    const variables = decodeURIComponent(new URL(convCall.url).searchParams.get("variables") || "");
+    assert(variables === `(mailboxUrn:${expectedMailboxUrn})`, `conversations variables use fsd_profile entityUrn, not plainId (got: ${variables})`);
   }
 }
 
@@ -1013,6 +1056,7 @@ async function main() {
   await testAC4_headerCapture();
   await testAC5_manualSyncReadsLinkedInAndIngests();
   await testAC5d_manualSyncNoCountContractOmitsSyntheticCount();
+  await testAC5e_manualSync1252Attempt3NoCountUsesFsdProfileUrnFromMe();
   await testAC5b_manualSyncIncludesBearerToken();
   await testAC5c_extensionDirectionForMyMessages();
   await testAC6_manualRefresh();

--- a/chrome-extension/test_background.mjs
+++ b/chrome-extension/test_background.mjs
@@ -598,6 +598,39 @@ async function testAC5e_manualSync1252Attempt3NoCountUsesFsdProfileUrnFromMe() {
   }
 }
 
+async function testAC5f_manualSyncKeepsPlainIdFallbackForNonFsdEntityUrn() {
+  console.log("\nAC5f: MANUAL_SYNC keeps plainId fallback when /me entityUrn is not fsd_profile");
+  const env = buildEnv({
+    linkedinResponses: {
+      me: {
+        plainId: "123456789",
+        entityUrn: "urn:li:member:should-not-be-wrapped",
+      },
+      conversations: (url) => {
+        const variables = decodeURIComponent(new URL(url).searchParams.get("variables") || "");
+        if (variables.includes("urn:li:fsd_profile:urn:li:member:")) return { __error__: 400 };
+        if (!variables.includes("mailboxUrn:urn:li:fsd_profile:123456789")) return { __error__: 400 };
+        return { data: { messengerConversationsBySyncToken: { elements: [], metadata: {} } } };
+      },
+    },
+  });
+  env.storage.accountId = 1;
+  env.storage.xLiTrack = "SYNC_TRACK";
+  env.storage.csrfToken = "SYNC_CSRF";
+  env.storage.messagingContract = FRESH_MINIMAL_NO_COUNT_CONTRACT;
+  loadBackground(env);
+
+  const resp = await env.chrome.runtime.sendMessage({ type: "MANUAL_SYNC" });
+  assert(resp.ok === true, `non-fsd /me entityUrn does not corrupt mailboxUrn (got: ${JSON.stringify(resp)})`);
+
+  const convCall = env.fetchLog.find(f => f.url.includes("queryId=messengerConversations"));
+  assert(!!convCall, "extension fetched conversations with plainId fallback");
+  if (convCall) {
+    const variables = decodeURIComponent(new URL(convCall.url).searchParams.get("variables") || "");
+    assert(variables === "(mailboxUrn:urn:li:fsd_profile:123456789)", `conversations variables use plainId fallback for non-fsd entityUrn (got: ${variables})`);
+  }
+}
+
 async function testAC5b_manualSyncIncludesBearerToken() {
   console.log("\nAC5b: MANUAL_SYNC includes Authorization on /sync/ingest when apiToken configured");
   const env = buildEnv();
@@ -1057,6 +1090,7 @@ async function main() {
   await testAC5_manualSyncReadsLinkedInAndIngests();
   await testAC5d_manualSyncNoCountContractOmitsSyntheticCount();
   await testAC5e_manualSync1252Attempt3NoCountUsesFsdProfileUrnFromMe();
+  await testAC5f_manualSyncKeepsPlainIdFallbackForNonFsdEntityUrn();
   await testAC5b_manualSyncIncludesBearerToken();
   await testAC5c_extensionDirectionForMyMessages();
   await testAC6_manualRefresh();

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -37,7 +37,7 @@ Impact:
 
 ## 4. `/voyager/api/me` bootstrap is safer, but still a hard dependency
 
-Sync still needs `/voyager/api/me` to resolve the mailbox/profile URN before thread listing can start.
+Sync still needs `/voyager/api/me` to resolve the mailbox/profile URN before thread listing can start. The extension prefers a returned `urn:li:fsd_profile:...` value (for example `entityUrn`/`dashEntityUrn`) over `plainId`, because current no-count conversations contracts replay `mailboxUrn` as the live `fsd_profile` URN and can 400 when the numeric plainId is rewrapped instead.
 
 Current behavior:
 - redirected or auth-rejected `/voyager/api/me` responses now surface as explicit session/bootstrap failures with `POST /accounts/refresh` guidance


### PR DESCRIPTION
Rejection addressed: rebased work onto current origin/main (merge-base now origin/main 24c9d8f) and pruned the stale deleted origin/objective remote-tracking ref to avoid the prior stale-info push path. Files changed: chrome-extension/background.js — profile bootstrap now prefers any safe urn:li:fsd_profile value from /voyager/api/me for mailboxUrn replay while preserving plainId fallback for non-fsd identifiers; chrome-extension/test_background.mjs — added functional conversation response hooks plus #1252 Attempt #3 regression and fallback guard; docs/known-issues.md — documented fsd_profile mailbox replay guidance. Tests added/modified: testAC5e_manualSync1252Attempt3NoCountUsesFsdProfileUrnFromMe verifies the no-count conversations replay uses the fsd_profile entityUrn instead of rewrapping plainId and avoids the mocked LinkedIn HTTP 400; testAC5f_manualSyncKeepsPlainIdFallbackForNonFsdEntityUrn verifies non-fsd entityUrn does not corrupt mailboxUrn fallback. Regression proof: the new test suite run against origin/main background exited 1 with AC5e reproducing LinkedIn conversations request failed (400) and mailboxUrn:urn:li:fsd_profile:123456789. Verification: node chrome-extension/test_background.mjs passed 164/164; uv run pytest passed 425/425; git diff --check passed; final status clean with HEAD 18e2ed7. Noteworthy: existing rich-with-count and minimal-no-count contract behavior remains covered and passing; no raw cookies/tokens/headers were stored or printed. #1252 must rerun after this PR lands for final signed-in extension Sync Now proof; this dev PR does not mark O-24 achieved by tests alone.

---
Task: #1305 — Fix LinkedIn extension conversations GraphQL 400 after no-count replay
Opened automatically by mission-control dispatcher.