### PR TITLE
Expand LinkedIn DMs CLI into safe operator command suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,11 +206,33 @@ secrets, browser CSRF material, or local API auth values.
 
 ## Running the CLI
 
-The CLI uses the same storage and provider stack as the API.
+The CLI uses the same SQLite storage and provider stack as the API, but is safe-by-default for operator workflows. Browsing, search, status, drafts, and campaign dry-runs are local-only. Live sends are approval-gated and refuse to run unless an approved local approval record matches the exact account, recipient, text hash, and idempotency key.
 
 ```bash
-python -m apps.cli sync --account-id 1
-python -m apps.cli send --account-id 1 --recipient 'urn:li:fsd_profile:123' --text 'Hello'
+# Local status and account readiness
+python -m apps.cli status --db-path ./desearch_linkedin_dms.sqlite
+python -m apps.cli auth status --account-id 1
+
+# Sync reads LinkedIn and writes local cache; pagination defaults to one page per thread
+python -m apps.cli sync --account-id 1 --limit-per-thread 50
+python -m apps.cli sync --account-id 1 --dry-run
+
+# Local inbox/search/detail inspection
+python -m apps.cli inbox --account-id 1 --limit 25 --json
+python -m apps.cli search --account-id 1 --query bittensor --direction in --json
+python -m apps.cli threads list --account-id 1 --limit 25 --json
+python -m apps.cli threads show --account-id 1 --thread-id 10 --include-messages --json
+python -m apps.cli messages list --account-id 1 --thread-id 10 --json
+
+# Local draft only; this does not send to LinkedIn
+python -m apps.cli draft-reply --account-id 1 --recipient 'urn:li:fsd_profile:123' --text 'Hello' --idempotency-key linkedin-dm-2026-05-10-001
+
+# Campaign execution is dry-run only in this phase
+python -m apps.cli campaign status --campaign-id 5 --account-id 1
+python -m apps.cli campaign run --campaign-id 5 --account-id 1 --dry-run
+
+# Live send requires explicit approved evidence; text alone is rejected
+python -m apps.cli send --approved appr_20260510_000031 --account-id 1 --recipient 'urn:li:fsd_profile:123' --text 'Hello' --idempotency-key linkedin-dm-2026-05-10-001
 ```
 
 Useful sync options:
@@ -220,13 +242,22 @@ Useful sync options:
 - `--exhaust-pagination`
 - `--delay-threads SEC`
 - `--delay-pages SEC`
+- `--dry-run`
 
 CLI pagination behavior matches the API:
 - default effective behavior is one page per thread
 - `--max-pages-per-thread N` sets an explicit cap
 - `--exhaust-pagination` follows cursors until exhaustion
 
-Useful send option:
+Useful read/detail options:
+- `--json` for machine-readable output (the CLI emits JSON on success by default)
+- `--limit N` and `--cursor CURSOR` for local pagination
+- `--unread`/`--unread-only` on inbox (currently no local unread state is tracked)
+- `--from`, `--to`, and `--direction in|out` on search
+
+Useful send options:
+- `--approved APPROVAL_ID` (required for live sends)
+- `--draft-id ID` to source recipient/body from a stored draft
 - `--idempotency-key KEY`
 
 ## Account authentication input
@@ -296,7 +327,7 @@ Set `max_pages_per_thread` to `null` in the API or pass `--exhaust-pagination` i
 
 ## Send behavior
 
-`POST /send` and `python -m apps.cli send` both call `libs.core.job_runner.run_send()`.
+`POST /send`, `/ops/send-approved`, and the CLI ultimately call `libs.core.job_runner.run_send()`, but the operator CLI only exposes the approval-gated path.
 
 Current behavior:
 - creates or reuses an outbound send record before calling LinkedIn
@@ -304,6 +335,7 @@ Current behavior:
 - retries transient network errors and backs off on rate limiting
 - stores successful outbound messages in both `outbound_sends` and `messages`
 - exposes historical send records through `GET /sends`
+- requires `python -m apps.cli send --approved APPROVAL_ID ...`; without approved state the CLI exits non-zero before loading the provider
 
 ## Storage summary
 
@@ -314,8 +346,13 @@ The SQLite database currently contains these tables:
 - `sync_cursors`
 - `schema_version`
 - `outbound_sends`
+- `draft_replies`
+- `send_approvals`
+- `campaigns`
+- `campaign_recipients`
+- `ops_audit_events`
 
-Migrations also add message direction constraints, indexes, and the `outbound_sends(account_id, status)` lookup path used by `GET /sends`.
+Migrations also add message direction constraints, indexes, the `outbound_sends(account_id, status)` lookup path used by `GET /sends`, and local Ops Console tables for drafts, approvals, campaign dry-run state, and redacted audit evidence.
 
 ## Security notes
 

--- a/apps/cli/__main__.py
+++ b/apps/cli/__main__.py
@@ -1,6 +1,6 @@
-"""CLI entrypoint: sync and send without running FastAPI.
+"""Safe operator CLI for local LinkedIn DM sync, browsing, drafts, and approved sends.
 
