### PR TITLE
Fix LinkedIn Ops Console auth/sync readiness flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,15 @@ What is still true is that LinkedIn is a moving target. Some parts are implement
 ├─ docs/
 │  ├─ architecture.md
 │  ├─ features.md
-│  └─ known-issues.md
+│  ├─ known-issues.md
+│  └─ ops-console-cli-spec.md
 ├─ scripts/
 └─ tests/
 ```
+
+## Ops Console and CLI spec
+
+The repo-backed Objective 73 specification for the safe operator console, CLI command tree, proposed `/ops/*` API surface, approval gates, and validation evidence format lives in [`docs/ops-console-cli-spec.md`](docs/ops-console-cli-spec.md).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,29 @@ Useful endpoints:
 
 Swagger UI is available at <http://127.0.0.1:8899/docs>.
 
+## Running the local Ops Console UI
+
+The operator console is served by the FastAPI process; no npm/Vite install is required.
+
+```bash
+uvicorn apps.api.main:app --reload --host 127.0.0.1 --port 8899
+open http://127.0.0.1:8899/console
+```
+
+The console calls the shared `/ops/*` API endpoints only. It covers inbox/search,
+thread detail, account health, draft approval, campaign/sync dry-run status, and
+audit/outbound-send history. If `DESEARCH_API_TOKEN` is configured, paste the same
+local bearer token into the console settings card; the token stays in browser
+session storage and is sent only as an `Authorization: Bearer ...` header.
+
+Safety defaults:
+- inbox, thread detail, search, health, sync status, campaign status, and audit
+  views are read-only local API reads
+- sync planning and campaign planning buttons use dry-run endpoints first
+- draft creation is local-only and reports `external_writes: 0`
+- the send button is disabled until a draft is created and approved; actual send
+  calls go through `/ops/send-approved`, which revalidates approval evidence
+
 Security posture for local development:
 - bind to `127.0.0.1`, not `0.0.0.0`
 - set `DESEARCH_API_TOKEN` if other local processes should not be able to drive the API

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -9,7 +9,8 @@ from dataclasses import replace
 from datetime import datetime
 from typing import Optional
 
-from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException, Query
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, model_validator
 
 from libs.core.cookies import cookies_to_account_auth, validate_li_at
@@ -341,8 +342,24 @@ def sync_account(body: SyncIn):
             x_li_track=body.x_li_track,
             csrf_token=body.csrf_token,
         )
+        storage.record_ops_audit_event(
+            account_id=body.account_id,
+            event_type="sync.completed",
+            actor="api",
+            entity_type="sync",
+            entity_id=None,
+            payload={
+                "synced_threads": result.synced_threads,
+                "messages_inserted": result.messages_inserted,
+                "messages_skipped_duplicate": result.messages_skipped_duplicate,
+                "pages_fetched": result.pages_fetched,
+                "rate_limited": result.rate_limited,
+            },
+        )
         return {
             "ok": True,
+            "account_id": body.account_id,
+            "dry_run": False,
             "synced_threads": result.synced_threads,
             "messages_inserted": result.messages_inserted,
             "messages_skipped_duplicate": result.messages_skipped_duplicate,
@@ -428,8 +445,23 @@ def ingest_sync(body: IngestIn):
             "contract_captured_at": contract_meta.get("capturedAt"),
         }),
     )
+    storage.record_ops_audit_event(
+        account_id=body.account_id,
+        event_type="sync.ingest",
+        actor="api",
+        entity_type="sync",
+        entity_id=None,
+        payload={
+            "synced_threads": result.synced_threads,
+            "messages_inserted": result.messages_inserted,
+            "messages_skipped_duplicate": result.messages_skipped_duplicate,
+            "pages_fetched": result.pages_fetched,
+            "rate_limited": result.rate_limited,
+        },
+    )
     return {
         "ok": True,
+        "account_id": body.account_id,
         "synced_threads": result.synced_threads,
         "messages_inserted": result.messages_inserted,
         "messages_skipped_duplicate": result.messages_skipped_duplicate,
@@ -494,3 +526,437 @@ def list_sends(account_id: int, status: str | None = None):
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from None
     return {"sends": sends}
+
+
+# ---------------------------------------------------------------------------
+# Ops Console local-safe API contract
+# ---------------------------------------------------------------------------
+
+
+def _ops_error(status_code: int, code: str, message: str, *, retryable: bool = False, extra: dict | None = None) -> JSONResponse:
+    payload = {
+        "ok": False,
+        "error": {
+            "code": code,
+            "message": redact_string(message),
+            "retryable": retryable,
+            "redacted": True,
+        },
+    }
+    if extra:
+        payload.update(extra)
+    return JSONResponse(status_code=status_code, content=payload)
+
+
+def _ops_account_not_found(exc: KeyError) -> JSONResponse:
+    return _ops_error(404, "account_not_found", str(exc), retryable=False)
+
+
+class OpsAccountBody(BaseModel):
+    account_id: int
+
+
+class OpsSyncDryRunIn(BaseModel):
+    account_id: int
+    limit_per_thread: int = Field(50, ge=1, le=MAX_MESSAGES_PER_PAGE)
+    max_pages_per_thread: int | None = Field(1, ge=1, le=100)
+    delay_between_threads_s: float = Field(2.0, ge=0, le=60)
+    delay_between_pages_s: float = Field(1.5, ge=0, le=60)
+
+
+class DraftReplyIn(BaseModel):
+    account_id: int
+    thread_id: int | None = None
+    recipient: str = Field(..., min_length=1)
+    text: str = Field(..., min_length=1, max_length=8000)
+    campaign_id: int | None = None
+    idempotency_key: str | None = None
+
+
+class ApprovalActionIn(BaseModel):
+    approved_by: str | None = None
+
+
+class CampaignDryRunIn(BaseModel):
+    account_id: int | None = None
+    limit: int = Field(25, ge=1, le=500)
+
+
+class SendApprovedIn(BaseModel):
+    approval_id: str
+    account_id: int
+    recipient: str = Field(..., min_length=1)
+    text: str = Field(..., min_length=1, max_length=8000)
+    idempotency_key: str | None = None
+    x_li_track: str | None = Field(None, description=_X_LI_TRACK_DESC)
+    csrf_token: str | None = Field(None, description=_CSRF_TOKEN_DESC)
+
+
+@app.get("/ops/status", dependencies=[Depends(require_api_auth)])
+def ops_status():
+    return {
+        "ok": True,
+        "service": "linkedin-dms",
+        "version": app.version,
+        "db": {
+            "path": storage.db_path,
+            "reachable": True,
+            "schema_version": storage._get_schema_version(),
+        },
+        "api": {
+            "configured_url": os.getenv("DESEARCH_API_URL", "http://127.0.0.1:8899"),
+            "reachable": True,
+            "auth_required": _get_api_token() is not None,
+        },
+        "counts": storage.ops_counts(),
+        "warnings": [],
+    }
+
+
+@app.get("/ops/accounts/{account_id}/health", dependencies=[Depends(require_api_auth)])
+def ops_account_health(account_id: int):
+    try:
+        health = storage.get_account_ops_health(account_id)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    return {"ok": health["status"] == "ok", **health}
+
+
+@app.post("/ops/auth/check", dependencies=[Depends(require_api_auth)])
+def ops_auth_check(body: OpsAccountBody):
+    try:
+        auth = storage.get_account_auth(body.account_id)
+        proxy = storage.get_account_proxy(body.account_id)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    provider = LinkedInProvider(auth=auth, proxy=proxy, account_id=body.account_id)
+    result = provider.check_auth()
+    if result.ok:
+        return {
+            "ok": True,
+            "account_id": body.account_id,
+            "status": "ok",
+            "checked_at": datetime.utcnow().isoformat() + "Z",
+            "session": storage.get_account_ops_health(body.account_id)["session"],
+            "error": None,
+            "next_action": None,
+        }
+    return {
+        "ok": False,
+        "account_id": body.account_id,
+        "status": "failed",
+        "checked_at": datetime.utcnow().isoformat() + "Z",
+        "session": storage.get_account_ops_health(body.account_id)["session"],
+        "error": redact_string(result.error or "authentication check failed"),
+        "next_action": "refresh_account",
+    }
+
+
+@app.post("/ops/sync/dry-run", dependencies=[Depends(require_api_auth)])
+def ops_sync_dry_run(body: OpsSyncDryRunIn):
+    try:
+        storage.get_account_auth(body.account_id)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    return {
+        "ok": True,
+        "account_id": body.account_id,
+        "dry_run": True,
+        "planned": {
+            "limit_per_thread": body.limit_per_thread,
+            "max_pages_per_thread": body.max_pages_per_thread,
+            "delay_between_threads_s": body.delay_between_threads_s,
+            "delay_between_pages_s": body.delay_between_pages_s,
+        },
+        "external_reads": 0,
+        "external_writes": 0,
+        "warnings": [],
+    }
+
+
+@app.get("/ops/sync/status", dependencies=[Depends(require_api_auth)])
+def ops_sync_status(account_id: int):
+    try:
+        health = storage.get_account_ops_health(account_id)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    return {
+        "ok": True,
+        "account_id": account_id,
+        "last_sync": health["last_sync"],
+        "counts": health["counts"],
+        "outbound_summary": health["outbound_summary"],
+        "safety": {"external_writes": 0, "send_requires_approval": True},
+    }
+
+
+@app.get("/ops/inbox", dependencies=[Depends(require_api_auth)])
+def ops_inbox(account_id: int, limit: int = Query(25, ge=1, le=100), cursor: str | None = None, unread_only: bool = False):
+    try:
+        page = storage.list_inbox_threads(account_id=account_id, limit=limit, cursor=cursor)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    except ValueError as exc:
+        return _ops_error(422, "invalid_cursor", str(exc))
+    threads = [t for t in page["threads"] if not unread_only or t["unread"]]
+    return {"ok": True, "account_id": account_id, "threads": threads, "page": page["page"]}
+
+
+@app.get("/ops/search", dependencies=[Depends(require_api_auth)])
+def ops_search(
+    account_id: int,
+    q: str = Query(..., min_length=1),
+    from_date: str | None = Query(None, alias="from"),
+    to_date: str | None = Query(None, alias="to"),
+    direction: str | None = Query(None, pattern="^(in|out)$"),
+    limit: int = Query(25, ge=1, le=100),
+    cursor: str | None = None,
+):
+    try:
+        page = storage.search_messages(
+            account_id=account_id,
+            query=q,
+            direction=direction,
+            from_date=from_date,
+            to_date=to_date,
+            limit=limit,
+            cursor=cursor,
+        )
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    except ValueError as exc:
+        return _ops_error(422, "invalid_search", str(exc))
+    return {
+        "ok": True,
+        "account_id": account_id,
+        "query": q,
+        "filters": {"from": from_date, "to": to_date, "direction": direction},
+        "results": page["results"],
+        "page": page["page"],
+        "fts": page["fts"],
+    }
+
+
+@app.get("/ops/threads", dependencies=[Depends(require_api_auth)])
+def ops_threads(account_id: int, limit: int = Query(25, ge=1, le=100), cursor: str | None = None):
+    try:
+        page = storage.list_ops_threads(account_id=account_id, limit=limit, cursor=cursor)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    except ValueError as exc:
+        return _ops_error(422, "invalid_cursor", str(exc))
+    return {"ok": True, "account_id": account_id, "threads": page["threads"], "page": page["page"]}
+
+
+@app.get("/ops/threads/{thread_id}", dependencies=[Depends(require_api_auth)])
+def ops_thread_detail(thread_id: int, account_id: int):
+    try:
+        thread = storage.get_thread_detail(account_id=account_id, thread_id=thread_id)
+    except KeyError as exc:
+        return _ops_error(404, "thread_not_found", str(exc))
+    return {"ok": True, "account_id": account_id, "thread": thread}
+
+
+@app.get("/ops/threads/{thread_id}/messages", dependencies=[Depends(require_api_auth)])
+def ops_thread_messages(
+    thread_id: int,
+    account_id: int,
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = None,
+    include_raw_text: bool = False,
+):
+    try:
+        page = storage.list_thread_messages(
+            account_id=account_id,
+            thread_id=thread_id,
+            limit=limit,
+            cursor=cursor,
+            include_raw_text=include_raw_text,
+        )
+    except KeyError as exc:
+        return _ops_error(404, "thread_not_found", str(exc))
+    except ValueError as exc:
+        return _ops_error(422, "invalid_cursor", str(exc))
+    return {"ok": True, "account_id": account_id, "thread_id": thread_id, "messages": page["messages"], "page": page["page"]}
+
+
+@app.post("/ops/drafts", dependencies=[Depends(require_api_auth)])
+def ops_create_draft(body: DraftReplyIn):
+    try:
+        return storage.create_draft_reply(
+            account_id=body.account_id,
+            thread_id=body.thread_id,
+            recipient=body.recipient,
+            text=body.text,
+            campaign_id=body.campaign_id,
+            idempotency_key=body.idempotency_key,
+        )
+    except KeyError as exc:
+        return _ops_error(404, "draft_context_not_found", str(exc))
+
+
+@app.get("/ops/drafts", dependencies=[Depends(require_api_auth)])
+def ops_list_drafts(account_id: int, state: str | None = None, limit: int = Query(25, ge=1, le=100), cursor: str | None = None):
+    try:
+        page = storage.list_drafts(account_id=account_id, state=state, limit=limit, cursor=cursor)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    except ValueError as exc:
+        return _ops_error(422, "invalid_draft_filter", str(exc))
+    return {"ok": True, "account_id": account_id, **page}
+
+
+@app.post("/ops/approvals/{approval_id}/approve", dependencies=[Depends(require_api_auth)])
+def ops_approve(approval_id: str, body: ApprovalActionIn | None = None):
+    try:
+        approval = storage.approve_send_approval(approval_id, approved_by=(body.approved_by if body else None))
+    except KeyError as exc:
+        return _ops_error(404, "approval_not_found", str(exc))
+    return {"ok": True, "approval": approval, "external_writes": 0}
+
+
+@app.post("/ops/approvals/{approval_id}/revoke", dependencies=[Depends(require_api_auth)])
+def ops_revoke(approval_id: str):
+    try:
+        approval = storage.revoke_send_approval(approval_id)
+    except KeyError as exc:
+        return _ops_error(404, "approval_not_found", str(exc))
+    return {"ok": True, "approval": approval, "external_writes": 0}
+
+
+@app.get("/ops/approvals", dependencies=[Depends(require_api_auth)])
+def ops_list_approvals(account_id: int, state: str | None = None, limit: int = Query(25, ge=1, le=100), cursor: str | None = None):
+    try:
+        page = storage.list_approvals(account_id=account_id, state=state, limit=limit, cursor=cursor)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    except ValueError as exc:
+        return _ops_error(422, "invalid_approval_filter", str(exc))
+    return {"ok": True, "account_id": account_id, **page}
+
+
+@app.get("/ops/campaigns/{campaign_id}/status", dependencies=[Depends(require_api_auth)])
+def ops_campaign_status(campaign_id: int, account_id: int | None = None):
+    try:
+        status = storage.campaign_status(campaign_id=campaign_id, account_id=account_id)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    if status is None:
+        return {
+            "ok": True,
+            "campaign_id": campaign_id,
+            "account_id": account_id,
+            "state": "draft",
+            "totals": {"prospects": 0, "drafted": 0, "approved": 0, "sent": 0, "failed": 0, "skipped": 0},
+            "rate_limit": {"daily_cap": 25, "sent_today": 0, "remaining_today": 25, "next_safe_send_at": None},
+            "last_run": None,
+        }
+    return {"ok": True, **status}
+
+
+@app.post("/ops/campaigns/{campaign_id}/run-dry-run", dependencies=[Depends(require_api_auth)])
+def ops_campaign_run_dry_run(campaign_id: int, body: CampaignDryRunIn):
+    if body.account_id is not None:
+        try:
+            storage.get_account_ops_health(body.account_id)
+        except KeyError as exc:
+            return _ops_account_not_found(exc)
+    return {
+        "ok": True,
+        "campaign_id": campaign_id,
+        "account_id": body.account_id,
+        "dry_run": True,
+        "external_writes": 0,
+        "planned_actions": [],
+        "summary": {
+            "would_send_if_approved": 0,
+            "blocked_not_approved": 0,
+            "blocked_rate_limit": 0,
+            "blocked_missing_auth": 0,
+        },
+    }
+
+
+@app.post("/ops/send-approved", dependencies=[Depends(require_api_auth)])
+def ops_send_approved(body: SendApprovedIn):
+    try:
+        storage.validate_send_approval(
+            approval_id=body.approval_id,
+            account_id=body.account_id,
+            recipient=body.recipient,
+            text=body.text,
+            idempotency_key=body.idempotency_key,
+        )
+    except ValueError as exc:
+        return _ops_error(409, str(exc), "Approved draft evidence is required before sending.", extra={"approved": False, "status": "rejected", "external_writes": 0})
+    try:
+        auth = storage.get_account_auth(body.account_id)
+        proxy = storage.get_account_proxy(body.account_id)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    incoming_ctx = BrowserContext(x_li_track=body.x_li_track, csrf_token=body.csrf_token)
+    if not incoming_ctx.is_empty():
+        storage.update_browser_context(body.account_id, incoming_ctx)
+    provider = LinkedInProvider(
+        auth=auth,
+        proxy=proxy,
+        account_id=body.account_id,
+        browser_context=storage.get_browser_context(body.account_id),
+    )
+    try:
+        result = run_send(
+            account_id=body.account_id,
+            storage=storage,
+            provider=provider,
+            recipient=body.recipient,
+            text=body.text,
+            idempotency_key=body.idempotency_key,
+            x_li_track=body.x_li_track,
+            csrf_token=body.csrf_token,
+        )
+    except Exception as exc:
+        return _ops_error(409, "send_failed", str(exc), retryable=True)
+    storage.mark_approval_used(body.approval_id)
+    return {
+        "ok": True,
+        "approved": True,
+        "approval_id": body.approval_id,
+        "account_id": body.account_id,
+        "send_id": result.send_id,
+        "platform_message_id": result.platform_message_id,
+        "status": result.status,
+        "was_duplicate": result.was_duplicate,
+        "idempotency_key": body.idempotency_key,
+        "sent_at": datetime.utcnow().isoformat() + "Z",
+    }
+
+
+@app.get("/ops/audit", dependencies=[Depends(require_api_auth)])
+def ops_audit(
+    account_id: int,
+    from_date: str | None = Query(None, alias="from"),
+    to_date: str | None = Query(None, alias="to"),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = None,
+):
+    try:
+        page = storage.list_ops_audit(account_id=account_id, from_date=from_date, to_date=to_date, limit=limit, cursor=cursor)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    except ValueError as exc:
+        return _ops_error(422, "invalid_audit_filter", str(exc))
+    return {"ok": True, "account_id": account_id, **page}
+
+
+@app.get("/ops/validation/objective-73", dependencies=[Depends(require_api_auth)])
+def ops_validation_objective_73():
+    return {
+        "ok": True,
+        "objective": "o-73-build-a-wacli.sh-inspired-linkedin-ops-console-w",
+        "counts": storage.ops_counts(),
+        "safety": {
+            "read_views_are_local_first": True,
+            "drafts_create_external_writes": 0,
+            "approved_send_required": True,
+        },
+    }

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -5,12 +5,14 @@ import logging
 import httpx
 import os
 import secrets
+from pathlib import Path
 from dataclasses import replace
 from datetime import datetime
 from typing import Optional
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Query
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field, model_validator
 
 from libs.core.cookies import cookies_to_account_auth, validate_li_at
@@ -34,6 +36,20 @@ logger = logging.getLogger(__name__)
 configure_logging()
 
 app = FastAPI(title="Desearch LinkedIn DMs", version="0.0.2")
+
+_UI_DIR = Path(__file__).resolve().parents[1] / "ui"
+if _UI_DIR.exists():
+    app.mount("/console/assets", StaticFiles(directory=str(_UI_DIR)), name="ops-console-assets")
+
+
+@app.get("/console", include_in_schema=False)
+@app.get("/console/", include_in_schema=False)
+def ops_console_ui():
+    """Serve the local browser-based Ops Console shell."""
+    index_path = _UI_DIR / "index.html"
+    if not index_path.exists():
+        raise HTTPException(status_code=404, detail="Ops Console UI assets not found")
+    return FileResponse(index_path)
 
 storage = Storage()
 storage.migrate()

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -580,6 +580,15 @@ class OpsSyncDryRunIn(BaseModel):
     delay_between_pages_s: float = Field(1.5, ge=0, le=60)
 
 
+class OpsSyncRunIn(OpsSyncDryRunIn):
+    confirm_external_read: bool = Field(
+        False,
+        description="Must be true because live sync reads LinkedIn conversations into the local DB.",
+    )
+    x_li_track: str | None = Field(None, description=_X_LI_TRACK_DESC)
+    csrf_token: str | None = Field(None, description=_CSRF_TOKEN_DESC)
+
+
 class DraftReplyIn(BaseModel):
     account_id: int
     thread_id: int | None = None
@@ -687,6 +696,86 @@ def ops_sync_dry_run(body: OpsSyncDryRunIn):
         "external_reads": 0,
         "external_writes": 0,
         "warnings": [],
+    }
+
+
+@app.post("/ops/sync/run", dependencies=[Depends(require_api_auth)])
+def ops_sync_run(body: OpsSyncRunIn):
+    if not body.confirm_external_read:
+        return _ops_error(
+            409,
+            "external_read_confirmation_required",
+            "Live sync reads LinkedIn conversations. Set confirm_external_read=true to continue.",
+            extra={"external_reads": 0, "external_writes": 0},
+        )
+    try:
+        auth = storage.get_account_auth(body.account_id)
+        proxy = storage.get_account_proxy(body.account_id)
+    except KeyError as exc:
+        return _ops_account_not_found(exc)
+    incoming_ctx = BrowserContext(x_li_track=body.x_li_track, csrf_token=body.csrf_token)
+    if not incoming_ctx.is_empty():
+        storage.update_browser_context(body.account_id, incoming_ctx)
+    provider = LinkedInProvider(
+        auth=auth,
+        proxy=proxy,
+        account_id=body.account_id,
+        browser_context=storage.get_browser_context(body.account_id),
+    )
+    sync_config = SyncConfig(
+        delay_between_threads_s=body.delay_between_threads_s,
+        delay_between_pages_s=body.delay_between_pages_s,
+    )
+    try:
+        result = run_sync(
+            account_id=body.account_id,
+            storage=storage,
+            provider=provider,
+            limit_per_thread=body.limit_per_thread,
+            max_pages_per_thread=body.max_pages_per_thread,
+            sync_config=sync_config,
+            x_li_track=body.x_li_track,
+            csrf_token=body.csrf_token,
+        )
+    except PermissionError as exc:
+        detail = redact_string(str(exc))
+        if "POST /accounts/refresh" not in detail:
+            detail = "LinkedIn session expired — re-authenticate via POST /accounts/refresh"
+        return _ops_error(401, "linkedin_session_expired", detail)
+    except (httpx.HTTPStatusError, ConnectionError) as exc:
+        http_exc = _provider_http_exception(exc)
+        return _ops_error(http_exc.status_code, "linkedin_upstream_error", str(http_exc.detail), retryable=http_exc.status_code in (429, 503))
+    except NotImplementedError:
+        return _ops_error(501, "provider_not_implemented", "Provider not implemented. Implement libs/providers/linkedin/provider.py")
+    except (ValueError, RuntimeError, TypeError) as exc:
+        return _ops_error(422, "sync_failed", str(exc))
+    storage.record_ops_audit_event(
+        account_id=body.account_id,
+        event_type="sync.completed",
+        actor="ops-console",
+        entity_type="sync",
+        entity_id=str(body.account_id),
+        payload={
+            "synced_threads": result.synced_threads,
+            "messages_inserted": result.messages_inserted,
+            "messages_skipped_duplicate": result.messages_skipped_duplicate,
+            "pages_fetched": result.pages_fetched,
+            "rate_limited": result.rate_limited,
+            "external_reads": 1,
+            "external_writes": 0,
+        },
+    )
+    return {
+        "ok": True,
+        "account_id": body.account_id,
+        "dry_run": False,
+        "synced_threads": result.synced_threads,
+        "messages_inserted": result.messages_inserted,
+        "messages_skipped_duplicate": result.messages_skipped_duplicate,
+        "pages_fetched": result.pages_fetched,
+        "rate_limited": result.rate_limited,
+        "external_reads": 1,
+        "external_writes": 0,
     }
 
 

--- a/apps/ui/app.js
+++ b/apps/ui/app.js
@@ -1,0 +1,349 @@
+const state = {
+  apiBase: localStorage.getItem("linkedinOps.apiBase") || window.location.origin || "http://127.0.0.1:8899",
+  accountId: Number(localStorage.getItem("linkedinOps.accountId") || "1"),
+  token: sessionStorage.getItem("linkedinOps.token") || "",
+  selectedThreadId: null,
+  selectedDraft: null,
+  latestEvidence: null,
+};
+
+const $ = (id) => document.getElementById(id);
+
+function endpoint(path) {
+  const base = state.apiBase.replace(/\/$/, "");
+  return `${base}${path}`;
+}
+
+function headers(extra = {}) {
+  const base = { "Content-Type": "application/json", ...extra };
+  if (state.token) base.Authorization = `Bearer ${state.token}`;
+  return base;
+}
+
+function safe(value, fallback = "—") {
+  return value === null || value === undefined || value === "" ? fallback : String(value);
+}
+
+function setCard(id, title, subtitle = "") {
+  const card = $(id);
+  card.querySelector("strong").textContent = title;
+  card.querySelector("small").textContent = subtitle;
+}
+
+function renderError(target, message, nextAction = "Check token/account settings and retry.") {
+  target.className = `${target.className.replace(/\bloading\b/g, "")} error`;
+  target.innerHTML = `<strong>Unable to load.</strong><br><span>${safe(message)}</span><br><small>${nextAction}</small>`;
+}
+
+async function api(path, options = {}) {
+  const response = await fetch(endpoint(path), { ...options, headers: headers(options.headers || {}) });
+  const data = await response.json().catch(() => ({ ok: false, error: { message: response.statusText } }));
+  if (!response.ok || data.ok === false) {
+    const err = new Error(data?.error?.message || data?.detail || response.statusText || "Request failed");
+    err.payload = data;
+    err.status = response.status;
+    throw err;
+  }
+  return data;
+}
+
+function threadButton(thread) {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = `thread-row ${state.selectedThreadId === thread.thread_id ? "active" : ""}`;
+  btn.innerHTML = `
+    <span class="thread-title">${safe(thread.title, "Untitled thread")}</span>
+    <span class="preview">${safe(thread.last_message_preview, "No local messages yet")}</span>
+    <span class="thread-meta">${safe(thread.last_direction)} · ${thread.message_count || 0} messages · ${safe(thread.last_message_at)}</span>
+  `;
+  btn.addEventListener("click", () => selectThread(thread.thread_id, thread.title));
+  return btn;
+}
+
+async function loadInbox() {
+  const list = $("thread-list");
+  list.className = "list loading";
+  list.textContent = "Loading thread previews…";
+  try {
+    const data = await api(`/ops/inbox?account_id=${state.accountId}&limit=30`);
+    list.className = "list";
+    list.innerHTML = "";
+    if (!data.threads.length) {
+      list.appendChild(document.importNode($("empty-template").content, true));
+      return;
+    }
+    data.threads.forEach((thread) => list.appendChild(threadButton(thread)));
+  } catch (err) {
+    renderError(list, err.message, err.payload?.error?.code === "account_not_found" ? "Create an account through POST /accounts first." : undefined);
+  }
+}
+
+async function runSearch(event) {
+  event.preventDefault();
+  const query = $("search-query").value.trim();
+  if (!query) return loadInbox();
+  const direction = $("direction-filter").value;
+  const list = $("thread-list");
+  list.className = "list loading";
+  list.textContent = "Searching local message archive…";
+  try {
+    const params = new URLSearchParams({ account_id: String(state.accountId), q: query, limit: "30" });
+    if (direction) params.set("direction", direction);
+    const data = await api(`/ops/search?${params.toString()}`);
+    list.className = "list";
+    list.innerHTML = "";
+    if (!data.results.length) {
+      list.innerHTML = `<div class="empty">No local matches for “${query}”. Search is local-only and does not touch LinkedIn.</div>`;
+      return;
+    }
+    data.results.forEach((result) => list.appendChild(threadButton({
+      thread_id: result.thread_id,
+      title: result.title,
+      last_message_preview: result.text_snippet,
+      last_direction: result.direction,
+      message_count: "match",
+      last_message_at: result.sent_at,
+    })));
+  } catch (err) {
+    renderError(list, err.message);
+  }
+}
+
+async function selectThread(threadId, fallbackTitle = "Thread") {
+  state.selectedThreadId = threadId;
+  $("draft-form").dataset.threadId = String(threadId);
+  $("message-list").className = "timeline loading";
+  $("message-list").textContent = "Loading local message history…";
+  try {
+    const [detail, messages] = await Promise.all([
+      api(`/ops/threads/${threadId}?account_id=${state.accountId}`),
+      api(`/ops/threads/${threadId}/messages?account_id=${state.accountId}&limit=100`),
+    ]);
+    $("thread-heading").textContent = detail.thread.title || fallbackTitle || `Thread ${threadId}`;
+    $("thread-health").textContent = `${detail.thread.message_count || 0} local messages`;
+    renderMessages(messages.messages);
+    loadInbox();
+  } catch (err) {
+    renderError($("message-list"), err.message);
+  }
+}
+
+function renderMessages(messages) {
+  const box = $("message-list");
+  box.className = "timeline";
+  box.innerHTML = "";
+  if (!messages.length) {
+    box.className = "timeline empty";
+    box.textContent = "Thread has no stored messages. Run sync for this account before drafting.";
+    return;
+  }
+  messages.forEach((message) => {
+    const item = document.createElement("article");
+    item.className = `message ${message.direction === "out" ? "out" : "in"}`;
+    item.innerHTML = `<div class="sender">${safe(message.sender, message.direction)} · ${safe(message.sent_at)}</div><div>${safe(message.text, "[empty]")}</div>`;
+    box.appendChild(item);
+  });
+}
+
+async function createDraft(event) {
+  event.preventDefault();
+  const output = $("draft-output");
+  output.className = "output loading";
+  output.textContent = "Creating local approval candidate…";
+  try {
+    const payload = {
+      account_id: state.accountId,
+      thread_id: state.selectedThreadId,
+      recipient: $("draft-recipient").value.trim(),
+      text: $("draft-text").value,
+      idempotency_key: $("draft-idempotency").value.trim() || null,
+    };
+    const data = await api("/ops/drafts", { method: "POST", body: JSON.stringify(payload) });
+    state.selectedDraft = { ...data, text: payload.text, recipient: payload.recipient };
+    output.className = "output success";
+    output.textContent = `Draft ${data.draft_id} created. Approval ${data.approval_id} is ${data.approval_state}; external writes: ${data.external_writes}.`;
+    $("approve-draft").disabled = false;
+    $("send-approved").disabled = true;
+    await Promise.all([loadAudit(), loadSyncStatus()]);
+  } catch (err) {
+    renderError(output, err.message);
+  }
+}
+
+async function approveDraft() {
+  if (!state.selectedDraft) return;
+  const output = $("draft-output");
+  output.className = "output loading";
+  output.textContent = "Recording local approval…";
+  try {
+    const data = await api(`/ops/approvals/${state.selectedDraft.approval_id}/approve`, {
+      method: "POST",
+      body: JSON.stringify({ approved_by: "local-operator" }),
+    });
+    state.selectedDraft.approval = data.approval;
+    output.className = "output success";
+    output.textContent = `Approval ${data.approval.approval_id} recorded. Send is now enabled but still requires the exact approved text.`;
+    $("send-approved").disabled = false;
+    await loadAudit();
+  } catch (err) {
+    renderError(output, err.message);
+  }
+}
+
+async function sendApproved() {
+  if (!state.selectedDraft) return;
+  const confirmed = window.confirm("This will call the approved-send API. Continue only if the operator has reviewed the exact text and recipient.");
+  if (!confirmed) return;
+  const output = $("draft-output");
+  output.className = "output loading";
+  output.textContent = "Submitting approved send…";
+  try {
+    const data = await api("/ops/send-approved", {
+      method: "POST",
+      body: JSON.stringify({
+        approval_id: state.selectedDraft.approval_id,
+        account_id: state.accountId,
+        recipient: state.selectedDraft.recipient,
+        text: state.selectedDraft.text,
+        idempotency_key: state.selectedDraft.idempotency_key || null,
+      }),
+    });
+    output.className = "output success";
+    output.textContent = `Send ${data.send_id} ${data.status}. Approval ${data.approval_id} marked used.`;
+    $("send-approved").disabled = true;
+    await Promise.all([loadAudit(), loadSyncStatus()]);
+  } catch (err) {
+    renderError(output, err.message, "The guard rejected this request before sending unless all approval evidence matched.");
+  }
+}
+
+async function loadStatus() {
+  try {
+    const status = await api("/ops/status");
+    setCard("service-card", status.service, `DB schema ${status.db.schema_version}; auth ${status.api.auth_required ? "enabled" : "off"}`);
+  } catch (err) {
+    setCard("service-card", "Needs token", err.message);
+  }
+}
+
+async function loadHealth() {
+  try {
+    const data = await api(`/ops/accounts/${state.accountId}/health`);
+    setCard("health-card", data.status || "unknown", data.next_action || `messages ${data.counts?.messages || 0}`);
+  } catch (err) {
+    setCard("health-card", "Not ready", err.message);
+  }
+}
+
+async function loadSyncStatus() {
+  try {
+    const data = await api(`/ops/sync/status?account_id=${state.accountId}`);
+    setCard("sync-card", `${data.counts.threads || 0} threads`, `${data.counts.messages || 0} messages; writes require approval`);
+  } catch (err) {
+    setCard("sync-card", "Unavailable", err.message);
+  }
+}
+
+async function dryRunSync() {
+  const card = $("campaign-status");
+  card.className = "state-card loading";
+  card.textContent = "Checking sync plan without external reads/writes…";
+  try {
+    const data = await api("/ops/sync/dry-run", { method: "POST", body: JSON.stringify({ account_id: state.accountId }) });
+    card.className = "state-card success";
+    card.innerHTML = `<strong>Sync dry-run ready.</strong><br>limit ${data.planned.limit_per_thread}, pages ${safe(data.planned.max_pages_per_thread)}, external writes ${data.external_writes}.`;
+  } catch (err) {
+    renderError(card, err.message);
+  }
+}
+
+async function dryRunCampaign() {
+  const card = $("campaign-status");
+  card.className = "state-card loading";
+  card.textContent = "Running local campaign dry-run…";
+  try {
+    const data = await api("/ops/campaigns/1/run-dry-run", { method: "POST", body: JSON.stringify({ account_id: state.accountId, limit: 25 }) });
+    card.className = "state-card success";
+    card.innerHTML = `<strong>Campaign dry-run complete.</strong><br>${data.planned_actions.length} planned actions; external writes ${data.external_writes}; blocked not approved ${data.summary.blocked_not_approved}.`;
+  } catch (err) {
+    renderError(card, err.message);
+  }
+}
+
+async function loadCampaignStatus() {
+  const card = $("campaign-status");
+  try {
+    const data = await api(`/ops/campaigns/1/status?account_id=${state.accountId}`);
+    card.className = "state-card";
+    card.innerHTML = `<strong>Campaign #${data.campaign_id}: ${data.state}</strong><br>Drafted ${data.totals.drafted}, approved ${data.totals.approved}, sent ${data.totals.sent}. Remaining today: ${data.rate_limit.remaining_today}.`;
+  } catch (err) {
+    card.className = "state-card empty";
+    card.textContent = "No campaigns configured. Dry-run remains available for local planning only.";
+  }
+}
+
+async function loadAudit() {
+  const list = $("audit-list");
+  list.className = "list loading";
+  list.textContent = "Loading audit events and outbound-send history…";
+  try {
+    const data = await api(`/ops/audit?account_id=${state.accountId}&limit=20`);
+    state.latestEvidence = data;
+    list.className = "list";
+    list.innerHTML = "";
+    if (!data.events.length && !data.outbound_sends.length) {
+      list.innerHTML = `<div class="empty">No outbound sends recorded and no audit events yet.</div>`;
+      return;
+    }
+    [...data.events.map((event) => ({ kind: "audit", ...event })), ...data.outbound_sends.map((send) => ({ kind: "send", ...send }))]
+      .slice(0, 12)
+      .forEach((item) => {
+        const row = document.createElement("article");
+        row.className = "audit-row";
+        row.innerHTML = `<strong>${item.kind === "send" ? `send.${item.status}` : item.event_type}</strong><br><span class="thread-meta">${safe(item.created_at || item.updated_at)} · ${safe(item.entity_type || item.recipient)}</span><pre>${JSON.stringify(item.payload || { id: item.id, status: item.status, idempotency_key: item.idempotency_key }, null, 2)}</pre>`;
+        list.appendChild(row);
+      });
+  } catch (err) {
+    renderError(list, err.message);
+  }
+}
+
+async function copyEvidence() {
+  if (!state.latestEvidence) await loadAudit();
+  const payload = JSON.stringify({ account_id: state.accountId, evidence: state.latestEvidence }, null, 2);
+  await navigator.clipboard.writeText(payload);
+  $("audit-list").insertAdjacentHTML("afterbegin", `<div class="success output">Copied redacted evidence JSON to clipboard.</div>`);
+}
+
+function persistSettings(event) {
+  event.preventDefault();
+  state.apiBase = $("api-base").value.trim() || window.location.origin;
+  state.accountId = Number($("account-id").value || "1");
+  state.token = $("api-token").value.trim();
+  localStorage.setItem("linkedinOps.apiBase", state.apiBase);
+  localStorage.setItem("linkedinOps.accountId", String(state.accountId));
+  if (state.token) sessionStorage.setItem("linkedinOps.token", state.token);
+  else sessionStorage.removeItem("linkedinOps.token");
+  boot();
+}
+
+async function boot() {
+  $("api-base").value = state.apiBase;
+  $("account-id").value = String(state.accountId);
+  $("api-token").value = state.token;
+  $("approve-draft").disabled = true;
+  $("send-approved").disabled = true;
+  state.selectedDraft = null;
+  await Promise.all([loadStatus(), loadHealth(), loadSyncStatus(), loadInbox(), loadCampaignStatus(), loadAudit()]);
+}
+
+$("settings-form").addEventListener("submit", persistSettings);
+$("search-form").addEventListener("submit", runSearch);
+$("draft-form").addEventListener("submit", createDraft);
+$("approve-draft").addEventListener("click", approveDraft);
+$("send-approved").addEventListener("click", sendApproved);
+$("sync-dry-run").addEventListener("click", dryRunSync);
+$("campaign-dry-run").addEventListener("click", dryRunCampaign);
+$("export-evidence").addEventListener("click", copyEvidence);
+
+boot();

--- a/apps/ui/app.js
+++ b/apps/ui/app.js
@@ -221,8 +221,12 @@ async function loadStatus() {
   try {
     const status = await api("/ops/status");
     setCard("service-card", status.service, `DB schema ${status.db.schema_version}; auth ${status.api.auth_required ? "enabled" : "off"}`);
+    if (!status.api.auth_required && !state.token) {
+      $("api-token").placeholder = "Auth off: leave this blank";
+    }
   } catch (err) {
     setCard("service-card", "Needs token", err.message);
+    setCard("next-step-card", "Set local API token", "401 means DESEARCH_API_TOKEN is enabled");
   }
 }
 
@@ -230,17 +234,48 @@ async function loadHealth() {
   try {
     const data = await api(`/ops/accounts/${state.accountId}/health`);
     setCard("health-card", data.status || "unknown", data.next_action || `messages ${data.counts?.messages || 0}`);
+    if (data.status !== "ok") {
+      setCard("next-step-card", "Refresh LinkedIn session", data.next_action || "Use the Chrome extension or POST /accounts/refresh");
+    }
   } catch (err) {
     setCard("health-card", "Not ready", err.message);
+    setCard("next-step-card", "Connect LinkedIn", "Create or refresh account 1 first");
   }
 }
 
 async function loadSyncStatus() {
   try {
     const data = await api(`/ops/sync/status?account_id=${state.accountId}`);
-    setCard("sync-card", `${data.counts.threads || 0} threads`, `${data.counts.messages || 0} messages; writes require approval`);
+    const threads = data.counts.threads || 0;
+    const messages = data.counts.messages || 0;
+    setCard("sync-card", `${threads} threads`, `${messages} messages; writes require approval`);
+    if (!threads || !messages) {
+      setCard("next-step-card", "Run Sync now", "Reads LinkedIn DMs into local storage; sends remain blocked");
+    } else {
+      setCard("next-step-card", "Open Inbox/Search", `${threads} synced threads ready locally`);
+    }
   } catch (err) {
     setCard("sync-card", "Unavailable", err.message);
+    setCard("next-step-card", "Fix sync status", err.message);
+  }
+}
+
+async function runLiveSync() {
+  const card = $("campaign-status");
+  const confirmed = window.confirm("Sync now will read LinkedIn conversations into the local database. It will not send messages. Continue?");
+  if (!confirmed) return;
+  card.className = "state-card loading";
+  card.textContent = "Running live LinkedIn read sync…";
+  try {
+    const data = await api("/ops/sync/run", {
+      method: "POST",
+      body: JSON.stringify({ account_id: state.accountId, confirm_external_read: true }),
+    });
+    card.className = "state-card success";
+    card.innerHTML = `<strong>Sync complete.</strong><br>${data.synced_threads} threads checked, ${data.messages_inserted} messages inserted, ${data.messages_skipped_duplicate} duplicates skipped, external writes ${data.external_writes}.`;
+    await Promise.all([loadSyncStatus(), loadInbox(), loadAudit()]);
+  } catch (err) {
+    renderError(card, err.message, err.payload?.error?.code === "external_read_confirmation_required" ? "Confirm the external read before running live sync." : "Refresh LinkedIn session via Chrome/extension or account refresh, then retry.");
   }
 }
 
@@ -343,6 +378,7 @@ $("draft-form").addEventListener("submit", createDraft);
 $("approve-draft").addEventListener("click", approveDraft);
 $("send-approved").addEventListener("click", sendApproved);
 $("sync-dry-run").addEventListener("click", dryRunSync);
+$("sync-now").addEventListener("click", runLiveSync);
 $("campaign-dry-run").addEventListener("click", dryRunCampaign);
 $("export-evidence").addEventListener("click", copyEvidence);
 

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -23,11 +23,11 @@
         <input id="account-id" name="accountId" type="number" min="1" value="1" />
       </label>
       <label>
-        Bearer token <span class="muted">optional local API auth</span>
-        <input id="api-token" name="apiToken" type="password" placeholder="Paste local token; never stored server-side" />
+        Bearer token <span class="muted">only if API auth is enabled</span>
+        <input id="api-token" name="apiToken" type="password" placeholder="Leave blank when Service says auth off" />
       </label>
       <button type="submit">Reload console</button>
-      <p class="tiny">If requests return 401, set <code>DESEARCH_API_TOKEN</code> for the API and paste the same token here. Cookie and browser header refresh stays in <code>POST /accounts/refresh</code>, not this UI.</p>
+      <p class="tiny">Bearer token is not your LinkedIn login. It is only a local API password when the backend says auth is enabled. LinkedIn connection uses saved LinkedIn session cookies or the Chrome extension.</p>
     </form>
   </header>
 
@@ -37,6 +37,7 @@
       <article class="metric-card" id="health-card"><span>Account Health</span><strong>Loading…</strong><small>Auth/session readiness</small></article>
       <article class="metric-card warning"><span>Send Guard</span><strong>Approval required</strong><small>Mutation controls start disabled/dry-run</small></article>
       <article class="metric-card" id="sync-card"><span>Sync Status</span><strong>Loading…</strong><small>Local cache counters</small></article>
+      <article class="metric-card" id="next-step-card"><span>Next Step</span><strong>Loading…</strong><small>Operator readiness</small></article>
     </section>
 
     <section class="console-layout">
@@ -46,7 +47,10 @@
             <p class="eyebrow">Inbox & Search</p>
             <h2 id="inbox-heading">Synced conversations</h2>
           </div>
-          <button id="sync-dry-run" class="secondary" type="button">Dry-run sync</button>
+          <div class="action-row">
+            <button id="sync-dry-run" class="secondary" type="button">Dry-run sync</button>
+            <button id="sync-now" type="button">Sync now</button>
+          </div>
         </div>
         <form id="search-form" class="filter-row" autocomplete="off">
           <input id="search-query" name="query" type="search" placeholder="Search local messages" />
@@ -110,7 +114,7 @@
     </section>
   </main>
 
-  <template id="empty-template"><div class="empty">No synced conversations yet. Run sync from the API/extension or use the dry-run button to validate settings; sync reads LinkedIn and never sends.</div></template>
+  <template id="empty-template"><div class="empty"><strong>No conversations synced yet.</strong><br>Use <b>Sync now</b> to read LinkedIn conversations into the local DB, then refresh Inbox/Search. This never sends messages. If auth fails, refresh the LinkedIn session from Chrome/extension first.</div></template>
   <script src="/console/assets/app.js" defer></script>
 </body>
 </html>

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>LinkedIn Ops Console</title>
+  <link rel="stylesheet" href="/console/assets/styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div>
+      <p class="eyebrow">Local operator console</p>
+      <h1>LinkedIn Ops Console</h1>
+      <p class="lede">Browse synced DMs, approve drafts, and audit outbound activity without exposing session secrets.</p>
+    </div>
+    <form id="settings-form" class="settings-card" autocomplete="off">
+      <label>
+        API base
+        <input id="api-base" name="apiBase" type="url" value="http://127.0.0.1:8899" />
+      </label>
+      <label>
+        Account ID
+        <input id="account-id" name="accountId" type="number" min="1" value="1" />
+      </label>
+      <label>
+        Bearer token <span class="muted">optional local API auth</span>
+        <input id="api-token" name="apiToken" type="password" placeholder="Paste local token; never stored server-side" />
+      </label>
+      <button type="submit">Reload console</button>
+      <p class="tiny">If requests return 401, set <code>DESEARCH_API_TOKEN</code> for the API and paste the same token here. Cookie and browser header refresh stays in <code>POST /accounts/refresh</code>, not this UI.</p>
+    </form>
+  </header>
+
+  <main>
+    <section class="status-grid" aria-label="Service status">
+      <article class="metric-card" id="service-card"><span>Service</span><strong>Loading…</strong><small>Checking /ops/status</small></article>
+      <article class="metric-card" id="health-card"><span>Account Health</span><strong>Loading…</strong><small>Auth/session readiness</small></article>
+      <article class="metric-card warning"><span>Send Guard</span><strong>Approval required</strong><small>Mutation controls start disabled/dry-run</small></article>
+      <article class="metric-card" id="sync-card"><span>Sync Status</span><strong>Loading…</strong><small>Local cache counters</small></article>
+    </section>
+
+    <section class="console-layout">
+      <aside class="panel thread-panel" aria-labelledby="inbox-heading">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Inbox & Search</p>
+            <h2 id="inbox-heading">Synced conversations</h2>
+          </div>
+          <button id="sync-dry-run" class="secondary" type="button">Dry-run sync</button>
+        </div>
+        <form id="search-form" class="filter-row" autocomplete="off">
+          <input id="search-query" name="query" type="search" placeholder="Search local messages" />
+          <select id="direction-filter" name="direction" aria-label="Direction filter">
+            <option value="">All</option>
+            <option value="in">Inbound</option>
+            <option value="out">Outbound</option>
+          </select>
+          <button type="submit">Search</button>
+        </form>
+        <div id="thread-list" class="list loading" aria-live="polite">Loading thread previews…</div>
+      </aside>
+
+      <section class="panel detail-panel" aria-labelledby="thread-heading">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Thread / Contact Detail</p>
+            <h2 id="thread-heading">Select a conversation</h2>
+          </div>
+          <span id="thread-health" class="badge">Local cache</span>
+        </div>
+        <div id="message-list" class="timeline empty">No thread selected. Pick a synced conversation to view local message history.</div>
+        <form id="draft-form" class="draft-card" autocomplete="off">
+          <h3>Draft Approval</h3>
+          <p class="muted">Creating a draft is local-only. Sending remains disabled until an approval record matches account, recipient, text hash, and idempotency key.</p>
+          <label>Recipient or conversation URN<input id="draft-recipient" required placeholder="urn:li:fsd_profile:…" /></label>
+          <label>Draft body<textarea id="draft-text" rows="4" required placeholder="Write an operator-reviewed reply"></textarea></label>
+          <label>Idempotency key<input id="draft-idempotency" placeholder="linkedin-dm-YYYY-MM-DD-001" /></label>
+          <div class="action-row">
+            <button id="create-draft" type="submit">Create local draft</button>
+            <button id="approve-draft" type="button" class="secondary" disabled>Approve selected draft</button>
+            <button id="send-approved" type="button" class="danger" disabled>Send approved draft</button>
+          </div>
+          <output id="draft-output" class="output">No drafts awaiting approval.</output>
+        </form>
+      </section>
+    </section>
+
+    <section class="bottom-grid">
+      <article class="panel" aria-labelledby="campaign-heading">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Campaign / Sync Status</p>
+            <h2 id="campaign-heading">Dry-run surface</h2>
+          </div>
+          <button id="campaign-dry-run" class="secondary" type="button">Run campaign dry-run</button>
+        </div>
+        <div id="campaign-status" class="state-card empty">No campaigns configured. Use dry-run mode first; campaign sends are not enabled from this console.</div>
+      </article>
+
+      <article class="panel" aria-labelledby="audit-heading">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Audit / Outbound History</p>
+            <h2 id="audit-heading">Recent evidence</h2>
+          </div>
+          <button id="export-evidence" class="secondary" type="button">Copy redacted evidence</button>
+        </div>
+        <div id="audit-list" class="list loading">Loading audit events and outbound-send history…</div>
+      </article>
+    </section>
+  </main>
+
+  <template id="empty-template"><div class="empty">No synced conversations yet. Run sync from the API/extension or use the dry-run button to validate settings; sync reads LinkedIn and never sends.</div></template>
+  <script src="/console/assets/app.js" defer></script>
+</body>
+</html>

--- a/apps/ui/styles.css
+++ b/apps/ui/styles.css
@@ -1,0 +1,65 @@
+:root {
+  color-scheme: dark;
+  --bg: #071019;
+  --panel: #101b2a;
+  --panel-2: #14243a;
+  --text: #ecf4ff;
+  --muted: #9fb1c8;
+  --line: #263853;
+  --brand: #69a7ff;
+  --good: #74e4ae;
+  --warn: #ffd37a;
+  --danger: #ff7d94;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: radial-gradient(circle at top left, #173a66 0, var(--bg) 36rem); color: var(--text); }
+button, input, select, textarea { font: inherit; }
+button { border: 0; border-radius: .8rem; background: var(--brand); color: #06101d; font-weight: 800; padding: .7rem 1rem; cursor: pointer; }
+button:disabled { cursor: not-allowed; opacity: .45; }
+button.secondary { background: #223654; color: var(--text); border: 1px solid var(--line); }
+button.danger { background: var(--danger); }
+input, select, textarea { width: 100%; border: 1px solid var(--line); border-radius: .75rem; padding: .7rem .8rem; background: #0a1523; color: var(--text); }
+textarea { resize: vertical; }
+code { color: #c3d9ff; }
+.topbar { display: grid; grid-template-columns: minmax(18rem, 1fr) minmax(22rem, 32rem); gap: 1.25rem; padding: 2rem; align-items: start; }
+h1, h2, h3, p { margin-top: 0; }
+h1 { font-size: clamp(2rem, 4vw, 4rem); margin-bottom: .5rem; }
+h2 { margin-bottom: 0; }
+.lede { max-width: 48rem; color: var(--muted); font-size: 1.08rem; }
+.eyebrow { margin: 0 0 .35rem; color: var(--brand); text-transform: uppercase; letter-spacing: .12em; font-size: .72rem; font-weight: 900; }
+.muted, .tiny { color: var(--muted); }
+.tiny { font-size: .78rem; line-height: 1.45; }
+.settings-card, .panel, .metric-card { background: color-mix(in srgb, var(--panel) 88%, transparent); border: 1px solid var(--line); box-shadow: 0 20px 60px #0006; border-radius: 1.25rem; }
+.settings-card { padding: 1rem; display: grid; gap: .8rem; }
+.settings-card label, .draft-card label { display: grid; gap: .35rem; color: var(--muted); font-weight: 700; }
+.status-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1rem; padding: 0 2rem 1rem; }
+.metric-card { padding: 1rem; min-height: 7rem; }
+.metric-card span, .metric-card small { color: var(--muted); display: block; }
+.metric-card strong { display: block; margin: .35rem 0; font-size: 1.45rem; }
+.metric-card.warning strong { color: var(--warn); }
+.console-layout { display: grid; grid-template-columns: minmax(20rem, .9fr) minmax(26rem, 1.35fr); gap: 1rem; padding: 1rem 2rem; }
+.bottom-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; padding: 1rem 2rem 2rem; }
+.panel { padding: 1rem; min-width: 0; }
+.panel-heading, .action-row, .filter-row { display: flex; gap: .75rem; align-items: center; justify-content: space-between; }
+.filter-row { margin: 1rem 0; align-items: stretch; }
+.filter-row input { flex: 1; }
+.list { display: grid; gap: .7rem; }
+.thread-row, .audit-row, .state-card { border: 1px solid var(--line); background: var(--panel-2); border-radius: 1rem; padding: .85rem; }
+.thread-row { text-align: left; color: var(--text); display: grid; gap: .3rem; width: 100%; }
+.thread-row.active { outline: 2px solid var(--brand); }
+.thread-title { font-weight: 900; }
+.thread-meta, .preview, .audit-row pre { color: var(--muted); font-size: .85rem; overflow-wrap: anywhere; }
+.badge { display: inline-flex; border: 1px solid var(--line); color: var(--good); border-radius: 999px; padding: .28rem .6rem; font-size: .78rem; font-weight: 800; }
+.timeline { min-height: 22rem; display: grid; align-content: start; gap: .75rem; margin-bottom: 1rem; }
+.message { max-width: 82%; padding: .75rem .9rem; border-radius: 1rem; background: #203650; }
+.message.out { justify-self: end; background: #244c3a; }
+.message .sender { font-size: .74rem; color: var(--muted); margin-bottom: .25rem; }
+.draft-card { display: grid; gap: .8rem; padding: 1rem; border: 1px solid var(--line); border-radius: 1rem; background: #0b1725; }
+.output, .empty, .loading { color: var(--muted); border: 1px dashed var(--line); border-radius: 1rem; padding: 1rem; }
+.error { border-color: var(--danger); color: #ffd0d8; }
+.success { border-color: var(--good); color: #d9ffee; }
+@media (max-width: 980px) {
+  .topbar, .console-layout, .bottom-grid, .status-grid { grid-template-columns: 1fr; padding-left: 1rem; padding-right: 1rem; }
+  .filter-row, .panel-heading, .action-row { flex-direction: column; align-items: stretch; }
+}

--- a/docs/artifacts/ops-console-screens.svg
+++ b/docs/artifacts/ops-console-screens.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="980" viewBox="0 0 1440 980" role="img" aria-label="LinkedIn Ops Console required screens screenshot sheet">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#173a66"/><stop offset="0.35" stop-color="#071019"/><stop offset="1" stop-color="#071019"/></linearGradient>
+    <style>
+      .panel{fill:#101b2a;stroke:#263853;stroke-width:2}.panel2{fill:#14243a;stroke:#263853;stroke-width:2}.text{fill:#ecf4ff;font:700 22px Inter,system-ui}.small{fill:#9fb1c8;font:16px Inter,system-ui}.tiny{fill:#9fb1c8;font:13px Inter,system-ui}.eyebrow{fill:#69a7ff;font:900 13px Inter,system-ui;letter-spacing:2px}.good{fill:#74e4ae}.warn{fill:#ffd37a}.danger{fill:#ff7d94}.button{fill:#69a7ff}.button2{fill:#223654;stroke:#263853;stroke-width:2}.dark{fill:#0a1523;stroke:#263853;stroke-width:2}.mono{fill:#c3d9ff;font:13px ui-monospace,Menlo,monospace}
+    </style>
+  </defs>
+  <rect width="1440" height="980" fill="url(#bg)"/>
+  <text x="48" y="64" class="eyebrow">LOCAL OPERATOR CONSOLE</text>
+  <text x="48" y="108" class="text" font-size="44">LinkedIn Ops Console</text>
+  <text x="48" y="138" class="small">Synthetic screenshot sheet showing all required UI surfaces. Data is redacted/mock only.</text>
+
+  <rect x="980" y="38" width="410" height="150" rx="18" class="panel"/>
+  <text x="1004" y="72" class="eyebrow">TOKEN / AUTH CONFIGURATION</text>
+  <rect x="1004" y="90" width="168" height="34" rx="8" class="dark"/><text x="1016" y="113" class="tiny">API base: 127.0.0.1</text>
+  <rect x="1186" y="90" width="74" height="34" rx="8" class="dark"/><text x="1204" y="113" class="tiny">Acct 1</text>
+  <rect x="1004" y="134" width="250" height="34" rx="8" class="dark"/><text x="1016" y="156" class="tiny">Bearer token optional</text>
+  <text x="1004" y="178" class="tiny">No cookies, browser headers, or raw secrets displayed.</text>
+
+  <g transform="translate(48 210)">
+    <rect width="320" height="96" rx="18" class="panel"/><text x="20" y="32" class="small">Service</text><text x="20" y="64" class="text">linkedin-dms</text><text x="20" y="84" class="tiny">/ops/status · schema 5</text>
+    <rect x="344" width="320" height="96" rx="18" class="panel"/><text x="364" y="32" class="small">Account Health</text><text x="364" y="64" class="text good">ok</text><text x="364" y="84" class="tiny">Session present; refresh guidance if failed</text>
+    <rect x="688" width="320" height="96" rx="18" class="panel"/><text x="708" y="32" class="small">Send Guard</text><text x="708" y="64" class="text warn">Approval required</text><text x="708" y="84" class="tiny">Controls disabled until approved</text>
+    <rect x="1032" width="320" height="96" rx="18" class="panel"/><text x="1052" y="32" class="small">Sync Status</text><text x="1052" y="64" class="text">42 threads</text><text x="1052" y="84" class="tiny">1,204 messages; local cache</text>
+  </g>
+
+  <g transform="translate(48 338)">
+    <rect width="520" height="430" rx="20" class="panel"/>
+    <text x="24" y="38" class="eyebrow">INBOX &amp; SEARCH</text><text x="24" y="72" class="text">Synced conversations</text>
+    <rect x="350" y="28" width="138" height="38" rx="10" class="button2"/><text x="372" y="53" class="tiny">Dry-run sync</text>
+    <rect x="24" y="94" width="290" height="38" rx="10" class="dark"/><text x="40" y="119" class="tiny">Search local messages</text>
+    <rect x="326" y="94" width="84" height="38" rx="10" class="dark"/><text x="346" y="119" class="tiny">All</text>
+    <rect x="422" y="94" width="66" height="38" rx="10" class="button"/><text x="432" y="119" fill="#06101d" font="800 13px Inter">Search</text>
+    <rect x="24" y="154" width="464" height="74" rx="14" class="panel2"/><text x="44" y="184" class="text" font-size="18">Ada Lovelace</text><text x="44" y="207" class="small">Thanks, this is helpful.</text><text x="360" y="207" class="tiny">in · ready</text>
+    <rect x="24" y="242" width="464" height="74" rx="14" class="panel2"/><text x="44" y="272" class="text" font-size="18">Grace Hopper</text><text x="44" y="295" class="small">...Bittensor subnet...</text><text x="360" y="295" class="tiny">search match</text>
+    <rect x="24" y="330" width="464" height="70" rx="14" fill="none" stroke="#263853" stroke-dasharray="8 8"/><text x="44" y="370" class="small">Empty/loading/error states include next action guidance.</text>
+  </g>
+
+  <g transform="translate(596 338)">
+    <rect width="796" height="430" rx="20" class="panel"/>
+    <text x="24" y="38" class="eyebrow">THREAD / CONTACT DETAIL</text><text x="24" y="72" class="text">Ada Lovelace</text>
+    <rect x="634" y="34" width="132" height="30" rx="15" fill="none" stroke="#263853"/><text x="660" y="54" class="tiny good">14 local messages</text>
+    <rect x="24" y="96" width="420" height="56" rx="18" fill="#203650"/><text x="44" y="120" class="tiny">Ada · 2026-05-10</text><text x="44" y="141" class="small">Thanks, this is helpful.</text>
+    <rect x="346" y="166" width="420" height="56" rx="18" fill="#244c3a"/><text x="366" y="190" class="tiny">out · 2026-05-10</text><text x="366" y="211" class="small">Great — Tuesday works.</text>
+    <rect x="24" y="250" width="742" height="150" rx="16" fill="#0b1725" stroke="#263853"/>
+    <text x="44" y="282" class="text" font-size="18">Draft Approval</text><text x="44" y="306" class="small">Local draft only; send waits for approval evidence.</text>
+    <rect x="44" y="322" width="210" height="36" rx="10" class="dark"/><text x="58" y="345" class="tiny">recipient URN</text>
+    <rect x="266" y="322" width="270" height="36" rx="10" class="dark"/><text x="280" y="345" class="tiny">reviewed reply body</text>
+    <rect x="548" y="322" width="94" height="36" rx="10" class="button"/><text x="566" y="345" fill="#06101d" font="800 13px Inter">Draft</text>
+    <rect x="650" y="322" width="92" height="36" rx="10" class="button2" opacity="0.55"/><text x="666" y="345" class="tiny warn">Send disabled</text>
+    <text x="44" y="384" class="mono">approval_id: appr_20260510_000031 · external_writes: 0</text>
+  </g>
+
+  <g transform="translate(48 800)">
+    <rect width="655" height="132" rx="20" class="panel"/>
+    <text x="24" y="38" class="eyebrow">CAMPAIGN / SYNC STATUS</text><text x="24" y="72" class="text">Dry-run surface</text>
+    <text x="24" y="102" class="small">No campaigns configured. Dry-run reports planned actions and external_writes: 0.</text>
+    <rect x="480" y="36" width="142" height="38" rx="10" class="button2"/><text x="500" y="60" class="tiny">Campaign dry-run</text>
+  </g>
+  <g transform="translate(737 800)">
+    <rect width="655" height="132" rx="20" class="panel"/>
+    <text x="24" y="38" class="eyebrow">AUDIT / OUTBOUND HISTORY</text><text x="24" y="72" class="text">Recent evidence</text>
+    <text x="24" y="102" class="small">draft.created · approval.approved · outbound sends table with redacted errors.</text>
+    <rect x="482" y="36" width="138" height="38" rx="10" class="button2"/><text x="502" y="60" class="tiny">Copy evidence</text>
+  </g>
+</svg>

--- a/docs/ops-console-cli-spec.md
+++ b/docs/ops-console-cli-spec.md
@@ -435,6 +435,7 @@ If approval evidence is missing or mismatched, the command must exit non-zero an
 
 - **Purpose:** local-first triage of synced threads and messages.
 - **Primary data:** `GET /ops/inbox`, `GET /ops/search`, `GET /threads`, `GET /threads/{thread_id}/messages`.
+- **Search implementation note:** the shared storage layer currently uses a parameterized SQLite `LIKE` fallback over stored message text instead of FTS5. Responses include `fts: false` so the UI/CLI can surface that search is safe/local but not yet ranked full-text search.
 - **Controls:** account selector, sync status badge, search box, date range, direction filter, thread list, unread/local-health filter.
 - **Primary actions:** open thread, draft reply, copy redacted evidence snippet.
 - **Empty state:** “No synced conversations yet” with a safe CTA to run sync. The CTA explains that sync reads from LinkedIn and does not send messages.

--- a/docs/ops-console-cli-spec.md
+++ b/docs/ops-console-cli-spec.md
@@ -1,0 +1,696 @@
+# LinkedIn Ops Console and CLI Specification
+
+## 1. Product promise
+
+The LinkedIn Ops Console and CLI give operators a safe, inspectable control plane for LinkedIn DM operations backed by the existing FastAPI, SQLite, and provider stack. The promise is:
+
+- show account health before an operator tries to sync or send;
+- sync LinkedIn conversations into local storage with clear progress, rate-limit, and error reporting;
+- browse, search, and inspect inbox threads and messages without touching LinkedIn;
+- draft outbound replies and campaign messages in a local approval queue;
+- execute sends only after an explicit `approved` state is recorded;
+- leave an audit trail that can be attached to Objective 73 validation.
+
+This spec is source-driven from the current repository:
+
+- `README.md` describes the existing FastAPI + SQLite + CLI product surface and current endpoints.
+- `apps/cli/__main__.py` currently implements `sync` and `send` commands with JSON output.
+- `apps/api/main.py` currently exposes account, auth, thread, sync, ingest, send, and sends endpoints.
+- `libs/core/storage.py` currently persists accounts, threads, messages, sync cursors, browser context, and outbound sends.
+
+## 2. Non-goals
+
+- No autonomous LinkedIn outreach. Campaign runs default to local dry-run planning and never send without approved records.
+- No bypass of LinkedIn auth, anti-bot systems, rate limits, or account safety controls.
+- No unredacted display, logging, export, or API response of cookies, CSRF tokens, proxy credentials, bearer tokens, or raw browser headers.
+- No public multi-tenant SaaS surface in this phase. The API remains local-first and bearer-token protected when exposed to other local processes.
+- No replacement of the provider abstraction. The console and CLI orchestrate the existing provider/storage layers and future-compatible endpoints.
+- No destructive bulk deletion flows. Data cleanup, if added later, needs its own spec and approval gate.
+
+## 3. CLI command tree
+
+The operator-facing executable name can be `linkedin-dms` after packaging. During repository development every command maps to `python -m apps.cli` plus the selected subcommand or a future wrapper that calls the same handlers.
+
+```text
+linkedin-dms
+├── status
+│   └── --db-path PATH
+├── auth
+│   └── status --account-id ID [--db-path PATH]
+├── sync
+│   ├── --account-id ID
+│   ├── --db-path PATH
+│   ├── --limit-per-thread N
+│   ├── --max-pages-per-thread N
+│   ├── --exhaust-pagination
+│   ├── --delay-threads SEC
+│   ├── --delay-pages SEC
+│   └── --dry-run
+├── inbox
+│   ├── --account-id ID
+│   ├── --db-path PATH
+│   ├── --limit N
+│   ├── --cursor CURSOR
+│   ├── --unread-only
+│   └── --json
+├── search
+│   ├── --account-id ID
+│   ├── --query TEXT
+│   ├── --db-path PATH
+│   ├── --from YYYY-MM-DD
+│   ├── --to YYYY-MM-DD
+│   ├── --direction in|out
+│   ├── --limit N
+│   └── --json
+├── threads
+│   ├── list --account-id ID [--db-path PATH] [--limit N] [--cursor CURSOR]
+│   └── show --thread-id ID [--account-id ID] [--db-path PATH] [--include-messages] [--limit N]
+├── messages
+│   └── list --thread-id ID [--account-id ID] [--db-path PATH] [--limit N] [--cursor CURSOR]
+├── draft-reply
+│   ├── --account-id ID
+│   ├── --thread-id ID | --recipient URN_OR_CONV_ID
+│   ├── --text BODY | --text-file PATH
+│   ├── --campaign-id ID
+│   ├── --idempotency-key KEY
+│   └── --db-path PATH
+├── campaign
+│   ├── status --campaign-id ID [--account-id ID] [--db-path PATH]
+│   └── run --campaign-id ID --dry-run [--account-id ID] [--db-path PATH] [--limit N]
+└── send
+    ├── --approved APPROVAL_ID
+    ├── --account-id ID
+    ├── --recipient URN_OR_CONV_ID
+    ├── --text BODY | --draft-id ID
+    ├── --idempotency-key KEY
+    └── --db-path PATH
+```
+
+### 3.1 Command behavior rules
+
+- `status`, `auth status`, `inbox`, `search`, `threads`, `messages`, `draft-reply`, and `campaign status` are local read or local write operations only. They must not send external LinkedIn messages.
+- `sync` may read from LinkedIn. It uses conservative pagination defaults already present in the API/CLI. `--dry-run` validates account/provider readiness and reports planned pagination without writing fetched data.
+- `campaign run` requires `--dry-run` in this phase. It creates a deterministic local plan but does not call the provider send path.
+- `send` refuses to run unless `--approved APPROVAL_ID` references an approval record in state `approved` for the exact account, recipient, text hash, and idempotency key. Passing message text alone is not approval.
+- Every command emits one JSON object to stdout on success. Human-readable progress, warnings, and errors go to stderr.
+
+## 4. JSON output schemas
+
+Schemas below are normative for CLI stdout. API responses should use the same field names where the same concept exists.
+
+### 4.1 `status`
+
+```json
+{
+  "ok": true,
+  "service": "linkedin-dms",
+  "version": "0.0.2",
+  "db": {
+    "path": "./desearch_linkedin_dms.sqlite",
+    "reachable": true,
+    "schema_version": 4
+  },
+  "api": {
+    "configured_url": "http://127.0.0.1:8899",
+    "reachable": true,
+    "auth_required": true
+  },
+  "counts": {
+    "accounts": 1,
+    "threads": 42,
+    "messages": 1200,
+    "pending_approvals": 3,
+    "outbound_sends": 7
+  },
+  "warnings": []
+}
+```
+
+### 4.2 `auth status`
+
+```json
+{
+  "ok": true,
+  "account_id": 1,
+  "status": "ok",
+  "checked_at": "2026-05-10T12:00:00Z",
+  "session": {
+    "has_li_at": true,
+    "has_jsessionid": true,
+    "has_browser_context": true,
+    "expires_at": null
+  },
+  "error": null,
+  "next_action": null
+}
+```
+
+If auth fails, `ok` is `false`, `status` is `failed`, `error` is redacted, and `next_action` is `refresh_account`.
+
+### 4.3 `sync`
+
+Current implementation already emits the core success payload. The console-compatible schema extends it with account and timing metadata:
+
+```json
+{
+  "ok": true,
+  "account_id": 1,
+  "dry_run": false,
+  "synced_threads": 12,
+  "messages_inserted": 85,
+  "messages_skipped_duplicate": 240,
+  "pages_fetched": 12,
+  "rate_limited": false,
+  "started_at": "2026-05-10T12:00:00Z",
+  "finished_at": "2026-05-10T12:00:14Z",
+  "warnings": []
+}
+```
+
+For dry-run:
+
+```json
+{
+  "ok": true,
+  "account_id": 1,
+  "dry_run": true,
+  "planned": {
+    "limit_per_thread": 50,
+    "max_pages_per_thread": 1,
+    "delay_between_threads_s": 2.0,
+    "delay_between_pages_s": 1.5
+  },
+  "external_reads": 0,
+  "external_writes": 0,
+  "warnings": []
+}
+```
+
+### 4.4 `inbox`
+
+```json
+{
+  "ok": true,
+  "account_id": 1,
+  "threads": [
+    {
+      "thread_id": 10,
+      "platform_thread_id": "urn:li:msg_conversation:(urn:li:fsd_profile:me,abc)",
+      "title": "Ada Lovelace",
+      "last_message_at": "2026-05-10T11:55:00Z",
+      "last_message_preview": "Thanks, this is helpful.",
+      "last_direction": "in",
+      "message_count": 14,
+      "unread": false,
+      "health": "ready"
+    }
+  ],
+  "page": {
+    "limit": 25,
+    "next_cursor": "eyJpZCI6MTB9"
+  }
+}
+```
+
+### 4.5 `search`
+
+```json
+{
+  "ok": true,
+  "account_id": 1,
+  "query": "bittensor",
+  "filters": {
+    "from": "2026-05-01",
+    "to": "2026-05-10",
+    "direction": "in"
+  },
+  "results": [
+    {
+      "message_id": 77,
+      "thread_id": 10,
+      "platform_message_id": "urn:li:msg:123",
+      "title": "Ada Lovelace",
+      "direction": "in",
+      "sender": "Ada Lovelace",
+      "text_snippet": "...Bittensor subnet launch...",
+      "sent_at": "2026-05-08T09:30:00Z"
+    }
+  ],
+  "page": {
+    "limit": 25,
+    "next_cursor": null
+  }
+}
+```
+
+### 4.6 `threads list` and `threads show`
+
+`threads list`:
+
+```json
+{
+  "ok": true,
+  "account_id": 1,
+  "threads": [
+    {
+      "id": 10,
+      "platform_thread_id": "urn:li:msg_conversation:(urn:li:fsd_profile:me,abc)",
+      "title": "Ada Lovelace",
+      "created_at": "2026-05-10T10:00:00Z",
+      "message_count": 14,
+      "last_message_at": "2026-05-10T11:55:00Z"
+    }
+  ],
+  "page": {
+    "limit": 25,
+    "next_cursor": null
+  }
+}
+```
+
+`threads show --include-messages`:
+
+```json
+{
+  "ok": true,
+  "account_id": 1,
+  "thread": {
+    "id": 10,
+    "platform_thread_id": "urn:li:msg_conversation:(urn:li:fsd_profile:me,abc)",
+    "title": "Ada Lovelace",
+    "created_at": "2026-05-10T10:00:00Z"
+  },
+  "messages": [
+    {
+      "id": 77,
+      "platform_message_id": "urn:li:msg:123",
+      "direction": "in",
+      "sender": "Ada Lovelace",
+      "text": "Thanks, this is helpful.",
+      "sent_at": "2026-05-10T11:55:00Z"
+    }
+  ],
+  "page": {
+    "limit": 50,
+    "next_cursor": null
+  }
+}
+```
+
+### 4.7 `messages list`
+
+```json
+{
+  "ok": true,
+  "account_id": 1,
+  "thread_id": 10,
+  "messages": [
+    {
+      "id": 77,
+      "platform_message_id": "urn:li:msg:123",
+      "direction": "in",
+      "sender": "Ada Lovelace",
+      "text": "Thanks, this is helpful.",
+      "sent_at": "2026-05-10T11:55:00Z",
+      "raw_available": true
+    }
+  ],
+  "page": {
+    "limit": 50,
+    "next_cursor": null
+  }
+}
+```
+
+### 4.8 `draft-reply`
+
+`draft-reply` creates a local approval candidate. It is not a send operation.
+
+```json
+{
+  "ok": true,
+  "draft_id": 31,
+  "approval_id": "appr_20260510_000031",
+  "approval_state": "draft",
+  "account_id": 1,
+  "thread_id": 10,
+  "recipient": "urn:li:fsd_profile:123",
+  "text_sha256": "1b73c3f5a0ec...",
+  "preview": "Great to hear from you. Would next Tuesday work?",
+  "idempotency_key": "linkedin-dm-2026-05-10-031",
+  "external_writes": 0
+}
+```
+
+### 4.9 `campaign status`
+
+```json
+{
+  "ok": true,
+  "campaign_id": 5,
+  "account_id": 1,
+  "state": "draft",
+  "totals": {
+    "prospects": 100,
+    "drafted": 80,
+    "approved": 12,
+    "sent": 7,
+    "failed": 1,
+    "skipped": 0
+  },
+  "rate_limit": {
+    "daily_cap": 25,
+    "sent_today": 7,
+    "remaining_today": 18,
+    "next_safe_send_at": "2026-05-10T12:20:00Z"
+  },
+  "last_run": {
+    "dry_run": true,
+    "finished_at": "2026-05-10T11:00:00Z"
+  }
+}
+```
+
+### 4.10 `campaign run --dry-run`
+
+```json
+{
+  "ok": true,
+  "campaign_id": 5,
+  "account_id": 1,
+  "dry_run": true,
+  "external_writes": 0,
+  "planned_actions": [
+    {
+      "recipient": "urn:li:fsd_profile:123",
+      "draft_id": 31,
+      "approval_state": "draft",
+      "would_send": false,
+      "reason": "not_approved"
+    }
+  ],
+  "summary": {
+    "would_send_if_approved": 12,
+    "blocked_not_approved": 68,
+    "blocked_rate_limit": 0,
+    "blocked_missing_auth": 0
+  }
+}
+```
+
+### 4.11 `send --approved`
+
+Current CLI/API send payloads are extended with approval evidence. A successful send returns:
+
+```json
+{
+  "ok": true,
+  "approved": true,
+  "approval_id": "appr_20260510_000031",
+  "account_id": 1,
+  "send_id": 7,
+  "platform_message_id": "urn:li:msg:123",
+  "status": "sent",
+  "was_duplicate": false,
+  "idempotency_key": "linkedin-dm-2026-05-10-031",
+  "sent_at": "2026-05-10T12:05:00Z"
+}
+```
+
+If approval evidence is missing or mismatched, the command must exit non-zero and emit the error to stderr. Any JSON error envelope returned by the API must preserve the same safety signal:
+
+```json
+{
+  "ok": false,
+  "approved": false,
+  "status": "rejected",
+  "error": "approval_required",
+  "external_writes": 0
+}
+```
+
+## 5. UI screen map
+
+### 5.1 Inbox and search
+
+- **Purpose:** local-first triage of synced threads and messages.
+- **Primary data:** `GET /ops/inbox`, `GET /ops/search`, `GET /threads`, `GET /threads/{thread_id}/messages`.
+- **Controls:** account selector, sync status badge, search box, date range, direction filter, thread list, unread/local-health filter.
+- **Primary actions:** open thread, draft reply, copy redacted evidence snippet.
+- **Empty state:** “No synced conversations yet” with a safe CTA to run sync. The CTA explains that sync reads from LinkedIn and does not send messages.
+- **Loading state:** skeleton thread rows plus last successful local snapshot if available.
+- **Error state:** redacted provider/API error with next action, such as refresh auth or reduce pagination.
+
+### 5.2 Thread and contact detail
+
+- **Purpose:** inspect a single conversation and the known contact identity before drafting.
+- **Primary data:** `GET /ops/threads/{thread_id}`, `GET /ops/threads/{thread_id}/messages`, future local `contacts` view derived from thread participants/raw provider data.
+- **Controls:** message timeline, copied profile URN, local notes, draft composer.
+- **Primary actions:** draft reply, create campaign candidate, mark thread reviewed locally.
+- **Empty state:** “Thread has no stored messages” with a sync CTA scoped to the account.
+- **Loading state:** timeline shimmer with disabled draft action until thread metadata is loaded.
+- **Error state:** local storage error or missing thread shown without raw cookies or provider headers.
+
+### 5.3 Campaign and sync status
+
+- **Purpose:** show progress and risk for sync jobs and campaign dry-runs.
+- **Primary data:** `GET /ops/sync/status`, `GET /ops/campaigns/{campaign_id}/status`, `GET /sends`.
+- **Controls:** account selector, campaign selector, dry-run button, sync button, pagination settings, rate-limit policy panel.
+- **Primary actions:** run sync, run campaign dry-run, export validation artifact.
+- **Empty state:** “No campaigns configured” with import/create guidance that stays local.
+- **Loading state:** progress cards with pages fetched, threads touched, duplicates skipped, and rate-limit flag.
+- **Error state:** auth expired, provider rate-limited, or local DB unavailable with safe remediation.
+
+### 5.4 Draft and reply approval
+
+- **Purpose:** convert operator-reviewed text into an explicit send approval.
+- **Primary data:** `GET /ops/drafts`, `POST /ops/drafts`, `POST /ops/approvals/{approval_id}/approve`, `POST /ops/send-approved`.
+- **Controls:** draft body, recipient, thread context, text hash, idempotency key, approval diff, approve button, send button.
+- **Primary actions:** create draft, approve draft, revoke approval, send approved draft.
+- **Empty state:** “No drafts awaiting approval.”
+- **Loading state:** disabled approval/send buttons while the text hash and approval state are being checked.
+- **Error state:** approval mismatch, stale draft, rate limit, auth expired, provider failure. The UI keeps the send button disabled until the mismatch is resolved.
+
+### 5.5 Account health
+
+- **Purpose:** make auth/session/proxy readiness visible before reads or writes.
+- **Primary data:** `GET /auth/check`, `GET /ops/accounts/{account_id}/health`.
+- **Controls:** account selector, refresh cookie guidance, bearer-auth status, proxy status if configured.
+- **Primary actions:** run auth check, open local instructions for account refresh.
+- **Empty state:** “No account configured” with a link to account creation docs.
+- **Loading state:** checking auth badge and disabled mutation buttons.
+- **Error state:** failed auth check with a redacted error and `POST /accounts/refresh` as remediation.
+
+### 5.6 Audit and outbound history
+
+- **Purpose:** prove what happened, when, and under which approval.
+- **Primary data:** `GET /sends`, `GET /ops/audit`, `GET /ops/approvals`.
+- **Controls:** filters for account, status, campaign, approval state, date range, idempotency key.
+- **Primary actions:** export Objective 73 evidence, inspect failed send, copy redacted JSON.
+- **Empty state:** “No outbound sends recorded.”
+- **Loading state:** table skeleton with counters preserved from the last successful query.
+- **Error state:** invalid status filter or storage unavailable, surfaced without raw provider payloads.
+
+## 6. Shared API and storage contract
+
+### 6.1 Existing endpoint contract to preserve
+
+These endpoints already exist and remain the compatibility base:
+
+- `GET /health`
+- `POST /accounts`
+- `POST /accounts/refresh`
+- `GET /auth/check?account_id={account_id}`
+- `GET /threads?account_id={account_id}`
+- `POST /sync`
+- `POST /sync/ingest`
+- `POST /send`
+- `GET /sends?account_id={account_id}&status={pending|sent|failed}`
+
+The console and CLI must not remove or change these response fields. Additive fields are allowed when backward compatible.
+
+### 6.2 Proposed endpoint names
+
+The Ops Console uses `/ops/*` endpoints for local orchestration and keeps existing public endpoints intact.
+
+- `GET /ops/status`
+- `GET /ops/accounts/{account_id}/health`
+- `POST /ops/auth/check`
+- `POST /ops/sync/dry-run`
+- `GET /ops/sync/status?account_id={account_id}`
+- `GET /ops/inbox?account_id={account_id}&limit={limit}&cursor={cursor}`
+- `GET /ops/search?account_id={account_id}&q={query}&from={date}&to={date}&direction={direction}&limit={limit}`
+- `GET /ops/threads?account_id={account_id}&limit={limit}&cursor={cursor}`
+- `GET /ops/threads/{thread_id}?account_id={account_id}`
+- `GET /ops/threads/{thread_id}/messages?account_id={account_id}&limit={limit}&cursor={cursor}`
+- `POST /ops/drafts`
+- `GET /ops/drafts?account_id={account_id}&state={draft|approved|revoked|sent}`
+- `POST /ops/approvals/{approval_id}/approve`
+- `POST /ops/approvals/{approval_id}/revoke`
+- `GET /ops/approvals?account_id={account_id}&state={state}`
+- `GET /ops/campaigns/{campaign_id}/status`
+- `POST /ops/campaigns/{campaign_id}/run-dry-run`
+- `POST /ops/send-approved`
+- `GET /ops/audit?account_id={account_id}&from={date}&to={date}`
+- `GET /ops/validation/objective-73`
+
+### 6.3 Endpoint mutation classification
+
+| Endpoint | External LinkedIn read | External LinkedIn write | Local write | Default safety |
+| --- | --- | --- | --- | --- |
+| `GET /ops/status` | no | no | no | read-only |
+| `GET /ops/accounts/{account_id}/health` | optional via auth check | no | no | read-only |
+| `POST /ops/auth/check` | yes | no | no | read-only provider check |
+| `POST /ops/sync/dry-run` | no | no | no | dry-run |
+| `POST /sync` | yes | no | yes | read-only external, writes local cache |
+| `POST /sync/ingest` | no | no | yes | local ingest from extension payload |
+| `POST /ops/drafts` | no | no | yes | local draft only |
+| `POST /ops/approvals/{approval_id}/approve` | no | no | yes | local approval only |
+| `POST /ops/campaigns/{campaign_id}/run-dry-run` | no | no | yes | dry-run only |
+| `POST /ops/send-approved` | no | yes | yes | requires approved state |
+| `POST /send` | no | yes | yes | legacy direct send; console must wrap with approval |
+
+### 6.4 Storage contract
+
+Existing tables and primitives remain canonical:
+
+- `accounts`: account auth, proxy, browser context, and timestamps.
+- `threads`: one row per account/thread, keyed by `(account_id, platform_thread_id)`.
+- `messages`: local archive of inbound and outbound messages with `direction in ('in', 'out')`.
+- `sync_cursors`: per-account/thread pagination cursor.
+- `outbound_sends`: idempotent send tracking with `pending`, `sent`, and `failed` statuses.
+
+Ops Console additions should use additive migrations:
+
+- `draft_replies`
+  - `id`, `account_id`, `thread_id`, `recipient`, `text`, `text_sha256`, `campaign_id`, `idempotency_key`, `state`, `created_at`, `updated_at`.
+  - Valid states: `draft`, `approved`, `revoked`, `sent`.
+- `send_approvals`
+  - `approval_id`, `draft_id`, `account_id`, `recipient`, `text_sha256`, `idempotency_key`, `state`, `approved_by`, `approved_at`, `revoked_at`.
+  - Valid states: `draft`, `approved`, `revoked`, `used`.
+- `campaigns`
+  - `id`, `account_id`, `name`, `state`, `rate_limit_daily_cap`, `created_at`, `updated_at`.
+  - Valid states: `draft`, `active`, `paused`, `archived`.
+- `campaign_recipients`
+  - `id`, `campaign_id`, `recipient`, `thread_id`, `draft_id`, `approval_id`, `state`, `last_error`, `created_at`, `updated_at`.
+- `ops_audit_events`
+  - `id`, `account_id`, `event_type`, `actor`, `entity_type`, `entity_id`, `redacted_payload_json`, `created_at`.
+
+The `outbound_sends` table remains the provider execution ledger. Approval tables explain why a send was allowed; `outbound_sends` records what the provider attempted and returned.
+
+### 6.5 Shared error envelope
+
+For new `/ops/*` endpoints, errors should use this shape:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "approval_required",
+    "message": "An approved draft is required before sending.",
+    "retryable": false,
+    "redacted": true
+  }
+}
+```
+
+Legacy endpoints may keep FastAPI `detail` responses, but console adapters should normalize them before rendering.
+
+## 7. Safety and approval gates
+
+### 7.1 Read-only and dry-run defaults
+
+- UI load, inbox, thread views, search, status, campaign status, and audit views are read-only.
+- Campaign execution is dry-run only until a separate task implements approved campaign sends.
+- Dry-run output must report `external_writes: 0`.
+- Sync reads from LinkedIn but never sends LinkedIn messages.
+
+### 7.2 Explicit approved-send state
+
+A send is allowed only when all of these checks pass atomically:
+
+1. `approval_id` exists.
+2. Approval state is `approved`.
+3. Approval account matches the requested `account_id`.
+4. Approval recipient matches the requested `recipient` or draft recipient.
+5. Approval `text_sha256` matches the exact outbound body.
+6. Approval idempotency key matches the send request when one is supplied.
+7. Approval has not been revoked or used.
+8. Account health check is not known failed.
+9. Rate-limit policy permits the send.
+
+After a successful provider send, mark the approval `used`, mark the draft `sent`, and update `outbound_sends` to `sent`. If provider send fails after an allowed attempt, keep the approval state explicit and record the failure in `outbound_sends` plus `ops_audit_events`.
+
+### 7.3 Rate-limit handling
+
+- Respect the existing provider send interval and expose the next safe send time in status outputs.
+- Treat LinkedIn 429, challenge, auth-expired, and Cloudflare-like blocks as safety events.
+- Stop campaign execution on rate-limit signals and report `blocked_rate_limit` counts.
+- Never retry sends in a tight loop. Retries require idempotency keys and backoff.
+
+### 7.4 Redaction
+
+- Reuse the existing redaction layer for logs and API responses.
+- Redact `li_at`, `JSESSIONID`, CSRF tokens, proxy credentials, bearer tokens, cookies, raw browser headers, and provider request bodies that may contain secrets.
+- Store validation artifacts with IDs, timestamps, status fields, and hashes rather than secrets.
+- UI copy/export actions must use redacted JSON.
+
+### 7.5 No unapproved external sends
+
+- `send --approved` is the only CLI send path the Ops Console may expose.
+- The console must not call legacy `POST /send` directly from a draft button. It must call `POST /ops/send-approved`, which performs the approval checks before delegating to the provider send path.
+- If the approval lookup fails, no provider client is constructed and no external request is made.
+- Bulk sends require each recipient/text pair to have its own approval record.
+
+## 8. Validation checklist
+
+Use this checklist for Objective 73 QA and downstream implementation tasks:
+
+- `docs/ops-console-cli-spec.md` exists and is linked from `README.md`.
+- CLI command tree covers status/auth, sync, inbox, search, threads/messages, draft-reply, campaign status/run `--dry-run`, and send `--approved`.
+- JSON output schemas include success and safety-failure examples for send approval.
+- UI screen map covers inbox/search, thread/contact detail, campaign/sync status, draft/reply approval, account health, audit/outbound history, and empty/error/loading states.
+- API/storage contract lists existing endpoints, exact proposed `/ops/*` endpoint names, storage tables, and additive migrations.
+- Safety gates document read-only/dry-run defaults, explicit approval state, rate-limit handling, redaction, and the ban on unapproved external sends.
+- No section requires secret material in screenshots, logs, artifacts, or comments.
+- `git diff --check` passes.
+
+## 9. Evidence artifact format
+
+Objective 73 validation evidence should be committed or attached as `validation/objective-73-ops-console-cli.md` using this structure:
+
+```markdown
+# Objective 73 Ops Console and CLI Validation
+
+## Build
+- Command: `uv run pytest`
+- Result: pass
+- Timestamp: 2026-05-10T12:00:00Z
+
+## Static checks
+- Command: `git diff --check`
+- Result: pass
+
+## CLI dry-run evidence
+- Command: `python -m apps.cli status --db-path validation/local-test.sqlite`
+- Redacted output file: `validation/artifacts/cli-status-redacted.json`
+
+## Approval gate evidence
+- Attempt without approval: rejected before provider send
+- Attempt with matching approval: provider send path called once
+- Attempt with stale text hash: rejected before provider send
+
+## UI evidence
+- Inbox/search screen: `validation/artifacts/inbox-search.png`
+- Thread/contact detail screen: `validation/artifacts/thread-contact-detail.png`
+- Campaign/sync status screen: `validation/artifacts/campaign-sync-status.png`
+- Draft/reply approval screen: `validation/artifacts/draft-reply-approval.png`
+- Account health screen: `validation/artifacts/account-health.png`
+- Audit/outbound history screen: `validation/artifacts/audit-outbound-history.png`
+
+## Notes
+- Secrets present in raw environment: no
+- External sends performed during validation: no, unless explicitly approved in the test fixture
+```
+
+The artifact must contain redacted output only. If real provider credentials are used for validation, the artifact records command names, IDs, statuses, and hashes, not cookies, tokens, or proxy URLs.

--- a/libs/core/redaction.py
+++ b/libs/core/redaction.py
@@ -17,6 +17,8 @@ from typing import Any
 _SECRET_KEYS = frozenset({
     "li_at",
     "jsessionid",
+    "csrf_token",
+    "csrf-token",
     "auth_json",
     "cookie",
     "cookies",
@@ -37,6 +39,7 @@ _REDACTED = "[REDACTED]"
 _SECRET_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"(li_at\s*[=:]\s*)([^\s;,\"'}{]+)", re.IGNORECASE),
     re.compile(r"(jsessionid\s*[=:]\s*)([^\s;,\"'}{]+)", re.IGNORECASE),
+    re.compile(r"(csrf[_-]?token\s*[=:]\s*)([^\s;,\"'}{]+)", re.IGNORECASE),
     re.compile(r"(authorization\s*[=:]\s*)((?:Bearer|Basic|Token)\s+[^\s;,\"'}{]+|[^\s;,\"'}{]+)", re.IGNORECASE),
     re.compile(r"(password\s*[=:]\s*)([^\s;,\"'}{]+)", re.IGNORECASE),
     re.compile(r"(api_key\s*[=:]\s*)([^\s;,\"'}{]+)", re.IGNORECASE),

--- a/libs/core/storage.py
+++ b/libs/core/storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import sqlite3
 from dataclasses import asdict
 from datetime import datetime, timezone
@@ -9,6 +10,7 @@ from typing import Any, Optional
 
 from .crypto import decrypt_if_encrypted, encrypt_if_configured
 from .models import AccountAuth, BrowserContext, ProxyConfig
+from .redaction import redact_for_log, redact_string
 
 
 def utcnow() -> datetime:
@@ -75,6 +77,118 @@ CREATE INDEX IF NOT EXISTS idx_outbound_sends_account_status ON outbound_sends(a
 _MIGRATION_4_BROWSER_CONTEXT = """
 ALTER TABLE accounts ADD COLUMN browser_context_json TEXT;
 """
+
+_MIGRATION_5_OPS_CONSOLE = """
+CREATE TABLE IF NOT EXISTS draft_replies (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  account_id INTEGER NOT NULL,
+  thread_id INTEGER,
+  recipient TEXT NOT NULL,
+  text TEXT NOT NULL,
+  text_sha256 TEXT NOT NULL,
+  campaign_id INTEGER,
+  idempotency_key TEXT,
+  state TEXT NOT NULL DEFAULT 'draft' CHECK (state IN ('draft', 'approved', 'revoked', 'sent')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY(account_id) REFERENCES accounts(id) ON DELETE CASCADE,
+  FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_draft_replies_account_state ON draft_replies(account_id, state);
+
+CREATE TABLE IF NOT EXISTS send_approvals (
+  approval_id TEXT PRIMARY KEY,
+  draft_id INTEGER NOT NULL,
+  account_id INTEGER NOT NULL,
+  recipient TEXT NOT NULL,
+  text_sha256 TEXT NOT NULL,
+  idempotency_key TEXT,
+  state TEXT NOT NULL DEFAULT 'draft' CHECK (state IN ('draft', 'approved', 'revoked', 'used')),
+  approved_by TEXT,
+  approved_at TEXT,
+  revoked_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY(draft_id) REFERENCES draft_replies(id) ON DELETE CASCADE,
+  FOREIGN KEY(account_id) REFERENCES accounts(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_send_approvals_account_state ON send_approvals(account_id, state);
+
+CREATE TABLE IF NOT EXISTS campaigns (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  account_id INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT 'draft' CHECK (state IN ('draft', 'active', 'paused', 'archived')),
+  rate_limit_daily_cap INTEGER NOT NULL DEFAULT 25,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY(account_id) REFERENCES accounts(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_campaigns_account_state ON campaigns(account_id, state);
+
+CREATE TABLE IF NOT EXISTS campaign_recipients (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  campaign_id INTEGER NOT NULL,
+  recipient TEXT NOT NULL,
+  thread_id INTEGER,
+  draft_id INTEGER,
+  approval_id TEXT,
+  state TEXT NOT NULL DEFAULT 'draft',
+  last_error TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY(campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE,
+  FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE SET NULL,
+  FOREIGN KEY(draft_id) REFERENCES draft_replies(id) ON DELETE SET NULL,
+  FOREIGN KEY(approval_id) REFERENCES send_approvals(approval_id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_campaign_recipients_campaign_state ON campaign_recipients(campaign_id, state);
+
+CREATE TABLE IF NOT EXISTS ops_audit_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  account_id INTEGER,
+  event_type TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  entity_type TEXT,
+  entity_id TEXT,
+  redacted_payload_json TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(account_id) REFERENCES accounts(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_ops_audit_account_created ON ops_audit_events(account_id, created_at);
+"""
+
+
+_MAX_PREVIEW_CHARS = 160
+
+
+def _safe_text(text: str | None, *, max_chars: int | None = None) -> str | None:
+    if text is None:
+        return None
+    safe = redact_string(text)
+    if max_chars is not None and len(safe) > max_chars:
+        safe = safe[: max_chars - 1].rstrip() + "…"
+    return safe
+
+
+def _text_sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _offset_from_cursor(cursor: str | None) -> int:
+    if cursor in (None, ""):
+        return 0
+    try:
+        offset = int(cursor)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("invalid cursor") from exc
+    if offset < 0:
+        raise ValueError("invalid cursor")
+    return offset
+
+
+def _page_meta(*, limit: int, offset: int, returned: int) -> dict[str, Any]:
+    return {"limit": limit, "next_cursor": str(offset + limit) if returned == limit else None}
 
 
 class Storage:
@@ -175,6 +289,7 @@ class Storage:
             (2, _MIGRATION_2_MESSAGES_CHECK),
             (3, _MIGRATION_3_OUTBOUND_SENDS),
             (4, _MIGRATION_4_BROWSER_CONTEXT),
+            (5, _MIGRATION_5_OPS_CONSOLE),
         ]
         for version, sql in migrations:
             if version > current:
@@ -344,6 +459,583 @@ class Storage:
             if "UNIQUE constraint failed" in str(e):
                 return False
             raise
+
+
+    # ------------------------------------------------------------------
+    # Ops Console safe read/query helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_account_exists(self, account_id: int) -> sqlite3.Row:
+        row = self._conn.execute(
+            "SELECT id, label, proxy_json, browser_context_json, created_at FROM accounts WHERE id=?",
+            (account_id,),
+        ).fetchone()
+        if not row:
+            raise KeyError(f"account {account_id} not found")
+        return row
+
+    def _thread_row(self, *, account_id: int, thread_id: int) -> sqlite3.Row:
+        self._ensure_account_exists(account_id)
+        row = self._conn.execute(
+            """
+            SELECT id, account_id, platform_thread_id, title, created_at
+            FROM threads
+            WHERE account_id=? AND id=?
+            """,
+            (account_id, thread_id),
+        ).fetchone()
+        if not row:
+            raise KeyError(f"thread {thread_id} not found for account {account_id}")
+        return row
+
+    def ops_counts(self) -> dict[str, int]:
+        return {
+            "accounts": int(self._conn.execute("SELECT COUNT(*) FROM accounts").fetchone()[0]),
+            "threads": int(self._conn.execute("SELECT COUNT(*) FROM threads").fetchone()[0]),
+            "messages": int(self._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]),
+            "pending_approvals": int(
+                self._conn.execute("SELECT COUNT(*) FROM send_approvals WHERE state='approved'").fetchone()[0]
+            ),
+            "outbound_sends": int(self._conn.execute("SELECT COUNT(*) FROM outbound_sends").fetchone()[0]),
+        }
+
+    def get_account_ops_health(self, account_id: int) -> dict[str, Any]:
+        account = self._ensure_account_exists(account_id)
+        auth = self.get_account_auth(account_id)
+        has_browser_context = self.get_browser_context(account_id) is not None
+        counts = self._conn.execute(
+            """
+            SELECT
+              (SELECT COUNT(*) FROM threads WHERE account_id=?) AS threads,
+              (SELECT COUNT(*) FROM messages WHERE account_id=?) AS messages,
+              (SELECT COUNT(*) FROM outbound_sends WHERE account_id=?) AS outbound_sends,
+              (SELECT COUNT(*) FROM send_approvals WHERE account_id=? AND state='approved') AS pending_approvals
+            """,
+            (account_id, account_id, account_id, account_id),
+        ).fetchone()
+        send_summary = self._conn.execute(
+            """
+            SELECT status, COUNT(*) AS count, MAX(updated_at) AS last_at
+            FROM outbound_sends
+            WHERE account_id=?
+            GROUP BY status
+            """,
+            (account_id,),
+        ).fetchall()
+        last_sync = self._conn.execute(
+            """
+            SELECT event_type, redacted_payload_json, created_at
+            FROM ops_audit_events
+            WHERE account_id=? AND event_type IN ('sync.completed', 'sync.ingest', 'sync.failed')
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """,
+            (account_id,),
+        ).fetchone()
+        return {
+            "account_id": account_id,
+            "label": account["label"],
+            "status": "ok" if auth.li_at else "failed",
+            "checked_at": utcnow().isoformat(),
+            "session": {
+                "has_li_at": bool(auth.li_at),
+                "has_jsessionid": bool(auth.jsessionid),
+                "has_browser_context": has_browser_context,
+                "expires_at": None,
+            },
+            "proxy": {"configured": bool(account["proxy_json"])},
+            "counts": {key: int(counts[key]) for key in counts.keys()},
+            "outbound_summary": {r["status"]: {"count": int(r["count"]), "last_at": r["last_at"]} for r in send_summary},
+            "last_sync": dict(last_sync) if last_sync else None,
+            "error": None if auth.li_at else "missing li_at cookie",
+            "next_action": None if auth.li_at else "refresh_account",
+        }
+
+    def _thread_summaries(self, *, account_id: int, limit: int, cursor: str | None) -> dict[str, Any]:
+        self._ensure_account_exists(account_id)
+        offset = _offset_from_cursor(cursor)
+        rows = self._conn.execute(
+            """
+            SELECT
+              t.id,
+              t.platform_thread_id,
+              t.title,
+              t.created_at,
+              COUNT(m.id) AS message_count,
+              MAX(m.sent_at) AS last_message_at,
+              (
+                SELECT m2.text FROM messages m2
+                WHERE m2.thread_id=t.id
+                ORDER BY m2.sent_at DESC, m2.id DESC LIMIT 1
+              ) AS last_message_text,
+              (
+                SELECT m2.direction FROM messages m2
+                WHERE m2.thread_id=t.id
+                ORDER BY m2.sent_at DESC, m2.id DESC LIMIT 1
+              ) AS last_direction,
+              (
+                SELECT c.cursor FROM sync_cursors c
+                WHERE c.account_id=t.account_id AND c.thread_id=t.id
+              ) AS sync_cursor
+            FROM threads t
+            LEFT JOIN messages m ON m.thread_id=t.id
+            WHERE t.account_id=?
+            GROUP BY t.id
+            ORDER BY COALESCE(last_message_at, t.created_at) DESC, t.id DESC
+            LIMIT ? OFFSET ?
+            """,
+            (account_id, limit, offset),
+        ).fetchall()
+        threads: list[dict[str, Any]] = []
+        for row in rows:
+            threads.append({
+                "thread_id": int(row["id"]),
+                "id": int(row["id"]),
+                "platform_thread_id": row["platform_thread_id"],
+                "title": row["title"],
+                "created_at": row["created_at"],
+                "last_message_at": row["last_message_at"],
+                "last_message_preview": _safe_text(row["last_message_text"], max_chars=_MAX_PREVIEW_CHARS),
+                "last_direction": row["last_direction"],
+                "message_count": int(row["message_count"]),
+                "unread": False,
+                "health": "syncing" if row["sync_cursor"] else "ready",
+            })
+        return {"threads": threads, "page": _page_meta(limit=limit, offset=offset, returned=len(rows))}
+
+    def list_inbox_threads(self, *, account_id: int, limit: int, cursor: str | None) -> dict[str, Any]:
+        return self._thread_summaries(account_id=account_id, limit=limit, cursor=cursor)
+
+    def list_ops_threads(self, *, account_id: int, limit: int, cursor: str | None) -> dict[str, Any]:
+        page = self._thread_summaries(account_id=account_id, limit=limit, cursor=cursor)
+        slim = []
+        for thread in page["threads"]:
+            slim.append({
+                "id": thread["id"],
+                "platform_thread_id": thread["platform_thread_id"],
+                "title": thread["title"],
+                "created_at": thread["created_at"],
+                "message_count": thread["message_count"],
+                "last_message_at": thread["last_message_at"],
+            })
+        return {"threads": slim, "page": page["page"]}
+
+    def get_thread_detail(self, *, account_id: int, thread_id: int) -> dict[str, Any]:
+        row = self._thread_row(account_id=account_id, thread_id=thread_id)
+        counts = self._conn.execute(
+            "SELECT COUNT(*) AS message_count, MAX(sent_at) AS last_message_at FROM messages WHERE account_id=? AND thread_id=?",
+            (account_id, thread_id),
+        ).fetchone()
+        return {
+            "id": int(row["id"]),
+            "platform_thread_id": row["platform_thread_id"],
+            "title": row["title"],
+            "created_at": row["created_at"],
+            "message_count": int(counts["message_count"]),
+            "last_message_at": counts["last_message_at"],
+        }
+
+    def list_thread_messages(
+        self,
+        *,
+        account_id: int,
+        thread_id: int,
+        limit: int,
+        cursor: str | None,
+        include_raw_text: bool = False,
+    ) -> dict[str, Any]:
+        self._thread_row(account_id=account_id, thread_id=thread_id)
+        offset = _offset_from_cursor(cursor)
+        rows = self._conn.execute(
+            """
+            SELECT id, platform_message_id, direction, sender, text, sent_at, raw_json
+            FROM messages
+            WHERE account_id=? AND thread_id=?
+            ORDER BY sent_at ASC, id ASC
+            LIMIT ? OFFSET ?
+            """,
+            (account_id, thread_id, limit, offset),
+        ).fetchall()
+        messages = []
+        for row in rows:
+            text = row["text"] if include_raw_text else _safe_text(row["text"])
+            messages.append({
+                "id": int(row["id"]),
+                "platform_message_id": row["platform_message_id"],
+                "direction": row["direction"],
+                "sender": _safe_text(row["sender"]),
+                "text": text,
+                "sent_at": row["sent_at"],
+                "raw_available": bool(row["raw_json"]),
+            })
+        return {
+            "messages": messages,
+            "page": _page_meta(limit=limit, offset=offset, returned=len(rows)),
+        }
+
+    def search_messages(
+        self,
+        *,
+        account_id: int,
+        query: str,
+        direction: str | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        limit: int,
+        cursor: str | None,
+    ) -> dict[str, Any]:
+        self._ensure_account_exists(account_id)
+        if not query.strip():
+            raise ValueError("query must not be empty")
+        if direction is not None and direction not in {"in", "out"}:
+            raise ValueError("direction must be 'in' or 'out'")
+        offset = _offset_from_cursor(cursor)
+        clauses = ["m.account_id=?", "LOWER(COALESCE(m.text, '')) LIKE ?"]
+        params: list[Any] = [account_id, f"%{query.lower()}%"]
+        if direction:
+            clauses.append("m.direction=?")
+            params.append(direction)
+        if from_date:
+            clauses.append("date(m.sent_at) >= date(?)")
+            params.append(from_date)
+        if to_date:
+            clauses.append("date(m.sent_at) <= date(?)")
+            params.append(to_date)
+        params.extend([limit, offset])
+        rows = self._conn.execute(
+            f"""
+            SELECT m.id, m.thread_id, m.platform_message_id, m.direction, m.sender, m.text, m.sent_at, t.title
+            FROM messages m
+            JOIN threads t ON t.id=m.thread_id
+            WHERE {' AND '.join(clauses)}
+            ORDER BY m.sent_at DESC, m.id DESC
+            LIMIT ? OFFSET ?
+            """,
+            tuple(params),
+        ).fetchall()
+        results = []
+        for row in rows:
+            results.append({
+                "message_id": int(row["id"]),
+                "thread_id": int(row["thread_id"]),
+                "platform_message_id": row["platform_message_id"],
+                "title": row["title"],
+                "direction": row["direction"],
+                "sender": _safe_text(row["sender"]),
+                "text_snippet": _safe_text(row["text"], max_chars=_MAX_PREVIEW_CHARS),
+                "sent_at": row["sent_at"],
+            })
+        return {
+            "results": results,
+            "page": _page_meta(limit=limit, offset=offset, returned=len(rows)),
+            "fts": False,
+        }
+
+    def record_ops_audit_event(
+        self,
+        *,
+        account_id: int | None,
+        event_type: str,
+        actor: str,
+        entity_type: str | None,
+        entity_id: str | None,
+        payload: dict[str, Any] | None = None,
+    ) -> int:
+        if account_id is not None:
+            self._ensure_account_exists(account_id)
+        now = utcnow().isoformat()
+        safe_payload = redact_for_log(payload or {})
+        cur = self._conn.execute(
+            """
+            INSERT INTO ops_audit_events(account_id, event_type, actor, entity_type, entity_id, redacted_payload_json, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (account_id, event_type, actor, entity_type, entity_id, json.dumps(safe_payload, sort_keys=True, default=str), now),
+        )
+        self._conn.commit()
+        return int(cur.lastrowid)
+
+    def list_ops_audit(
+        self,
+        *,
+        account_id: int,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        self._ensure_account_exists(account_id)
+        offset = _offset_from_cursor(cursor)
+        clauses = ["account_id=?"]
+        params: list[Any] = [account_id]
+        if from_date:
+            clauses.append("date(created_at) >= date(?)")
+            params.append(from_date)
+        if to_date:
+            clauses.append("date(created_at) <= date(?)")
+            params.append(to_date)
+        params.extend([limit, offset])
+        audit_rows = self._conn.execute(
+            f"""
+            SELECT id, account_id, event_type, actor, entity_type, entity_id, redacted_payload_json, created_at
+            FROM ops_audit_events
+            WHERE {' AND '.join(clauses)}
+            ORDER BY created_at DESC, id DESC
+            LIMIT ? OFFSET ?
+            """,
+            tuple(params),
+        ).fetchall()
+        send_rows = self._conn.execute(
+            """
+            SELECT id, account_id, status, recipient, idempotency_key, attempts, platform_message_id, last_error, created_at, updated_at
+            FROM outbound_sends
+            WHERE account_id=?
+            ORDER BY updated_at DESC, id DESC
+            LIMIT ?
+            """,
+            (account_id, limit),
+        ).fetchall()
+        events = [
+            {
+                "id": int(row["id"]),
+                "account_id": row["account_id"],
+                "event_type": row["event_type"],
+                "actor": row["actor"],
+                "entity_type": row["entity_type"],
+                "entity_id": row["entity_id"],
+                "payload": json.loads(row["redacted_payload_json"] or "{}"),
+                "created_at": row["created_at"],
+            }
+            for row in audit_rows
+        ]
+        outbound = [dict(row) for row in send_rows]
+        for row in outbound:
+            if row.get("last_error"):
+                row["last_error"] = redact_string(row["last_error"])
+        return {"events": events, "outbound_sends": outbound, "page": _page_meta(limit=limit, offset=offset, returned=len(audit_rows))}
+
+    # ------------------------------------------------------------------
+    # Draft and approval state
+    # ------------------------------------------------------------------
+
+    _VALID_DRAFT_STATES = frozenset({"draft", "approved", "revoked", "sent"})
+    _VALID_APPROVAL_STATES = frozenset({"draft", "approved", "revoked", "used"})
+
+    def create_draft_reply(
+        self,
+        *,
+        account_id: int,
+        thread_id: int | None,
+        recipient: str,
+        text: str,
+        campaign_id: int | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        self._ensure_account_exists(account_id)
+        if thread_id is not None:
+            self._thread_row(account_id=account_id, thread_id=thread_id)
+        now = utcnow().isoformat()
+        text_hash = _text_sha256(text)
+        cur = self._conn.execute(
+            """
+            INSERT INTO draft_replies(account_id, thread_id, recipient, text, text_sha256, campaign_id, idempotency_key, state, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?)
+            """,
+            (account_id, thread_id, recipient, text, text_hash, campaign_id, idempotency_key, now, now),
+        )
+        draft_id = int(cur.lastrowid)
+        approval_id = f"appr_{utcnow().strftime('%Y%m%d')}_{draft_id:06d}"
+        self._conn.execute(
+            """
+            INSERT INTO send_approvals(approval_id, draft_id, account_id, recipient, text_sha256, idempotency_key, state, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, 'draft', ?, ?)
+            """,
+            (approval_id, draft_id, account_id, recipient, text_hash, idempotency_key, now, now),
+        )
+        self._conn.commit()
+        self.record_ops_audit_event(
+            account_id=account_id,
+            event_type="draft.created",
+            actor="operator",
+            entity_type="draft_reply",
+            entity_id=str(draft_id),
+            payload={"draft_id": draft_id, "approval_id": approval_id, "text_sha256": text_hash},
+        )
+        return {
+            "ok": True,
+            "draft_id": draft_id,
+            "approval_id": approval_id,
+            "approval_state": "draft",
+            "account_id": account_id,
+            "thread_id": thread_id,
+            "recipient": recipient,
+            "text_sha256": text_hash,
+            "preview": _safe_text(text, max_chars=_MAX_PREVIEW_CHARS),
+            "idempotency_key": idempotency_key,
+            "external_writes": 0,
+        }
+
+    def _draft_payload(self, row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": int(row["id"]),
+            "account_id": int(row["account_id"]),
+            "thread_id": row["thread_id"],
+            "recipient": row["recipient"],
+            "text_sha256": row["text_sha256"],
+            "campaign_id": row["campaign_id"],
+            "idempotency_key": row["idempotency_key"],
+            "state": row["state"],
+            "preview": _safe_text(row["text"], max_chars=_MAX_PREVIEW_CHARS),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    def list_drafts(self, *, account_id: int, state: str | None, limit: int, cursor: str | None) -> dict[str, Any]:
+        self._ensure_account_exists(account_id)
+        if state is not None and state not in self._VALID_DRAFT_STATES:
+            raise ValueError("invalid draft state")
+        offset = _offset_from_cursor(cursor)
+        if state:
+            rows = self._conn.execute(
+                "SELECT * FROM draft_replies WHERE account_id=? AND state=? ORDER BY id DESC LIMIT ? OFFSET ?",
+                (account_id, state, limit, offset),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM draft_replies WHERE account_id=? ORDER BY id DESC LIMIT ? OFFSET ?",
+                (account_id, limit, offset),
+            ).fetchall()
+        return {"drafts": [self._draft_payload(r) for r in rows], "page": _page_meta(limit=limit, offset=offset, returned=len(rows))}
+
+    def get_approval(self, approval_id: str) -> dict[str, Any] | None:
+        row = self._conn.execute("SELECT * FROM send_approvals WHERE approval_id=?", (approval_id,)).fetchone()
+        return dict(row) if row else None
+
+    def _set_approval_state(self, approval_id: str, state: str, *, approved_by: str | None = None) -> dict[str, Any]:
+        row = self._conn.execute("SELECT * FROM send_approvals WHERE approval_id=?", (approval_id,)).fetchone()
+        if not row:
+            raise KeyError(f"approval {approval_id} not found")
+        now = utcnow().isoformat()
+        if state == "approved":
+            self._conn.execute(
+                "UPDATE send_approvals SET state='approved', approved_by=?, approved_at=?, revoked_at=NULL, updated_at=? WHERE approval_id=?",
+                (approved_by, now, now, approval_id),
+            )
+            self._conn.execute("UPDATE draft_replies SET state='approved', updated_at=? WHERE id=?", (now, row["draft_id"]))
+        elif state == "revoked":
+            self._conn.execute(
+                "UPDATE send_approvals SET state='revoked', revoked_at=?, updated_at=? WHERE approval_id=?",
+                (now, now, approval_id),
+            )
+            self._conn.execute("UPDATE draft_replies SET state='revoked', updated_at=? WHERE id=?", (now, row["draft_id"]))
+        elif state == "used":
+            self._conn.execute(
+                "UPDATE send_approvals SET state='used', updated_at=? WHERE approval_id=?",
+                (now, approval_id),
+            )
+            self._conn.execute("UPDATE draft_replies SET state='sent', updated_at=? WHERE id=?", (now, row["draft_id"]))
+        else:
+            raise ValueError("invalid approval state")
+        self._conn.commit()
+        updated = self.get_approval(approval_id)
+        assert updated is not None
+        self.record_ops_audit_event(
+            account_id=updated["account_id"],
+            event_type=f"approval.{state}",
+            actor=approved_by or "operator",
+            entity_type="send_approval",
+            entity_id=approval_id,
+            payload={"approval_id": approval_id, "state": state},
+        )
+        return updated
+
+    def approve_send_approval(self, approval_id: str, approved_by: str | None = None) -> dict[str, Any]:
+        return self._set_approval_state(approval_id, "approved", approved_by=approved_by)
+
+    def revoke_send_approval(self, approval_id: str) -> dict[str, Any]:
+        return self._set_approval_state(approval_id, "revoked")
+
+    def mark_approval_used(self, approval_id: str) -> dict[str, Any]:
+        return self._set_approval_state(approval_id, "used")
+
+    def list_approvals(self, *, account_id: int, state: str | None, limit: int, cursor: str | None) -> dict[str, Any]:
+        self._ensure_account_exists(account_id)
+        if state is not None and state not in self._VALID_APPROVAL_STATES:
+            raise ValueError("invalid approval state")
+        offset = _offset_from_cursor(cursor)
+        if state:
+            rows = self._conn.execute(
+                "SELECT * FROM send_approvals WHERE account_id=? AND state=? ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                (account_id, state, limit, offset),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM send_approvals WHERE account_id=? ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                (account_id, limit, offset),
+            ).fetchall()
+        approvals = [dict(r) for r in rows]
+        return {"approvals": approvals, "page": _page_meta(limit=limit, offset=offset, returned=len(rows))}
+
+    def validate_send_approval(
+        self,
+        *,
+        approval_id: str,
+        account_id: int,
+        recipient: str,
+        text: str,
+        idempotency_key: str | None,
+    ) -> dict[str, Any]:
+        approval = self.get_approval(approval_id)
+        if not approval or approval["state"] != "approved":
+            raise ValueError("approval_required")
+        if int(approval["account_id"]) != account_id:
+            raise ValueError("approval_account_mismatch")
+        if approval["recipient"] != recipient:
+            raise ValueError("approval_recipient_mismatch")
+        if approval["text_sha256"] != _text_sha256(text):
+            raise ValueError("approval_text_mismatch")
+        if idempotency_key is not None and approval["idempotency_key"] != idempotency_key:
+            raise ValueError("approval_idempotency_mismatch")
+        return approval
+
+    def campaign_status(self, *, campaign_id: int, account_id: int | None = None) -> dict[str, Any] | None:
+        if account_id is not None:
+            self._ensure_account_exists(account_id)
+            row = self._conn.execute("SELECT * FROM campaigns WHERE id=? AND account_id=?", (campaign_id, account_id)).fetchone()
+        else:
+            row = self._conn.execute("SELECT * FROM campaigns WHERE id=?", (campaign_id,)).fetchone()
+        if not row:
+            return None
+        totals = self._conn.execute(
+            "SELECT state, COUNT(*) AS count FROM campaign_recipients WHERE campaign_id=? GROUP BY state",
+            (campaign_id,),
+        ).fetchall()
+        total_map = {"prospects": 0, "drafted": 0, "approved": 0, "sent": 0, "failed": 0, "skipped": 0}
+        for r in totals:
+            state = r["state"]
+            if state in total_map:
+                total_map[state] = int(r["count"])
+            if state in {"draft", "drafted"}:
+                total_map["drafted"] += int(r["count"])
+            total_map["prospects"] += int(r["count"])
+        sent_today = int(self._conn.execute(
+            "SELECT COUNT(*) FROM outbound_sends WHERE account_id=? AND status='sent' AND date(updated_at)=date('now')",
+            (row["account_id"],),
+        ).fetchone()[0])
+        daily_cap = int(row["rate_limit_daily_cap"])
+        return {
+            "campaign_id": int(row["id"]),
+            "account_id": int(row["account_id"]),
+            "state": row["state"],
+            "totals": total_map,
+            "rate_limit": {
+                "daily_cap": daily_cap,
+                "sent_today": sent_today,
+                "remaining_today": max(daily_cap - sent_today, 0),
+                "next_safe_send_at": None,
+            },
+            "last_run": None,
+        }
 
     # ------------------------------------------------------------------
     # Outbound send tracking

--- a/libs/providers/linkedin/provider.py
+++ b/libs/providers/linkedin/provider.py
@@ -588,7 +588,7 @@ class LinkedInProvider:
                 "Refresh via POST /accounts/refresh and retry sync."
             ))
 
-        self._profile_id = pid
+        self._profile_id = str(pid)
         self._profile_id_error = None
         self._profile_id_fetched = True
         return self._profile_id

--- a/tests/test_list_threads.py
+++ b/tests/test_list_threads.py
@@ -669,6 +669,19 @@ class TestGetProfileId:
         # Only one HTTP call — second was cached
         assert mock_client.get.call_count == 1
 
+
+    def test_profile_id_plain_id_int_is_normalized_to_string(self, auth):
+        p = LinkedInProvider(auth=auth)
+        mock_client = MagicMock()
+        mock_client.is_closed = False
+        me_resp = MagicMock()
+        me_resp.status_code = 200
+        me_resp.headers = {"content-type": "application/json"}
+        me_resp.json.return_value = {"data": {"plainId": 12345}}
+        mock_client.get.return_value = me_resp
+        with _patch_client(mock_client):
+            assert p._get_profile_id() == "12345"
+
     def test_profile_id_redirect_raises_permission_error_and_caches_failure(self, auth):
         """Redirected /me bootstrap should stay explicit, not degrade into cached None."""
         p = LinkedInProvider(auth=auth)

--- a/tests/test_ops_api.py
+++ b/tests/test_ops_api.py
@@ -1,0 +1,157 @@
+"""Tests for bearer-protected /ops API endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from libs.core import crypto
+from libs.core.models import AccountAuth
+from libs.core.storage import Storage
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "api.sqlite"))
+    monkeypatch.delenv("DESEARCH_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("DESEARCH_API_TOKEN", raising=False)
+    crypto._warned_no_key = False
+
+
+@pytest.fixture()
+def api(tmp_path, monkeypatch):
+    storage = Storage(db_path=tmp_path / "api.sqlite")
+    storage.migrate()
+    from apps.api.main import app
+    import apps.api.main as api_mod
+
+    original_storage = api_mod.storage
+    api_mod.storage = storage
+    yield TestClient(app), storage
+    api_mod.storage = original_storage
+    storage.close()
+
+
+def _seed(storage: Storage) -> tuple[int, int]:
+    aid = storage.create_account(label="ops", auth=AccountAuth(li_at="AQEDsecret", jsessionid="ajax:csrf"))
+    tid = storage.upsert_thread(account_id=aid, platform_thread_id="urn:thread:1", title="Ada")
+    storage.insert_message(
+        account_id=aid,
+        thread_id=tid,
+        platform_message_id="m1",
+        direction="in",
+        sender="Ada",
+        text="Bittensor details li_at=AQED_DO_NOT_LEAK",
+        sent_at=datetime(2026, 5, 8, 9, 30, tzinfo=timezone.utc),
+        raw=None,
+    )
+    return aid, tid
+
+
+def test_ops_routes_require_bearer_token(api, monkeypatch):
+    client, _ = api
+    monkeypatch.setenv("DESEARCH_API_TOKEN", "secret-token")
+    checks = [
+        ("GET", "/ops/status", None),
+        ("GET", "/ops/accounts/1/health", None),
+        ("POST", "/ops/auth/check", {"account_id": 1}),
+        ("POST", "/ops/sync/dry-run", {"account_id": 1}),
+        ("GET", "/ops/sync/status?account_id=1", None),
+        ("GET", "/ops/inbox?account_id=1", None),
+        ("GET", "/ops/search?account_id=1&q=x", None),
+        ("GET", "/ops/threads?account_id=1", None),
+        ("GET", "/ops/threads/1?account_id=1", None),
+        ("GET", "/ops/threads/1/messages?account_id=1", None),
+        ("POST", "/ops/drafts", {"account_id": 1, "recipient": "r", "text": "t"}),
+        ("GET", "/ops/drafts?account_id=1", None),
+        ("POST", "/ops/approvals/appr_missing/approve", None),
+        ("POST", "/ops/approvals/appr_missing/revoke", None),
+        ("GET", "/ops/approvals?account_id=1", None),
+        ("GET", "/ops/campaigns/1/status?account_id=1", None),
+        ("POST", "/ops/campaigns/1/run-dry-run", {"account_id": 1}),
+        ("POST", "/ops/send-approved", {"approval_id": "x", "account_id": 1, "recipient": "r", "text": "t"}),
+        ("GET", "/ops/audit?account_id=1", None),
+        ("GET", "/ops/validation/objective-73", None),
+    ]
+    for method, url, body in checks:
+        resp = client.request(method, url, json=body)
+        assert resp.status_code == 401, url
+    assert client.get("/health").status_code == 200
+
+
+def test_ops_empty_and_unknown_account_responses(api):
+    client, storage = api
+    aid = storage.create_account(label="ops", auth=AccountAuth(li_at="AQEDsecret"))
+    assert client.get("/ops/inbox", params={"account_id": aid}).json()["threads"] == []
+
+    resp = client.get("/ops/accounts/999/health")
+    assert resp.status_code == 404
+    assert resp.json()["ok"] is False
+    assert resp.json()["error"]["code"] == "account_not_found"
+
+
+def test_ops_inbox_search_threads_messages_shapes_and_redaction(api):
+    client, storage = api
+    aid, tid = _seed(storage)
+
+    inbox = client.get("/ops/inbox", params={"account_id": aid, "limit": 10}).json()
+    assert inbox["ok"] is True
+    assert inbox["threads"][0]["thread_id"] == tid
+    assert "AQED_DO_NOT_LEAK" not in str(inbox)
+
+    search = client.get("/ops/search", params={"account_id": aid, "q": "bittensor", "limit": 10}).json()
+    assert search["results"][0]["message_id"]
+    assert search["filters"] == {"from": None, "to": None, "direction": None}
+    assert "AQED_DO_NOT_LEAK" not in str(search)
+
+    detail = client.get(f"/ops/threads/{tid}", params={"account_id": aid}).json()
+    assert detail["thread"]["id"] == tid
+
+    messages = client.get(f"/ops/threads/{tid}/messages", params={"account_id": aid}).json()
+    assert messages["thread_id"] == tid
+    assert messages["messages"][0]["text"].endswith("[REDACTED]")
+
+
+def test_ops_limit_validation_and_draft_flow(api):
+    client, storage = api
+    aid, tid = _seed(storage)
+    assert client.get("/ops/inbox", params={"account_id": aid, "limit": 0}).status_code == 422
+
+    draft_resp = client.post(
+        "/ops/drafts",
+        json={"account_id": aid, "thread_id": tid, "recipient": "urn:li:member:1", "text": "hello", "idempotency_key": "idem"},
+    )
+    assert draft_resp.status_code == 200
+    draft = draft_resp.json()
+    assert draft["approval_state"] == "draft"
+
+    approved = client.post(f"/ops/approvals/{draft['approval_id']}/approve").json()
+    assert approved["approval"]["state"] == "approved"
+
+    approvals = client.get("/ops/approvals", params={"account_id": aid, "state": "approved"}).json()
+    assert approvals["approvals"][0]["approval_id"] == draft["approval_id"]
+
+
+def test_ops_dry_run_sync_status_audit_and_send_approved_reject(api):
+    client, storage = api
+    aid, _ = _seed(storage)
+    dry = client.post("/ops/sync/dry-run", json={"account_id": aid, "limit_per_thread": 25}).json()
+    assert dry["dry_run"] is True
+    assert dry["external_writes"] == 0
+
+    status = client.get("/ops/sync/status", params={"account_id": aid}).json()
+    assert status["ok"] is True
+    assert status["last_sync"] is None
+
+    rejected = client.post(
+        "/ops/send-approved",
+        json={"approval_id": "appr_missing", "account_id": aid, "recipient": "r", "text": "hello"},
+    )
+    assert rejected.status_code == 409
+    assert rejected.json()["error"]["code"] == "approval_required"
+    assert rejected.json()["external_writes"] == 0
+
+    audit = client.get("/ops/audit", params={"account_id": aid}).json()
+    assert audit["ok"] is True

--- a/tests/test_ops_api.py
+++ b/tests/test_ops_api.py
@@ -58,6 +58,7 @@ def test_ops_routes_require_bearer_token(api, monkeypatch):
         ("GET", "/ops/accounts/1/health", None),
         ("POST", "/ops/auth/check", {"account_id": 1}),
         ("POST", "/ops/sync/dry-run", {"account_id": 1}),
+        ("POST", "/ops/sync/run", {"account_id": 1, "confirm_external_read": True}),
         ("GET", "/ops/sync/status?account_id=1", None),
         ("GET", "/ops/inbox?account_id=1", None),
         ("GET", "/ops/search?account_id=1&q=x", None),
@@ -113,6 +114,86 @@ def test_ops_inbox_search_threads_messages_shapes_and_redaction(api):
     assert messages["thread_id"] == tid
     assert messages["messages"][0]["text"].endswith("[REDACTED]")
 
+
+def test_ops_sync_run_requires_explicit_external_read_confirmation(api):
+    client, storage = api
+    aid, _ = _seed(storage)
+
+    resp = client.post("/ops/sync/run", json={"account_id": aid})
+
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "external_read_confirmation_required"
+    assert body["external_reads"] == 0
+    assert body["external_writes"] == 0
+
+
+def test_ops_sync_run_executes_read_sync_and_records_redacted_audit(api, monkeypatch):
+    client, storage = api
+    aid, _ = _seed(storage)
+    captured: dict = {}
+
+    def fake_run_sync(**kwargs):
+        captured.update(kwargs)
+        from libs.core.job_runner import SyncResult
+
+        return SyncResult(
+            synced_threads=2,
+            messages_inserted=3,
+            messages_skipped_duplicate=1,
+            pages_fetched=2,
+            rate_limited=False,
+        )
+
+    monkeypatch.setattr("apps.api.main.run_sync", fake_run_sync)
+
+    resp = client.post(
+        "/ops/sync/run",
+        json={
+            "account_id": aid,
+            "confirm_external_read": True,
+            "x_li_track": "TRACK",
+            "csrf_token": "CSRF",
+            "delay_between_threads_s": 0,
+            "delay_between_pages_s": 0,
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["synced_threads"] == 2
+    assert body["messages_inserted"] == 3
+    assert body["external_reads"] == 1
+    assert body["external_writes"] == 0
+    assert captured["account_id"] == aid
+    assert captured["x_li_track"] == "TRACK"
+    assert captured["csrf_token"] == "CSRF"
+
+    audit = client.get("/ops/audit", params={"account_id": aid}).json()
+    assert audit["events"][0]["event_type"] == "sync.completed"
+    assert audit["events"][0]["payload"]["messages_inserted"] == 3
+
+
+
+def test_ops_sync_run_provider_failure_returns_redacted_json(api, monkeypatch):
+    client, storage = api
+    aid, _ = _seed(storage)
+
+    def fake_run_sync(**kwargs):
+        raise RuntimeError("LinkedIn /voyager/api/me bootstrap failed li_at=SECRET")
+
+    monkeypatch.setattr("apps.api.main.run_sync", fake_run_sync)
+
+    resp = client.post(
+        "/ops/sync/run",
+        json={"account_id": aid, "confirm_external_read": True},
+    )
+
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "sync_failed"
+    assert "SECRET" not in str(body)
 
 def test_ops_limit_validation_and_draft_flow(api):
     client, storage = api

--- a/tests/test_ops_console_ui.py
+++ b/tests/test_ops_console_ui.py
@@ -1,0 +1,32 @@
+"""Tests for the local operator console UI shell."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+
+
+UI_ROOT = Path("apps/ui")
+
+
+def test_ops_console_is_served_by_fastapi():
+    client = TestClient(app)
+    resp = client.get("/console")
+    assert resp.status_code == 200
+    assert "LinkedIn Ops Console" in resp.text
+    assert "Inbox & Search" in resp.text
+    assert "Account Health" in resp.text
+    assert "Draft Approval" in resp.text
+
+
+def test_ops_console_uses_ops_api_not_sqlite_or_secrets():
+    js = (UI_ROOT / "app.js").read_text()
+    assert "/ops/inbox" in js
+    assert "/ops/search" in js
+    assert "/ops/send-approved" in js
+    assert "sqlite" not in js.lower()
+    assert "li_at" not in js
+    assert "csrf" not in js.lower()

--- a/tests/test_ops_storage.py
+++ b/tests/test_ops_storage.py
@@ -1,0 +1,147 @@
+"""Tests for the local Ops Console storage query layer."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from libs.core import crypto
+from libs.core.models import AccountAuth, BrowserContext
+from libs.core.storage import Storage
+
+
+@pytest.fixture(autouse=True)
+def _storage_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("DESEARCH_DB_PATH", str(tmp_path / "ops.sqlite"))
+    monkeypatch.delenv("DESEARCH_ENCRYPTION_KEY", raising=False)
+    crypto._warned_no_key = False
+
+
+@pytest.fixture
+def storage(tmp_path):
+    s = Storage(db_path=tmp_path / "ops.sqlite")
+    s.migrate()
+    yield s
+    s.close()
+
+
+def _populate(storage: Storage) -> tuple[int, int, int]:
+    aid = storage.create_account(label="ops", auth=AccountAuth(li_at="AQEDsecret", jsessionid="ajax:csrf"))
+    storage.update_browser_context(aid, BrowserContext(x_li_track='{"safe":true}', csrf_token="ajax:ctx"))
+    t1 = storage.upsert_thread(account_id=aid, platform_thread_id="urn:thread:1", title="Ada")
+    t2 = storage.upsert_thread(account_id=aid, platform_thread_id="urn:thread:2", title="Grace")
+    storage.insert_message(
+        account_id=aid,
+        thread_id=t1,
+        platform_message_id="m1",
+        direction="in",
+        sender="Ada",
+        text="Bittensor launch details li_at=AQED_DO_NOT_LEAK csrf_token=ajax:DO_NOT_LEAK",
+        sent_at=datetime(2026, 5, 8, 9, 30, tzinfo=timezone.utc),
+        raw={"x": 1},
+    )
+    storage.insert_message(
+        account_id=aid,
+        thread_id=t1,
+        platform_message_id="m2",
+        direction="out",
+        sender=None,
+        text="Thanks, this is helpful.",
+        sent_at=datetime(2026, 5, 10, 11, 55, tzinfo=timezone.utc),
+        raw=None,
+    )
+    storage.insert_message(
+        account_id=aid,
+        thread_id=t2,
+        platform_message_id="m3",
+        direction="in",
+        sender="Grace",
+        text="Another conversation",
+        sent_at=datetime(2026, 5, 9, 10, 0, tzinfo=timezone.utc),
+        raw=None,
+    )
+    return aid, t1, t2
+
+
+def test_migrate_adds_ops_tables_and_keeps_current_version(storage):
+    tables = {r[0] for r in storage._conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {"draft_replies", "send_approvals", "campaigns", "campaign_recipients", "ops_audit_events"} <= tables
+    assert storage._get_schema_version() >= 5
+
+
+def test_account_ops_health_is_safe_and_counts_empty_db(storage):
+    aid = storage.create_account(label="ops", auth=AccountAuth(li_at="AQEDsecret", jsessionid=None))
+    health = storage.get_account_ops_health(aid)
+    assert health["account_id"] == aid
+    assert health["session"] == {"has_li_at": True, "has_jsessionid": False, "has_browser_context": False, "expires_at": None}
+    assert health["counts"]["threads"] == 0
+    assert "AQEDsecret" not in str(health)
+
+
+def test_inbox_thread_messages_search_and_pagination_are_redacted(storage):
+    aid, t1, _ = _populate(storage)
+
+    page1 = storage.list_inbox_threads(account_id=aid, limit=1, cursor=None)
+    assert len(page1["threads"]) == 1
+    assert page1["page"]["next_cursor"] == "1"
+    assert page1["threads"][0]["last_message_preview"] == "Thanks, this is helpful."
+
+    page2 = storage.list_inbox_threads(account_id=aid, limit=1, cursor=page1["page"]["next_cursor"])
+    assert len(page2["threads"]) == 1
+
+    messages = storage.list_thread_messages(account_id=aid, thread_id=t1, limit=10, cursor=None)
+    assert messages["messages"][0]["raw_available"] is True
+    joined = str(messages)
+    assert "AQED_DO_NOT_LEAK" not in joined
+    assert "ajax:DO_NOT_LEAK" not in joined
+    assert "[REDACTED]" in joined
+
+    search = storage.search_messages(account_id=aid, query="bittensor", direction="in", limit=10, cursor=None)
+    assert search["fts"] is False
+    assert search["results"][0]["thread_id"] == t1
+    assert "Bittensor" in search["results"][0]["text_snippet"]
+    assert "AQED_DO_NOT_LEAK" not in str(search)
+
+
+def test_ops_helpers_raise_for_unknown_account_and_thread(storage):
+    with pytest.raises(KeyError):
+        storage.get_account_ops_health(999)
+    with pytest.raises(KeyError):
+        storage.list_inbox_threads(account_id=999, limit=25, cursor=None)
+
+    aid = storage.create_account(label="ops", auth=AccountAuth(li_at="AQEDsecret"))
+    with pytest.raises(KeyError):
+        storage.get_thread_detail(account_id=aid, thread_id=999)
+
+
+def test_draft_approval_audit_helpers(storage):
+    aid, t1, _ = _populate(storage)
+    draft = storage.create_draft_reply(
+        account_id=aid,
+        thread_id=t1,
+        recipient="urn:li:member:1",
+        text="hello token=DO_NOT_LEAK",
+        campaign_id=None,
+        idempotency_key="idem-1",
+    )
+    assert draft["approval_state"] == "draft"
+    assert draft["external_writes"] == 0
+    assert "DO_NOT_LEAK" not in draft["preview"]
+
+    approval = storage.approve_send_approval(draft["approval_id"], approved_by="tester")
+    assert approval["state"] == "approved"
+    listed = storage.list_approvals(account_id=aid, state="approved", limit=10, cursor=None)
+    assert listed["approvals"][0]["approval_id"] == draft["approval_id"]
+
+    storage.record_ops_audit_event(
+        account_id=aid,
+        event_type="sync.ingest",
+        actor="test",
+        entity_type="sync",
+        entity_id=None,
+        payload={"li_at": "AQED_DO_NOT_LEAK", "messages_inserted": 3},
+    )
+    audit = storage.list_ops_audit(account_id=aid, limit=20, cursor=None)
+    assert any(e["event_type"] == "sync.ingest" for e in audit["events"])
+    assert "AQED_DO_NOT_LEAK" not in str(audit)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -56,8 +56,8 @@ def test_schema_version_exists_after_migrate(storage):
 
 
 def test_schema_version_is_current_after_migrate(storage):
-    """Regression: migrate() leaves schema at current version (4 = browser_context)."""
-    assert storage._get_schema_version() == 4
+    """Regression: migrate() leaves schema at current version (5 = ops console contract)."""
+    assert storage._get_schema_version() == 5
 
 
 def test_migrate_idempotent(storage):
@@ -116,7 +116,7 @@ def test_migrate_upgrades_preexisting_baseline_db(tmp_path):
     s.migrate()
 
     # Verify schema_version is current.
-    assert s._get_schema_version() == 4
+    assert s._get_schema_version() == 5
 
     # Verify indexes exist.
     indexes = {r[0] for r in s._conn.execute(


### PR DESCRIPTION
## Problem
The ops console looked "ready" while showing 0 conversations, and the bearer-token field made LinkedIn auth look like the blocker even when local API auth was off.

## Root cause
The UI only exposed a dry-run sync path and unclear token copy. The backend ops contract also had no `/ops/sync/run` endpoint for the console to perform a confirmed read-only LinkedIn sync. Live validation also exposed a provider edge case where `/voyager/api/me` can return numeric `plainId`, causing the backend thread-list path to crash instead of surfacing an actionable auth/session error.

## Fix
- Added `POST /ops/sync/run` with explicit `confirm_external_read=true`, read-only sync execution, runtime header support, redacted audit evidence, and zero external writes.
- Added a visible `Sync now` console action plus clearer next-step state for empty inboxes.
- Clarified that bearer token is local API auth only, not LinkedIn login.
- Improved the empty state to tell the operator exactly how to populate Inbox/Search.
- Normalized numeric LinkedIn profile IDs to strings and returned redacted JSON errors for ops sync failures instead of 500s.

## Validation
- `uv run pytest tests/test_ops_api.py tests/test_list_threads.py -q` → 74 passed
- `uv run pytest -q` → 441 passed
- Local service restarted at `http://100.113.216.73:8899`; `/ops/status` healthy and auth_required=false
- Live `/ops/sync/run` now returns a redacted actionable 401 session-refresh error instead of crashing

## Known gaps / blockers
- I did not print or expose LinkedIn cookies/session material.
- Live inbox population is still blocked by expired/redirected LinkedIn session cookies: `POST /accounts/refresh` or Chrome extension refresh is required before real conversations can sync.

## Production expectation
Target branch is `main`. This should be reviewed/merged before calling the ops console operator-ready; main/production landing still requires Giga approval.