-Run from repo root (or installed package): ``python -m apps.cli sync --account-id 1``
+Run from repo root (or installed package): ``python -m apps.cli status``.
 """
 from __future__ import annotations
 
@@ -9,8 +9,10 @@ import json
 import logging
 import sqlite3
 import sys
+from datetime import datetime, timezone
+from importlib import metadata
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Sequence
 
 import httpx
 
@@ -23,12 +25,28 @@ from libs.providers.linkedin.provider import LinkedInProvider, MAX_MESSAGES_PER_
 logger = logging.getLogger(__name__)
 
 _PROVIDER_TODO = "Provider not implemented. Implement libs/providers/linkedin/provider.py"
-
 _SEND_TEXT_MAX_LEN = 8000
+_SERVICE_NAME = "linkedin-dms"
+_DEFAULT_API_URL = "http://127.0.0.1:8899"
 
 
 def _stderr(msg: str) -> None:
     print(msg, file=sys.stderr)
+
+
+def _json(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, sort_keys=True))
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _service_version() -> str:
+    try:
+        return metadata.version("desearch-dms")
+    except metadata.PackageNotFoundError:
+        return "0.0.1"
 
 
 def _open_storage(db_path: str | None) -> Storage:
@@ -37,21 +55,45 @@ def _open_storage(db_path: str | None) -> Storage:
     return Storage(db_path=Path(db_path))
 
 
-def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        prog="python -m apps.cli",
-        description="Run sync/send against local SQLite storage (no web server).",
-    )
-
-    sub = parser.add_subparsers(dest="command", required=True)
-
-    p_sync = sub.add_parser("sync", help="Fetch threads and messages into storage")
-    p_sync.add_argument(
+def _add_db_path(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
         "--db-path",
         metavar="PATH",
         default=None,
         help="SQLite database file (default: ./desearch_linkedin_dms.sqlite)",
     )
+
+
+def _add_json_flag(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON (default for this CLI)")
+
+
+def _add_pagination(parser: argparse.ArgumentParser, *, default_limit: int = 25) -> None:
+    parser.add_argument("--limit", type=int, default=default_limit, metavar="N")
+    parser.add_argument("--cursor", default=None, metavar="CURSOR")
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m apps.cli",
+        description="Safe local operator CLI for LinkedIn DM sync, browsing, drafts, and approved sends.",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_status = sub.add_parser("status", help="Show local service/database status")
+    _add_db_path(p_status)
+    _add_json_flag(p_status)
+
+    p_auth = sub.add_parser("auth", help="Account authentication checks")
+    auth_sub = p_auth.add_subparsers(dest="auth_command", required=True)
+    p_auth_status = auth_sub.add_parser("status", help="Show stored auth readiness for an account")
+    _add_db_path(p_auth_status)
+    p_auth_status.add_argument("--account-id", type=int, required=True, metavar="ID")
+    _add_json_flag(p_auth_status)
+
+    p_sync = sub.add_parser("sync", help="Fetch threads and messages into storage")
+    _add_db_path(p_sync)
     p_sync.add_argument("--account-id", type=int, required=True, metavar="ID")
     p_sync.add_argument(
         "--limit-per-thread",
@@ -86,23 +128,86 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         metavar="SEC",
         help="Seconds to pause between fetch_messages pages (default: 1.5)",
     )
+    p_sync.add_argument("--dry-run", action="store_true", help="Validate account/options without reading LinkedIn or writing storage")
 
-    p_send = sub.add_parser("send", help="Send one DM via the LinkedIn provider")
-    p_send.add_argument(
-        "--db-path",
-        metavar="PATH",
-        default=None,
-        help="SQLite database file (default: ./desearch_linkedin_dms.sqlite)",
-    )
+    p_inbox = sub.add_parser("inbox", help="List stored inbox threads")
+    _add_db_path(p_inbox)
+    p_inbox.add_argument("--account-id", type=int, required=True, metavar="ID")
+    _add_pagination(p_inbox, default_limit=25)
+    p_inbox.add_argument("--unread", "--unread-only", dest="unread_only", action="store_true", help="Only include locally unread threads (currently none are marked unread)")
+    _add_json_flag(p_inbox)
+
+    p_search = sub.add_parser("search", help="Search stored message text locally")
+    _add_db_path(p_search)
+    p_search.add_argument("--account-id", type=int, required=True, metavar="ID")
+    p_search.add_argument("--query", "-q", required=True, metavar="TEXT")
+    p_search.add_argument("--from", dest="from_date", default=None, metavar="YYYY-MM-DD")
+    p_search.add_argument("--to", dest="to_date", default=None, metavar="YYYY-MM-DD")
+    p_search.add_argument("--direction", choices=["in", "out"], default=None)
+    _add_pagination(p_search, default_limit=25)
+    _add_json_flag(p_search)
+
+    p_threads = sub.add_parser("threads", help="List or inspect stored threads")
+    threads_sub = p_threads.add_subparsers(dest="threads_command", required=True)
+    p_threads_list = threads_sub.add_parser("list", help="List stored threads")
+    _add_db_path(p_threads_list)
+    p_threads_list.add_argument("--account-id", type=int, required=True, metavar="ID")
+    _add_pagination(p_threads_list, default_limit=25)
+    _add_json_flag(p_threads_list)
+    p_threads_show = threads_sub.add_parser("show", help="Show a stored thread")
+    _add_db_path(p_threads_show)
+    p_threads_show.add_argument("--account-id", type=int, required=True, metavar="ID")
+    p_threads_show.add_argument("--thread-id", type=int, required=True, metavar="ID")
+    p_threads_show.add_argument("--include-messages", action="store_true")
+    p_threads_show.add_argument("--limit", type=int, default=50, metavar="N")
+    _add_json_flag(p_threads_show)
+
+    p_messages = sub.add_parser("messages", help="Inspect stored messages")
+    messages_sub = p_messages.add_subparsers(dest="messages_command", required=True)
+    p_messages_list = messages_sub.add_parser("list", help="List stored messages for one thread")
+    _add_db_path(p_messages_list)
+    p_messages_list.add_argument("--account-id", type=int, required=True, metavar="ID")
+    p_messages_list.add_argument("--thread-id", type=int, required=True, metavar="ID")
+    _add_pagination(p_messages_list, default_limit=50)
+    _add_json_flag(p_messages_list)
+
+    p_draft = sub.add_parser("draft-reply", help="Create a local reply draft and approval candidate without sending")
+    _add_db_path(p_draft)
+    p_draft.add_argument("--account-id", type=int, required=True, metavar="ID")
+    target = p_draft.add_mutually_exclusive_group(required=True)
+    target.add_argument("--thread-id", type=int, metavar="ID")
+    target.add_argument("--recipient", metavar="URN_OR_CONV_ID")
+    body = p_draft.add_mutually_exclusive_group(required=True)
+    body.add_argument("--text", metavar="BODY")
+    body.add_argument("--text-file", metavar="PATH")
+    p_draft.add_argument("--campaign-id", type=int, default=None, metavar="ID")
+    p_draft.add_argument("--idempotency-key", default=None, metavar="KEY")
+    _add_json_flag(p_draft)
+
+    p_campaign = sub.add_parser("campaign", help="Inspect or dry-run local campaign state")
+    campaign_sub = p_campaign.add_subparsers(dest="campaign_command", required=True)
+    p_campaign_status = campaign_sub.add_parser("status", help="Show local campaign status")
+    _add_db_path(p_campaign_status)
+    p_campaign_status.add_argument("--campaign-id", type=int, required=True, metavar="ID")
+    p_campaign_status.add_argument("--account-id", type=int, default=None, metavar="ID")
+    _add_json_flag(p_campaign_status)
+    p_campaign_run = campaign_sub.add_parser("run", help="Build a local campaign run plan")
+    _add_db_path(p_campaign_run)
+    p_campaign_run.add_argument("--campaign-id", type=int, required=True, metavar="ID")
+    p_campaign_run.add_argument("--account-id", type=int, required=True, metavar="ID")
+    p_campaign_run.add_argument("--dry-run", action="store_true", help="Required; no external writes are performed")
+    p_campaign_run.add_argument("--limit", type=int, default=25, metavar="N")
+    _add_json_flag(p_campaign_run)
+
+    p_send = sub.add_parser("send", help="Send one DM only with approved local evidence")
+    _add_db_path(p_send)
+    p_send.add_argument("--approved", default=None, metavar="APPROVAL_ID", help="Required approval id in state approved")
     p_send.add_argument("--account-id", type=int, required=True, metavar="ID")
-    p_send.add_argument("--recipient", required=True, metavar="URN_OR_CONV_ID")
-    p_send.add_argument("--text", required=True, metavar="BODY")
-    p_send.add_argument(
-        "--idempotency-key",
-        default=None,
-        metavar="KEY",
-        help="Optional idempotency key (same as API)",
-    )
+    p_send.add_argument("--recipient", default=None, metavar="URN_OR_CONV_ID")
+    send_body = p_send.add_mutually_exclusive_group()
+    send_body.add_argument("--text", default=None, metavar="BODY")
+    send_body.add_argument("--draft-id", type=int, default=None, metavar="ID")
+    p_send.add_argument("--idempotency-key", default=None, metavar="KEY")
 
     args = parser.parse_args(list(argv) if argv is not None else None)
 
@@ -111,9 +216,10 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
             parser.error("cannot combine --exhaust-pagination with --max-pages-per-thread")
         if not (1 <= args.limit_per_thread <= MAX_MESSAGES_PER_PAGE):
             parser.error(f"--limit-per-thread must be between 1 and {MAX_MESSAGES_PER_PAGE}")
-        max_pages: int | None
+        if args.delay_threads < 0 or args.delay_pages < 0:
+            parser.error("sync delays must be non-negative")
         if args.exhaust_pagination:
-            max_pages = None
+            max_pages: int | None = None
         elif args.max_pages_per_thread is not None:
             if not (1 <= args.max_pages_per_thread <= 100):
                 parser.error("--max-pages-per-thread must be between 1 and 100")
@@ -121,6 +227,10 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         else:
             max_pages = 1
         args._resolved_max_pages = max_pages  # type: ignore[attr-defined]
+
+    for attr in ("limit",):
+        if hasattr(args, attr) and getattr(args, attr) is not None and not (1 <= getattr(args, attr) <= 100):
+            parser.error(f"--{attr} must be between 1 and 100")
 
     return args
 
@@ -131,6 +241,14 @@ def _account_must_exist(storage: Storage, account_id: int) -> tuple[AccountAuth,
     auth = storage.get_account_auth(account_id)
     proxy = storage.get_account_proxy(account_id)
     return auth, proxy
+
+
+def _account_exists(storage: Storage, account_id: int) -> bool:
+    try:
+        storage.get_account_ops_health(account_id)
+    except KeyError:
+        return False
+    return True
 
 
 def _load_provider(storage: Storage, account_id: int) -> LinkedInProvider | int:
@@ -146,16 +264,94 @@ def _load_provider(storage: Storage, account_id: int) -> LinkedInProvider | int:
     return LinkedInProvider(auth=auth, proxy=proxy, account_id=account_id)
 
 
+def _read_text_arg(args: argparse.Namespace) -> str:
+    text = args.text
+    if text is None and getattr(args, "text_file", None):
+        text = Path(args.text_file).read_text()
+    if text is None:
+        raise ValueError("--text or --text-file is required")
+    if len(text) < 1:
+        raise ValueError("--text must be non-empty")
+    if len(text) > _SEND_TEXT_MAX_LEN:
+        raise ValueError(f"--text must be at most {_SEND_TEXT_MAX_LEN} characters")
+    return text
+
+
+def _cmd_status(storage: Storage, args: argparse.Namespace) -> int:
+    payload = {
+        "ok": True,
+        "service": _SERVICE_NAME,
+        "version": _service_version(),
+        "db": {
+            "path": str(args.db_path or "./desearch_linkedin_dms.sqlite"),
+            "reachable": True,
+            "schema_version": storage._get_schema_version(),
+        },
+        "api": {
+            "configured_url": _DEFAULT_API_URL,
+            "reachable": None,
+            "auth_required": True,
+        },
+        "counts": storage.ops_counts(),
+        "warnings": [],
+    }
+    _json(payload)
+    return 0
+
+
+def _cmd_auth_status(storage: Storage, args: argparse.Namespace) -> int:
+    try:
+        health = storage.get_account_ops_health(args.account_id)
+    except KeyError:
+        _stderr(f"error: account {args.account_id} not found")
+        return 1
+    payload = {
+        "ok": health["status"] == "ok",
+        "account_id": args.account_id,
+        "status": health["status"],
+        "checked_at": health["checked_at"],
+        "session": health["session"],
+        "error": health["error"],
+        "next_action": health["next_action"],
+    }
+    _json(payload)
+    return 0 if payload["ok"] else 1
+
+
 def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
+    max_pages: int | None = args._resolved_max_pages  # type: ignore[attr-defined]
+    if args.dry_run:
+        if args.account_id < 1:
+            _stderr("error: account id must be a positive integer")
+            return 1
+        if not _account_exists(storage, args.account_id):
+            _stderr(f"error: account {args.account_id} not found")
+            return 1
+        _json({
+            "ok": True,
+            "account_id": args.account_id,
+            "dry_run": True,
+            "planned": {
+                "limit_per_thread": args.limit_per_thread,
+                "max_pages_per_thread": max_pages,
+                "delay_between_threads_s": args.delay_threads,
+                "delay_between_pages_s": args.delay_pages,
+            },
+            "external_reads": 0,
+            "external_writes": 0,
+            "warnings": [],
+        })
+        return 0
+
     loaded = _load_provider(storage, args.account_id)
     if isinstance(loaded, int):
         return loaded
     provider = loaded
-    max_pages: int | None = args._resolved_max_pages  # type: ignore[attr-defined]
     sync_config = SyncConfig(
         delay_between_threads_s=args.delay_threads,
         delay_between_pages_s=args.delay_pages,
     )
+    started_at = _now_iso()
     try:
         result: SyncResult = run_sync(
             account_id=args.account_id,
@@ -175,32 +371,220 @@ def _cmd_sync(storage: Storage, args: argparse.Namespace) -> int:
 
     payload = {
         "ok": True,
+        "account_id": args.account_id,
+        "dry_run": False,
         "synced_threads": result.synced_threads,
         "messages_inserted": result.messages_inserted,
         "messages_skipped_duplicate": result.messages_skipped_duplicate,
         "pages_fetched": result.pages_fetched,
         "rate_limited": result.rate_limited,
+        "started_at": started_at,
+        "finished_at": _now_iso(),
+        "warnings": [],
     }
-    print(json.dumps(payload))
+    _json(payload)
     return 0
 
 
-def _cmd_send(storage: Storage, args: argparse.Namespace) -> int:
-    recipient = args.recipient
-    text = args.text
-    if len(recipient) < 1:
-        _stderr("error: --recipient must be non-empty")
+def _cmd_inbox(storage: Storage, args: argparse.Namespace) -> int:
+    try:
+        page = storage.list_inbox_threads(account_id=args.account_id, limit=args.limit, cursor=args.cursor)
+    except KeyError:
+        _stderr(f"error: account {args.account_id} not found")
         return 1
-    if len(text) < 1:
-        _stderr("error: --text must be non-empty")
+    except ValueError as exc:
+        _stderr(f"error: {exc}")
         return 1
-    if len(text) > _SEND_TEXT_MAX_LEN:
-        _stderr(f"error: --text must be at most {_SEND_TEXT_MAX_LEN} characters")
+    threads = [t for t in page["threads"] if (not args.unread_only or t["unread"])]
+    _json({"ok": True, "account_id": args.account_id, "threads": threads, "page": page["page"]})
+    return 0
+
+
+def _cmd_search(storage: Storage, args: argparse.Namespace) -> int:
+    try:
+        page = storage.search_messages(
+            account_id=args.account_id,
+            query=args.query,
+            direction=args.direction,
+            from_date=args.from_date,
+            to_date=args.to_date,
+            limit=args.limit,
+            cursor=args.cursor,
+        )
+    except KeyError:
+        _stderr(f"error: account {args.account_id} not found")
+        return 1
+    except ValueError as exc:
+        _stderr(f"error: {exc}")
+        return 1
+    _json({
+        "ok": True,
+        "account_id": args.account_id,
+        "query": args.query,
+        "filters": {"from": args.from_date, "to": args.to_date, "direction": args.direction},
+        "results": page["results"],
+        "page": page["page"],
+        "fts": page["fts"],
+    })
+    return 0
+
+
+def _cmd_threads(storage: Storage, args: argparse.Namespace) -> int:
+    try:
+        if args.threads_command == "list":
+            page = storage.list_ops_threads(account_id=args.account_id, limit=args.limit, cursor=args.cursor)
+            _json({"ok": True, "account_id": args.account_id, "threads": page["threads"], "page": page["page"]})
+            return 0
+        thread = storage.get_thread_detail(account_id=args.account_id, thread_id=args.thread_id)
+        payload: dict[str, Any] = {"ok": True, "account_id": args.account_id, "thread": thread}
+        if args.include_messages:
+            messages = storage.list_thread_messages(
+                account_id=args.account_id,
+                thread_id=args.thread_id,
+                limit=args.limit,
+                cursor=None,
+            )
+            payload["messages"] = messages["messages"]
+            payload["page"] = messages["page"]
+        _json(payload)
+        return 0
+    except KeyError as exc:
+        _stderr(f"error: {exc}")
+        return 1
+    except ValueError as exc:
+        _stderr(f"error: {exc}")
         return 1
 
+
+def _cmd_messages(storage: Storage, args: argparse.Namespace) -> int:
+    try:
+        page = storage.list_thread_messages(
+            account_id=args.account_id,
+            thread_id=args.thread_id,
+            limit=args.limit,
+            cursor=args.cursor,
+        )
+    except KeyError as exc:
+        _stderr(f"error: {exc}")
+        return 1
+    except ValueError as exc:
+        _stderr(f"error: {exc}")
+        return 1
+    _json({"ok": True, "account_id": args.account_id, "thread_id": args.thread_id, "messages": page["messages"], "page": page["page"]})
+    return 0
+
+
+def _cmd_draft_reply(storage: Storage, args: argparse.Namespace) -> int:
+    try:
+        text = _read_text_arg(args)
+        if args.idempotency_key is not None and len(args.idempotency_key) < 1:
+            raise ValueError("--idempotency-key, if provided, must be non-empty")
+        recipient = args.recipient
+        if args.thread_id is not None and recipient is None:
+            recipient = storage.get_thread_detail(account_id=args.account_id, thread_id=args.thread_id)["platform_thread_id"]
+        if not recipient:
+            raise ValueError("recipient must be non-empty")
+        result = storage.create_draft_reply(
+            account_id=args.account_id,
+            thread_id=args.thread_id,
+            recipient=recipient,
+            text=text,
+            campaign_id=args.campaign_id,
+            idempotency_key=args.idempotency_key,
+        )
+    except (KeyError, ValueError, OSError) as exc:
+        _stderr(f"error: {exc}")
+        return 1
+    _json(result)
+    return 0
+
+
+def _empty_campaign_payload(campaign_id: int, account_id: int | None) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "campaign_id": campaign_id,
+        "account_id": account_id,
+        "state": "not_configured",
+        "totals": {"prospects": 0, "drafted": 0, "approved": 0, "sent": 0, "failed": 0, "skipped": 0},
+        "rate_limit": {"daily_cap": 0, "sent_today": 0, "remaining_today": 0, "next_safe_send_at": None},
+        "last_run": None,
+    }
+
+
+def _cmd_campaign(storage: Storage, args: argparse.Namespace) -> int:
+    if args.campaign_command == "status":
+        try:
+            status = storage.campaign_status(campaign_id=args.campaign_id, account_id=args.account_id)
+        except KeyError:
+            _stderr(f"error: account {args.account_id} not found")
+            return 1
+        _json({"ok": True, **(status or _empty_campaign_payload(args.campaign_id, args.account_id))})
+        return 0
+
+    if not args.dry_run:
+        _stderr("error: campaign run requires --dry-run; live campaign sends are not implemented")
+        return 2
+    try:
+        storage.get_account_ops_health(args.account_id)
+    except KeyError:
+        _stderr(f"error: account {args.account_id} not found")
+        return 1
+    _json({
+        "ok": True,
+        "campaign_id": args.campaign_id,
+        "account_id": args.account_id,
+        "dry_run": True,
+        "external_writes": 0,
+        "planned_actions": [],
+        "summary": {
+            "would_send_if_approved": 0,
+            "blocked_not_approved": 0,
+            "blocked_rate_limit": 0,
+            "blocked_missing_auth": 0,
+        },
+    })
+    return 0
+
+
+def _send_material_from_args(storage: Storage, args: argparse.Namespace) -> tuple[str, str, str | None]:
+    recipient = args.recipient
+    text = args.text
     idem = args.idempotency_key
+    if args.draft_id is not None:
+        draft = storage.get_draft_reply(account_id=args.account_id, draft_id=args.draft_id)
+        recipient = recipient or draft["recipient"]
+        text = draft["text"]
+        idem = idem if idem is not None else draft["idempotency_key"]
+    if not recipient:
+        raise ValueError("--recipient is required unless --draft-id supplies one")
+    if text is None:
+        raise ValueError("--text or --draft-id is required")
+    if len(recipient) < 1:
+        raise ValueError("--recipient must be non-empty")
+    if len(text) < 1:
+        raise ValueError("--text must be non-empty")
+    if len(text) > _SEND_TEXT_MAX_LEN:
+        raise ValueError(f"--text must be at most {_SEND_TEXT_MAX_LEN} characters")
     if idem is not None and len(idem) < 1:
-        _stderr("error: --idempotency-key, if provided, must be non-empty")
+        raise ValueError("--idempotency-key, if provided, must be non-empty")
+    return recipient, text, idem
+
+
+def _cmd_send(storage: Storage, args: argparse.Namespace) -> int:
+    if not args.approved:
+        _stderr("error: approval_required (--approved APPROVAL_ID is required before any live send)")
+        return 1
+    try:
+        recipient, text, idem = _send_material_from_args(storage, args)
+        storage.validate_send_approval(
+            approval_id=args.approved,
+            account_id=args.account_id,
+            recipient=recipient,
+            text=text,
+            idempotency_key=idem,
+        )
+    except (KeyError, ValueError) as exc:
+        _stderr(f"error: {exc}")
         return 1
 
     loaded = _load_provider(storage, args.account_id)
@@ -231,13 +615,19 @@ def _cmd_send(storage: Storage, args: argparse.Namespace) -> int:
         _stderr("error: send failed unexpectedly")
         return 1
 
-    print(json.dumps({
+    storage.mark_approval_used(args.approved)
+    _json({
         "ok": True,
+        "approved": True,
+        "approval_id": args.approved,
+        "account_id": args.account_id,
         "send_id": result.send_id,
         "platform_message_id": result.platform_message_id,
         "status": result.status,
         "was_duplicate": result.was_duplicate,
-    }))
+        "idempotency_key": idem,
+        "sent_at": _now_iso(),
+    })
     return 0
 
 
@@ -264,8 +654,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     try:
+        if args.command == "status":
+            return _cmd_status(storage, args)
+        if args.command == "auth" and args.auth_command == "status":
+            return _cmd_auth_status(storage, args)
         if args.command == "sync":
             return _cmd_sync(storage, args)
+        if args.command == "inbox":
+            return _cmd_inbox(storage, args)
+        if args.command == "search":
+            return _cmd_search(storage, args)
+        if args.command == "threads":
+            return _cmd_threads(storage, args)
+        if args.command == "messages":
+            return _cmd_messages(storage, args)
+        if args.command == "draft-reply":
+            return _cmd_draft_reply(storage, args)
+        if args.command == "campaign":
+            return _cmd_campaign(storage, args)
         if args.command == "send":
             return _cmd_send(storage, args)
         _stderr(f"error: unknown command {args.command!r}")

--- a/libs/core/storage.py
+++ b/libs/core/storage.py
@@ -907,6 +907,18 @@ class Storage:
             ).fetchall()
         return {"drafts": [self._draft_payload(r) for r in rows], "page": _page_meta(limit=limit, offset=offset, returned=len(rows))}
 
+    def get_draft_reply(self, *, account_id: int, draft_id: int) -> dict[str, Any]:
+        self._ensure_account_exists(account_id)
+        row = self._conn.execute(
+            "SELECT * FROM draft_replies WHERE account_id=? AND id=?",
+            (account_id, draft_id),
+        ).fetchone()
+        if not row:
+            raise KeyError(f"draft {draft_id} not found for account {account_id}")
+        payload = self._draft_payload(row)
+        payload["text"] = row["text"]
+        return payload
+
     def get_approval(self, approval_id: str) -> dict[str, Any] | None:
         row = self._conn.execute("SELECT * FROM send_approvals WHERE approval_id=?", (approval_id,)).fetchone()
         return dict(row) if row else None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,14 +62,14 @@ def test_cli_sync_stdout_json_on_success_with_mocked_empty_threads(
         )
     assert rc == 0
     out = json.loads(capsys.readouterr().out.strip())
-    assert out == {
-        "ok": True,
-        "synced_threads": 0,
-        "messages_inserted": 0,
-        "messages_skipped_duplicate": 0,
-        "pages_fetched": 0,
-        "rate_limited": False,
-    }
+    assert out["ok"] is True
+    assert out["account_id"] == account_id
+    assert out["dry_run"] is False
+    assert out["synced_threads"] == 0
+    assert out["messages_inserted"] == 0
+    assert out["messages_skipped_duplicate"] == 0
+    assert out["pages_fetched"] == 0
+    assert out["rate_limited"] is False
     inst.list_threads.assert_called_once_with()
 
 
@@ -169,8 +169,16 @@ def test_cli_sync_exhaust_pagination_passes_none_max_pages(
 
 
 def test_cli_send_stdout_json_on_success(
-    capsys: pytest.CaptureFixture[str], cli_db_path: str, account_id: int
+    capsys: pytest.CaptureFixture[str], cli_db_path: str, cli_storage: Storage, account_id: int
 ) -> None:
+    draft = cli_storage.create_draft_reply(
+        account_id=account_id,
+        thread_id=None,
+        recipient="urn:li:fsd_profile:ACoAAA",
+        text="hello",
+        idempotency_key=None,
+    )
+    cli_storage.approve_send_approval(draft["approval_id"], approved_by="test")
     with patch.object(cli_main, "LinkedInProvider") as m_cls:
         inst = MagicMock()
         inst.send_message.return_value = "urn:li:msg:1"
@@ -178,6 +186,8 @@ def test_cli_send_stdout_json_on_success(
         rc = cli_main.main(
             [
                 "send",
+                "--approved",
+                draft["approval_id"],
                 "--account-id",
                 str(account_id),
                 "--db-path",
@@ -191,6 +201,8 @@ def test_cli_send_stdout_json_on_success(
     assert rc == 0
     out = json.loads(capsys.readouterr().out.strip())
     assert out["ok"] is True
+    assert out["approved"] is True
+    assert out["approval_id"] == draft["approval_id"]
     assert out["platform_message_id"] == "urn:li:msg:1"
     assert out["status"] == "sent"
     assert out["was_duplicate"] is False
@@ -201,7 +213,15 @@ def test_cli_send_stdout_json_on_success(
     )
 
 
-def test_cli_send_passes_idempotency_key(cli_db_path: str, account_id: int) -> None:
+def test_cli_send_passes_idempotency_key(cli_db_path: str, cli_storage: Storage, account_id: int) -> None:
+    draft = cli_storage.create_draft_reply(
+        account_id=account_id,
+        thread_id=None,
+        recipient="r1",
+        text="t",
+        idempotency_key="k1",
+    )
+    cli_storage.approve_send_approval(draft["approval_id"], approved_by="test")
     with patch.object(cli_main, "LinkedInProvider") as m_cls:
         inst = MagicMock()
         inst.send_message.return_value = "mid"
@@ -209,6 +229,8 @@ def test_cli_send_passes_idempotency_key(cli_db_path: str, account_id: int) -> N
         rc = cli_main.main(
             [
                 "send",
+                "--approved",
+                draft["approval_id"],
                 "--account-id",
                 str(account_id),
                 "--db-path",
@@ -328,8 +350,16 @@ def test_cli_send_http_status_error_exits_one(cli_db_path: str, account_id: int)
 
 
 def test_cli_send_not_implemented_exits_one(
-    capsys: pytest.CaptureFixture[str], cli_db_path: str, account_id: int
+    capsys: pytest.CaptureFixture[str], cli_db_path: str, cli_storage: Storage, account_id: int
 ) -> None:
+    draft = cli_storage.create_draft_reply(
+        account_id=account_id,
+        thread_id=None,
+        recipient="r",
+        text="t",
+        idempotency_key=None,
+    )
+    cli_storage.approve_send_approval(draft["approval_id"], approved_by="test")
     with patch.object(cli_main, "LinkedInProvider") as m_cls:
         inst = MagicMock()
         inst.send_message.side_effect = NotImplementedError
@@ -337,6 +367,8 @@ def test_cli_send_not_implemented_exits_one(
         rc = cli_main.main(
             [
                 "send",
+                "--approved",
+                draft["approval_id"],
                 "--account-id",
                 str(account_id),
                 "--db-path",
@@ -374,3 +406,167 @@ def test_cli_module_invocation_help_succeeds() -> None:
     assert proc.returncode == 0
     assert "sync" in proc.stdout
     assert "send" in proc.stdout
+
+
+
+def _seed_cli_messages(storage: Storage, account_id: int) -> int:
+    from datetime import datetime, timezone
+
+    thread_id = storage.upsert_thread(
+        account_id=account_id,
+        platform_thread_id="urn:li:msg_conversation:ada",
+        title="Ada Lovelace",
+    )
+    storage.insert_message(
+        account_id=account_id,
+        thread_id=thread_id,
+        platform_message_id="msg-1",
+        direction="in",
+        sender="Ada",
+        text="Bittensor launch details li_at=AQED_DO_NOT_LEAK",
+        sent_at=datetime(2026, 5, 8, 9, 30, tzinfo=timezone.utc),
+        raw={"safe": True},
+    )
+    storage.insert_message(
+        account_id=account_id,
+        thread_id=thread_id,
+        platform_message_id="msg-2",
+        direction="out",
+        sender=None,
+        text="Thanks, this is helpful.",
+        sent_at=datetime(2026, 5, 10, 11, 55, tzinfo=timezone.utc),
+    )
+    return thread_id
+
+
+def test_cli_help_lists_operator_command_families(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        cli_main._parse_args(["--help"])
+    assert exc.value.code == 0
+    help_out = capsys.readouterr().out
+    for command in ["status", "auth", "sync", "inbox", "search", "threads", "messages", "draft-reply", "campaign", "send"]:
+        assert command in help_out
+
+
+def test_cli_status_json_empty_db(capsys: pytest.CaptureFixture[str], cli_db_path: str) -> None:
+    rc = cli_main.main(["status", "--db-path", cli_db_path])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["service"] == "linkedin-dms"
+    assert payload["counts"] == {
+        "accounts": 0,
+        "threads": 0,
+        "messages": 0,
+        "pending_approvals": 0,
+        "outbound_sends": 0,
+    }
+
+
+def test_cli_auth_status_unknown_account_exits_one(cli_db_path: str, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = cli_main.main(["auth", "status", "--account-id", "999", "--db-path", cli_db_path])
+    assert rc == 1
+    assert "account 999 not found" in capsys.readouterr().err
+
+
+def test_cli_inbox_search_thread_and_message_json_outputs(
+    capsys: pytest.CaptureFixture[str], cli_db_path: str, cli_storage: Storage, account_id: int
+) -> None:
+    thread_id = _seed_cli_messages(cli_storage, account_id)
+
+    assert cli_main.main(["inbox", "--account-id", str(account_id), "--db-path", cli_db_path, "--json"]) == 0
+    inbox = json.loads(capsys.readouterr().out)
+    assert inbox["threads"][0]["thread_id"] == thread_id
+    assert "AQED_DO_NOT_LEAK" not in str(inbox)
+
+    assert cli_main.main([
+        "search", "--account-id", str(account_id), "--db-path", cli_db_path, "--query", "bittensor", "--json"
+    ]) == 0
+    search = json.loads(capsys.readouterr().out)
+    assert search["results"][0]["thread_id"] == thread_id
+    assert "AQED_DO_NOT_LEAK" not in str(search)
+
+    assert cli_main.main([
+        "threads", "show", "--account-id", str(account_id), "--thread-id", str(thread_id),
+        "--db-path", cli_db_path, "--include-messages", "--json"
+    ]) == 0
+    detail = json.loads(capsys.readouterr().out)
+    assert detail["thread"]["id"] == thread_id
+    assert detail["messages"][0]["raw_available"] is True
+
+    assert cli_main.main([
+        "messages", "list", "--account-id", str(account_id), "--thread-id", str(thread_id), "--db-path", cli_db_path, "--json"
+    ]) == 0
+    messages = json.loads(capsys.readouterr().out)
+    assert messages["messages"][0]["platform_message_id"] == "msg-1"
+
+
+def test_cli_draft_reply_creates_local_draft_without_sending(
+    capsys: pytest.CaptureFixture[str], cli_db_path: str, account_id: int
+) -> None:
+    with patch.object(cli_main, "LinkedInProvider") as m_cls:
+        rc = cli_main.main([
+            "draft-reply", "--account-id", str(account_id), "--recipient", "urn:li:member:1",
+            "--text", "hello", "--idempotency-key", "idem-1", "--db-path", cli_db_path,
+        ])
+    assert rc == 0
+    draft = json.loads(capsys.readouterr().out)
+    assert draft["approval_state"] == "draft"
+    assert draft["external_writes"] == 0
+    m_cls.assert_not_called()
+
+
+def test_cli_campaign_run_requires_and_reports_dry_run(
+    capsys: pytest.CaptureFixture[str], cli_db_path: str, account_id: int
+) -> None:
+    rc = cli_main.main(["campaign", "run", "--campaign-id", "123", "--account-id", str(account_id), "--db-path", cli_db_path])
+    assert rc == 2
+
+    rc = cli_main.main([
+        "campaign", "run", "--campaign-id", "123", "--account-id", str(account_id), "--db-path", cli_db_path, "--dry-run"
+    ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert payload["external_writes"] == 0
+    assert payload["planned_actions"] == []
+
+
+def test_cli_send_refuses_without_approved_state(
+    capsys: pytest.CaptureFixture[str], cli_db_path: str, account_id: int
+) -> None:
+    with patch.object(cli_main, "LinkedInProvider") as m_cls:
+        rc = cli_main.main([
+            "send", "--account-id", str(account_id), "--db-path", cli_db_path,
+            "--recipient", "r", "--text", "t",
+        ])
+    assert rc == 1
+    assert "approval_required" in capsys.readouterr().err
+    m_cls.assert_not_called()
+
+
+def test_cli_send_with_approved_draft_executes_and_marks_used(
+    capsys: pytest.CaptureFixture[str], cli_db_path: str, cli_storage: Storage, account_id: int
+) -> None:
+    draft = cli_storage.create_draft_reply(
+        account_id=account_id,
+        thread_id=None,
+        recipient="r",
+        text="t",
+        idempotency_key="idem-approved",
+    )
+    cli_storage.approve_send_approval(draft["approval_id"], approved_by="test")
+    with patch.object(cli_main, "LinkedInProvider") as m_cls:
+        inst = MagicMock()
+        inst.send_message.return_value = "mid-approved"
+        m_cls.return_value = inst
+        rc = cli_main.main([
+            "send", "--approved", draft["approval_id"], "--account-id", str(account_id), "--db-path", cli_db_path,
+            "--recipient", "r", "--text", "t", "--idempotency-key", "idem-approved",
+        ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["approved"] is True
+    assert payload["approval_id"] == draft["approval_id"]
+    assert cli_storage.get_approval(draft["approval_id"])["state"] == "used"
+    inst.send_message.assert_called_once_with(recipient="r", text="t")


### PR DESCRIPTION
Files changed: apps/cli/__main__.py expanded parser/handlers for status, auth status, sync dry-run, inbox, search, threads, messages, draft-reply, campaign status/run dry-run, and approval-gated send; libs/core/storage.py added get_draft_reply helper for safe draft-backed sends; tests/test_cli.py added/updated operator CLI coverage for help output, JSON status/empty DB, account-not-found, inbox/search/thread/message samples, draft non-send behavior, campaign run --dry-run, send refusal without approval, and approved-send execution; README.md documented the new command suite and marked live send as approval-gated. Verification: uv run pytest -> 443 passed; uv run python scripts/integration_smoke.py -> integration_smoke OK. Noteworthy: live CLI send exits before provider load unless --approved matches local approved state; sync pagination defaults are preserved; no real secrets were added, only synthetic redaction test strings.

---
Task: #1396 — Expand LinkedIn DMs CLI into safe operator command suite
Opened automatically by mission-control dispatcher.