### PR TITLE
Build Discord Sync fixture ingestion CLI/API/UI prototype

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -10,9 +10,12 @@ from datetime import datetime
 from typing import Optional
 
 from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field, model_validator
 
 from libs.core.cookies import cookies_to_account_auth, validate_li_at
+from libs.core.discord_fixtures import DISCORD_COMMANDS
 from libs.core.job_runner import (
     IngestMessage,
     IngestThread,
@@ -36,6 +39,10 @@ app = FastAPI(title="Desearch LinkedIn DMs", version="0.0.2")
 
 storage = Storage()
 storage.migrate()
+
+_UI_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "ui"))
+if os.path.isdir(_UI_DIR):
+    app.mount("/ui/assets", StaticFiles(directory=_UI_DIR), name="ui-assets")
 
 
 def _get_api_token() -> str | None:
@@ -494,3 +501,82 @@ def list_sends(account_id: int, status: str | None = None):
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from None
     return {"sends": sends}
+
+
+@app.get("/discord/accounts", dependencies=[Depends(require_api_auth)])
+def discord_accounts():
+    """Read-only fixture Discord accounts; no credential or live-sync input accepted."""
+    return {"ok": True, "accounts": storage.list_discord_accounts()}
+
+
+@app.get("/discord/guilds", dependencies=[Depends(require_api_auth)])
+def discord_guilds():
+    return {"ok": True, "guilds": storage.list_discord_guilds()}
+
+
+@app.get("/discord/channels", dependencies=[Depends(require_api_auth)])
+def discord_channels(guild_id: str | None = None):
+    return {"ok": True, "channels": storage.list_discord_channels(guild_id=guild_id)}
+
+
+@app.get("/discord/users", dependencies=[Depends(require_api_auth)])
+def discord_users(guild_id: str | None = None):
+    return {"ok": True, "users": storage.list_discord_users(guild_id=guild_id)}
+
+
+@app.get("/discord/messages", dependencies=[Depends(require_api_auth)])
+def discord_messages(
+    account_id: str | None = None,
+    guild_id: str | None = None,
+    channel_id: str | None = None,
+    limit: int = 50,
+):
+    try:
+        messages = storage.list_discord_messages(
+            account_id=account_id,
+            guild_id=guild_id,
+            channel_id=channel_id,
+            limit=limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from None
+    return {"ok": True, "messages": messages}
+
+
+@app.get("/discord/search", dependencies=[Depends(require_api_auth)])
+def discord_search(
+    query: str,
+    account_id: str | None = None,
+    guild_id: str | None = None,
+    channel_id: str | None = None,
+    limit: int = 50,
+):
+    try:
+        messages = storage.search_discord_messages(
+            query,
+            account_id=account_id,
+            guild_id=guild_id,
+            channel_id=channel_id,
+            limit=limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from None
+    return {"ok": True, "messages": messages}
+
+
+@app.get("/discord/lead-signals", dependencies=[Depends(require_api_auth)])
+def discord_lead_signals():
+    return {"ok": True, "lead_signals": storage.list_discord_lead_signals()}
+
+
+@app.get("/discord/commands", dependencies=[Depends(require_api_auth)])
+def discord_commands():
+    return {"ok": True, "commands": DISCORD_COMMANDS}
+
+
+@app.get("/discord", include_in_schema=False)
+def discord_ui():
+    index_path = os.path.join(_UI_DIR, "index.html")
+    if not os.path.exists(index_path):
+        raise HTTPException(status_code=404, detail="Discord Sync UI not installed")
+    return FileResponse(index_path)

--- a/apps/cli/__main__.py
+++ b/apps/cli/__main__.py
@@ -14,6 +14,7 @@ from typing import Sequence
 
 import httpx
 
+from libs.core.discord_fixtures import DISCORD_COMMANDS
 from libs.core.job_runner import run_send, run_sync, SendResult, SyncConfig, SyncResult
 from libs.core.models import AccountAuth, ProxyConfig
 from libs.core.redaction import configure_logging
@@ -103,6 +104,41 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         metavar="KEY",
         help="Optional idempotency key (same as API)",
     )
+
+
+    p_discord = sub.add_parser("discord", help="Fixture-only Discord Sync prototype commands")
+    discord_sub = p_discord.add_subparsers(dest="discord_command", required=True)
+
+    p_discord_ingest = discord_sub.add_parser("fixture-ingest", help="Seed synthetic Discord Sync fixtures into SQLite")
+    p_discord_ingest.add_argument("--db-path", metavar="PATH", default=None)
+
+    p_discord_accounts = discord_sub.add_parser("list-accounts", help="List fixture Discord accounts")
+    p_discord_accounts.add_argument("--db-path", metavar="PATH", default=None)
+
+    p_discord_guilds = discord_sub.add_parser("list-guilds", help="List fixture Discord guilds")
+    p_discord_guilds.add_argument("--db-path", metavar="PATH", default=None)
+
+    p_discord_channels = discord_sub.add_parser("list-channels", help="List fixture Discord channels")
+    p_discord_channels.add_argument("--db-path", metavar="PATH", default=None)
+    p_discord_channels.add_argument("--guild-id", default=None)
+
+    p_discord_messages = discord_sub.add_parser("list-messages", help="List fixture Discord messages")
+    p_discord_messages.add_argument("--db-path", metavar="PATH", default=None)
+    p_discord_messages.add_argument("--account-id", default=None)
+    p_discord_messages.add_argument("--guild-id", default=None)
+    p_discord_messages.add_argument("--channel-id", default=None)
+    p_discord_messages.add_argument("--limit", type=int, default=50)
+
+    p_discord_search = discord_sub.add_parser("search", help="Search fixture Discord messages")
+    p_discord_search.add_argument("--db-path", metavar="PATH", default=None)
+    p_discord_search.add_argument("--query", required=True)
+    p_discord_search.add_argument("--account-id", default=None)
+    p_discord_search.add_argument("--guild-id", default=None)
+    p_discord_search.add_argument("--channel-id", default=None)
+    p_discord_search.add_argument("--limit", type=int, default=50)
+
+    p_discord_show = discord_sub.add_parser("show-commands", help="Show Discord Sync fixture CLI commands")
+    p_discord_show.add_argument("--db-path", metavar="PATH", default=None, help=argparse.SUPPRESS)
 
     args = parser.parse_args(list(argv) if argv is not None else None)
 
@@ -241,6 +277,53 @@ def _cmd_send(storage: Storage, args: argparse.Namespace) -> int:
     return 0
 
 
+
+def _cmd_discord(storage: Storage | None, args: argparse.Namespace) -> int:
+    subcommand = args.discord_command
+    if subcommand == "show-commands":
+        print(json.dumps({"ok": True, "commands": DISCORD_COMMANDS}))
+        return 0
+    if storage is None:
+        _stderr("error: storage is required for this Discord command")
+        return 1
+    try:
+        if subcommand == "fixture-ingest":
+            print(json.dumps({"ok": True, "counts": storage.ingest_discord_fixtures()}))
+        elif subcommand == "list-accounts":
+            print(json.dumps({"ok": True, "accounts": storage.list_discord_accounts()}))
+        elif subcommand == "list-guilds":
+            print(json.dumps({"ok": True, "guilds": storage.list_discord_guilds()}))
+        elif subcommand == "list-channels":
+            print(json.dumps({"ok": True, "channels": storage.list_discord_channels(guild_id=args.guild_id)}))
+        elif subcommand == "list-messages":
+            print(json.dumps({
+                "ok": True,
+                "messages": storage.list_discord_messages(
+                    account_id=args.account_id,
+                    guild_id=args.guild_id,
+                    channel_id=args.channel_id,
+                    limit=args.limit,
+                ),
+            }))
+        elif subcommand == "search":
+            print(json.dumps({
+                "ok": True,
+                "messages": storage.search_discord_messages(
+                    args.query,
+                    account_id=args.account_id,
+                    guild_id=args.guild_id,
+                    channel_id=args.channel_id,
+                    limit=args.limit,
+                ),
+            }))
+        else:
+            _stderr(f"error: unknown Discord command {subcommand!r}")
+            return 1
+    except ValueError as exc:
+        _stderr(f"error: {exc}")
+        return 1
+    return 0
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Parse CLI args, run command, return process exit code (0 = success)."""
     configure_logging()
@@ -251,6 +334,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         if code is None:
             return 0
         return int(code) if isinstance(code, int) else 1
+
+    if args.command == "discord" and args.discord_command == "show-commands":
+        return _cmd_discord(None, args)
 
     storage: Storage | None = None
     try:
@@ -268,6 +354,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return _cmd_sync(storage, args)
         if args.command == "send":
             return _cmd_send(storage, args)
+        if args.command == "discord":
+            return _cmd_discord(storage, args)
         _stderr(f"error: unknown command {args.command!r}")
         return 1
     finally:

--- a/apps/ui/app.js
+++ b/apps/ui/app.js
@@ -1,0 +1,113 @@
+const state = {
+  accounts: [],
+  guilds: [],
+  channels: [],
+};
+
+async function getJson(path) {
+  const res = await fetch(path);
+  if (!res.ok) throw new Error(`${path} failed: ${res.status}`);
+  return res.json();
+}
+
+function option(value, label) {
+  const el = document.createElement("option");
+  el.value = value;
+  el.textContent = label;
+  return el;
+}
+
+function fillSelect(id, rows, labelFor) {
+  const el = document.getElementById(id);
+  el.replaceChildren(el.firstElementChild);
+  rows.forEach((row) => el.appendChild(option(row.id, labelFor(row))));
+}
+
+function paramsFromFilters() {
+  const params = new URLSearchParams();
+  const account_id = document.getElementById("accountFilter").value;
+  const guild_id = document.getElementById("guildFilter").value;
+  const channel_id = document.getElementById("channelFilter").value;
+  if (account_id) params.set("account_id", account_id);
+  if (guild_id) params.set("guild_id", guild_id);
+  if (channel_id) params.set("channel_id", channel_id);
+  params.set("limit", "100");
+  return params;
+}
+
+function renderMessages(messages) {
+  const root = document.getElementById("messages");
+  root.replaceChildren();
+  if (!messages.length) {
+    root.textContent = "No fixture messages match the current filters.";
+    return;
+  }
+  messages.forEach((message) => {
+    const card = document.createElement("article");
+    card.className = "card";
+    card.innerHTML = `
+      <div class="meta">${message.account_label} · ${message.guild_name} / #${message.channel_name}</div>
+      <strong>${message.author_display_name}</strong>
+      <p>${message.content}</p>
+      <time>${message.sent_at}</time>
+    `;
+    root.appendChild(card);
+  });
+}
+
+function renderSignals(signals) {
+  const root = document.getElementById("signals");
+  root.replaceChildren();
+  signals.forEach((signal) => {
+    const card = document.createElement("article");
+    card.className = "card";
+    card.innerHTML = `
+      <div class="meta">${signal.keyword} · ${signal.guild_name} / #${signal.channel_name}</div>
+      <strong>${signal.topic}</strong>
+      <p>${signal.summary}</p>
+    `;
+    root.appendChild(card);
+  });
+}
+
+async function loadMessages() {
+  const query = document.getElementById("searchInput").value.trim();
+  const params = paramsFromFilters();
+  const endpoint = query ? "/discord/search" : "/discord/messages";
+  if (query) params.set("query", query);
+  const payload = await getJson(`${endpoint}?${params.toString()}`);
+  renderMessages(payload.messages || []);
+}
+
+async function boot() {
+  const [accounts, guilds, channels, commands, signals] = await Promise.all([
+    getJson("/discord/accounts"),
+    getJson("/discord/guilds"),
+    getJson("/discord/channels"),
+    getJson("/discord/commands"),
+    getJson("/discord/lead-signals"),
+  ]);
+  state.accounts = accounts.accounts || [];
+  state.guilds = guilds.guilds || [];
+  state.channels = channels.channels || [];
+  fillSelect("accountFilter", state.accounts, (row) => row.label);
+  fillSelect("guildFilter", state.guilds, (row) => row.name);
+  fillSelect("channelFilter", state.channels, (row) => `${row.guild_name} / #${row.name}`);
+
+  const commandRoot = document.getElementById("commands");
+  (commands.commands || []).forEach((command) => {
+    const item = document.createElement("li");
+    item.textContent = command;
+    commandRoot.appendChild(item);
+  });
+  renderSignals(signals.lead_signals || []);
+  await loadMessages();
+
+  ["accountFilter", "guildFilter", "channelFilter", "searchInput"].forEach((id) => {
+    document.getElementById(id).addEventListener("input", loadMessages);
+  });
+}
+
+boot().catch((error) => {
+  document.getElementById("messages").textContent = error.message;
+});

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Discord Sync Fixture Browser</title>
+    <link rel="stylesheet" href="/ui/assets/styles.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="hero">
+        <p class="eyebrow">Fixture-only prototype · no Discord credentials</p>
+        <h1>Discord Sync</h1>
+        <p>
+          Browse synthetic approved accounts, guilds, channels, users, messages,
+          keyword signals, and CLI commands before any real Discord sync exists.
+        </p>
+      </section>
+
+      <section class="panel commands">
+        <div>
+          <h2>CLI commands</h2>
+          <p>Seed locally, then browse or search the fixture dataset.</p>
+        </div>
+        <code>discord fixture-ingest</code>
+        <ul id="commands"></ul>
+      </section>
+
+      <section class="grid filters panel">
+        <label>
+          Account
+          <select id="accountFilter"><option value="">All accounts</option></select>
+        </label>
+        <label>
+          Guild
+          <select id="guildFilter"><option value="">All guilds</option></select>
+        </label>
+        <label>
+          Channel
+          <select id="channelFilter"><option value="">All channels</option></select>
+        </label>
+        <label>
+          Search
+          <input id="searchInput" placeholder="validator, lead, search API…" />
+        </label>
+      </section>
+
+      <section class="grid two-col">
+        <div class="panel">
+          <h2>Fixture messages</h2>
+          <div id="messages" class="cards"></div>
+        </div>
+        <div class="panel">
+          <h2>Lead / keyword signals</h2>
+          <div id="signals" class="cards compact"></div>
+        </div>
+      </section>
+    </main>
+    <script src="/ui/assets/app.js"></script>
+  </body>
+</html>

--- a/apps/ui/styles.css
+++ b/apps/ui/styles.css
@@ -1,0 +1,36 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0f1220;
+  color: #eef1ff;
+}
+body { margin: 0; }
+.shell { max-width: 1180px; margin: 0 auto; padding: 40px 20px; }
+.hero { margin-bottom: 24px; }
+.eyebrow { color: #8ea0ff; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; }
+h1 { font-size: clamp(42px, 8vw, 84px); line-height: .9; margin: 0 0 12px; }
+h2 { margin-top: 0; }
+.panel {
+  background: rgba(255,255,255,.07);
+  border: 1px solid rgba(255,255,255,.12);
+  border-radius: 20px;
+  padding: 20px;
+  box-shadow: 0 20px 60px rgba(0,0,0,.25);
+  margin-bottom: 20px;
+}
+.grid { display: grid; gap: 16px; }
+.filters { grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); }
+.two-col { grid-template-columns: minmax(0, 1.5fr) minmax(320px, .8fr); align-items: start; }
+label { display: grid; gap: 8px; color: #c8cffc; font-size: 14px; }
+select, input {
+  width: 100%; box-sizing: border-box; border-radius: 12px; border: 1px solid rgba(255,255,255,.18);
+  background: #171b2e; color: #fff; padding: 12px;
+}
+code { display: inline-block; background: #101525; border: 1px solid rgba(142,160,255,.35); border-radius: 10px; padding: 8px 10px; }
+.commands ul { columns: 2; padding-left: 18px; color: #dce1ff; }
+.cards { display: grid; gap: 12px; }
+.card { background: rgba(15,18,32,.76); border: 1px solid rgba(255,255,255,.1); border-radius: 16px; padding: 14px; }
+.card p { color: #d7dcff; }
+.meta, time { color: #95a0d8; font-size: 12px; }
+.compact .card p { margin-bottom: 0; }
+@media (max-width: 840px) { .two-col { grid-template-columns: 1fr; } .commands ul { columns: 1; } }

--- a/libs/core/discord_fixtures.py
+++ b/libs/core/discord_fixtures.py
@@ -1,0 +1,198 @@
+"""Fixture-only Discord Sync dataset and command metadata.
+
+No live Discord API, gateway, browser automation, user token, cookie, or credential
+material belongs in this module. These records are synthetic product-shape data
+for local prototype browsing and tests.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+DISCORD_COMMANDS = [
+    "discord fixture-ingest",
+    "discord list-messages",
+    "discord search",
+    "discord show-commands",
+    "discord fixture-ingest --db-path ./discord_sync.sqlite",
+    "discord list-accounts --db-path ./discord_sync.sqlite",
+    "discord list-guilds --db-path ./discord_sync.sqlite",
+    "discord list-channels --db-path ./discord_sync.sqlite --guild-id guild-bittensor",
+    "discord list-messages --db-path ./discord_sync.sqlite --account-id acct-growth --guild-id guild-bittensor --channel-id chan-alpha",
+    "discord search --db-path ./discord_sync.sqlite --query validator",
+    "discord show-commands",
+]
+
+_CREATED_AT = "2026-05-12T00:00:00+00:00"
+
+DISCORD_FIXTURES: dict[str, list[dict[str, Any]]] = {
+    "accounts": [
+        {
+            "id": "acct-growth",
+            "label": "Growth research bot fixture",
+            "account_type": "approved-bot-fixture",
+            "approved_scope": "fixture-only read model; no credentials or live Discord access",
+            "created_at": _CREATED_AT,
+        },
+        {
+            "id": "acct-founder-export",
+            "label": "Founder consented export fixture",
+            "account_type": "consented-export-fixture",
+            "approved_scope": "fixture-only imported export; no live sync",
+            "created_at": _CREATED_AT,
+        },
+    ],
+    "guilds": [
+        {
+            "id": "guild-bittensor",
+            "name": "Bittensor Builders",
+            "description": "Synthetic server for subnet operator and validator research signals.",
+            "created_at": _CREATED_AT,
+        },
+        {
+            "id": "guild-ai-founders",
+            "name": "AI Founders Lab",
+            "description": "Synthetic server for early-stage AI startup discovery signals.",
+            "created_at": _CREATED_AT,
+        },
+    ],
+    "channels": [
+        {
+            "id": "chan-alpha",
+            "guild_id": "guild-bittensor",
+            "name": "alpha-research",
+            "kind": "text",
+            "topic": "Subnet alpha, validator ops, launch research",
+        },
+        {
+            "id": "chan-growth",
+            "guild_id": "guild-bittensor",
+            "name": "growth-leads",
+            "kind": "text",
+            "topic": "Lead requests and partner intro opportunities",
+        },
+        {
+            "id": "chan-founder-intros",
+            "guild_id": "guild-ai-founders",
+            "name": "founder-intros",
+            "kind": "text",
+            "topic": "Founder requests, tool discovery, warm intro context",
+        },
+    ],
+    "users": [
+        {
+            "id": "user-ada",
+            "username": "ada_validator",
+            "display_name": "Ada Validator",
+            "profile_summary": "Validator operator comparing search and crawl quality tooling.",
+        },
+        {
+            "id": "user-ben",
+            "username": "ben_builder",
+            "display_name": "Ben Builder",
+            "profile_summary": "Subnet founder looking for monitoring and growth data.",
+        },
+        {
+            "id": "user-cyra",
+            "username": "cyra_growth",
+            "display_name": "Cyra Growth",
+            "profile_summary": "Growth lead tracking AI communities and warm intros.",
+        },
+        {
+            "id": "user-dev",
+            "username": "devrel_mira",
+            "display_name": "Mira DevRel",
+            "profile_summary": "DevRel operator evaluating Discord intelligence workflows.",
+        },
+        {
+            "id": "user-eli",
+            "username": "eli_founder",
+            "display_name": "Eli Founder",
+            "profile_summary": "AI founder searching for launch-partner evidence and messaging.",
+        },
+    ],
+    "members": [
+        {"guild_id": "guild-bittensor", "user_id": "user-ada", "roles": ["validator", "operator"], "joined_at": _CREATED_AT},
+        {"guild_id": "guild-bittensor", "user_id": "user-ben", "roles": ["builder"], "joined_at": _CREATED_AT},
+        {"guild_id": "guild-bittensor", "user_id": "user-cyra", "roles": ["growth"], "joined_at": _CREATED_AT},
+        {"guild_id": "guild-ai-founders", "user_id": "user-cyra", "roles": ["growth"], "joined_at": _CREATED_AT},
+        {"guild_id": "guild-ai-founders", "user_id": "user-dev", "roles": ["devrel"], "joined_at": _CREATED_AT},
+        {"guild_id": "guild-ai-founders", "user_id": "user-eli", "roles": ["founder"], "joined_at": _CREATED_AT},
+    ],
+}
+
+_MESSAGE_PLAN = [
+    ("acct-growth", "guild-bittensor", "chan-alpha", "user-ada", "Validator dashboards still miss semantic search regressions after miner updates."),
+    ("acct-growth", "guild-bittensor", "chan-alpha", "user-ben", "Looking for a crawl API that can explain why validator scores moved overnight."),
+    ("acct-growth", "guild-bittensor", "chan-alpha", "user-cyra", "Lead signal: teams asking for subnet launch monitoring need evidence packs."),
+    ("acct-growth", "guild-bittensor", "chan-alpha", "user-dev", "Could Discord topic tracking surface validator pain before support tickets arrive?"),
+    ("acct-growth", "guild-bittensor", "chan-alpha", "user-ada", "Keyword idea: validator churn, search freshness, crawler reliability."),
+    ("acct-growth", "guild-bittensor", "chan-alpha", "user-ben", "A local fixture browser would help review context before any Growth handoff."),
+    ("acct-growth", "guild-bittensor", "chan-alpha", "user-cyra", "Need human approval before turning this lead into outbound messaging."),
+    ("acct-growth", "guild-bittensor", "chan-alpha", "user-dev", "Discrawl-like account and guild filters are enough for the first prototype."),
+    ("acct-growth", "guild-bittensor", "chan-growth", "user-cyra", "Lead: validator ops teams want weekly search-quality summaries."),
+    ("acct-founder-export", "guild-bittensor", "chan-growth", "user-ben", "Partner request: compare Desearch API against generic SERP providers."),
+    ("acct-growth", "guild-bittensor", "chan-growth", "user-ada", "Evidence should quote messages and keep channel provenance visible."),
+    ("acct-founder-export", "guild-bittensor", "chan-growth", "user-cyra", "Growth draft should stay paused until Giga approves a campaign."),
+    ("acct-founder-export", "guild-bittensor", "chan-growth", "user-dev", "No outbound Discord sends from this prototype, only read-only browsing."),
+    ("acct-founder-export", "guild-ai-founders", "chan-founder-intros", "user-eli", "Founder intro request: need AI search API with citations for investor research."),
+    ("acct-growth", "guild-ai-founders", "chan-founder-intros", "user-dev", "Topic signal: local Discord intelligence can package evidence for review."),
+    ("acct-founder-export", "guild-ai-founders", "chan-founder-intros", "user-cyra", "Lead signal: founder asked for warm intro to search infrastructure teams."),
+    ("acct-founder-export", "guild-ai-founders", "chan-founder-intros", "user-eli", "Keyword tracking should catch crawl, search, validator, and outbound intent."),
+    ("acct-growth", "guild-ai-founders", "chan-founder-intros", "user-dev", "UI should browse messages by account, guild, and channel without credentials."),
+    ("acct-founder-export", "guild-ai-founders", "chan-founder-intros", "user-cyra", "Human-reviewed suggestions can later flow to Growth App, not auto-send."),
+    ("acct-growth", "guild-ai-founders", "chan-founder-intros", "user-eli", "Fixture-only seed data makes demos safe while product shape is validated."),
+]
+
+DISCORD_FIXTURES["messages"] = [
+    {
+        "id": f"msg-{idx:02d}",
+        "account_id": account_id,
+        "guild_id": guild_id,
+        "channel_id": channel_id,
+        "author_user_id": user_id,
+        "content": content,
+        "sent_at": datetime(2026, 5, 12, 9, idx, tzinfo=timezone.utc).isoformat(),
+        "raw": {"fixture": True, "sequence": idx},
+    }
+    for idx, (account_id, guild_id, channel_id, user_id, content) in enumerate(_MESSAGE_PLAN, start=1)
+]
+
+DISCORD_FIXTURES["lead_signals"] = [
+    {
+        "id": "signal-validator-quality",
+        "account_id": "acct-growth",
+        "guild_id": "guild-bittensor",
+        "channel_id": "chan-alpha",
+        "message_id": "msg-01",
+        "keyword": "validator",
+        "topic": "Subnet search quality monitoring",
+        "summary": "Validator operators are asking for explainable search/crawl quality signals.",
+        "evidence": ["msg-01", "msg-02", "msg-04"],
+        "created_at": _CREATED_AT,
+    },
+    {
+        "id": "signal-growth-evidence-pack",
+        "account_id": "acct-growth",
+        "guild_id": "guild-bittensor",
+        "channel_id": "chan-growth",
+        "message_id": "msg-09",
+        "keyword": "lead",
+        "topic": "Human-reviewed Growth evidence packs",
+        "summary": "Growth handoff needs message evidence and explicit human approval.",
+        "evidence": ["msg-09", "msg-11", "msg-12"],
+        "created_at": _CREATED_AT,
+    },
+    {
+        "id": "signal-founder-search-api",
+        "account_id": "acct-founder-export",
+        "guild_id": "guild-ai-founders",
+        "channel_id": "chan-founder-intros",
+        "message_id": "msg-14",
+        "keyword": "search API",
+        "topic": "AI founder search infrastructure intent",
+        "summary": "Founders are asking for citation-backed AI search infrastructure.",
+        "evidence": ["msg-14", "msg-16", "msg-17"],
+        "created_at": _CREATED_AT,
+    },
+]

--- a/libs/core/storage.py
+++ b/libs/core/storage.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from .crypto import decrypt_if_encrypted, encrypt_if_configured
+from .discord_fixtures import DISCORD_FIXTURES
 from .models import AccountAuth, BrowserContext, ProxyConfig
 
 
@@ -74,6 +75,86 @@ CREATE INDEX IF NOT EXISTS idx_outbound_sends_account_status ON outbound_sends(a
 
 _MIGRATION_4_BROWSER_CONTEXT = """
 ALTER TABLE accounts ADD COLUMN browser_context_json TEXT;
+"""
+
+_MIGRATION_5_DISCORD_FIXTURES = """
+CREATE TABLE IF NOT EXISTS discord_accounts (
+  id TEXT PRIMARY KEY,
+  label TEXT NOT NULL,
+  account_type TEXT NOT NULL,
+  approved_scope TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS discord_guilds (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS discord_channels (
+  id TEXT PRIMARY KEY,
+  guild_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  topic TEXT,
+  FOREIGN KEY(guild_id) REFERENCES discord_guilds(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS discord_users (
+  id TEXT PRIMARY KEY,
+  username TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  profile_summary TEXT
+);
+
+CREATE TABLE IF NOT EXISTS discord_members (
+  guild_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  roles_json TEXT NOT NULL,
+  joined_at TEXT NOT NULL,
+  PRIMARY KEY(guild_id, user_id),
+  FOREIGN KEY(guild_id) REFERENCES discord_guilds(id) ON DELETE CASCADE,
+  FOREIGN KEY(user_id) REFERENCES discord_users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS discord_messages (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  guild_id TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  author_user_id TEXT NOT NULL,
+  content TEXT NOT NULL,
+  sent_at TEXT NOT NULL,
+  raw_json TEXT,
+  FOREIGN KEY(account_id) REFERENCES discord_accounts(id) ON DELETE CASCADE,
+  FOREIGN KEY(guild_id) REFERENCES discord_guilds(id) ON DELETE CASCADE,
+  FOREIGN KEY(channel_id) REFERENCES discord_channels(id) ON DELETE CASCADE,
+  FOREIGN KEY(author_user_id) REFERENCES discord_users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS discord_lead_signals (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  guild_id TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  keyword TEXT NOT NULL,
+  topic TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  evidence_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(account_id) REFERENCES discord_accounts(id) ON DELETE CASCADE,
+  FOREIGN KEY(guild_id) REFERENCES discord_guilds(id) ON DELETE CASCADE,
+  FOREIGN KEY(channel_id) REFERENCES discord_channels(id) ON DELETE CASCADE,
+  FOREIGN KEY(message_id) REFERENCES discord_messages(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_discord_channels_guild_id ON discord_channels(guild_id);
+CREATE INDEX IF NOT EXISTS idx_discord_messages_account_id ON discord_messages(account_id);
+CREATE INDEX IF NOT EXISTS idx_discord_messages_guild_channel ON discord_messages(guild_id, channel_id);
+CREATE INDEX IF NOT EXISTS idx_discord_lead_signals_keyword ON discord_lead_signals(keyword);
 """
 
 
@@ -175,6 +256,7 @@ class Storage:
             (2, _MIGRATION_2_MESSAGES_CHECK),
             (3, _MIGRATION_3_OUTBOUND_SENDS),
             (4, _MIGRATION_4_BROWSER_CONTEXT),
+            (5, _MIGRATION_5_DISCORD_FIXTURES),
         ]
         for version, sql in migrations:
             if version > current:
@@ -467,3 +549,307 @@ class Storage:
                 (account_id,),
             ).fetchall()
         return [dict(r) for r in rows]
+
+
+    # ------------------------------------------------------------------
+    # Discord Sync fixture-only prototype storage
+    # ------------------------------------------------------------------
+
+    _DISCORD_COUNT_TABLES = {
+        "accounts": "discord_accounts",
+        "guilds": "discord_guilds",
+        "channels": "discord_channels",
+        "users": "discord_users",
+        "members": "discord_members",
+        "messages": "discord_messages",
+        "lead_signals": "discord_lead_signals",
+    }
+
+    def ingest_discord_fixtures(self) -> dict[str, int]:
+        """Upsert the synthetic Discord Sync fixture dataset.
+
+        This deliberately does not accept tokens, cookies, emails, passwords, or
+        live-sync configuration. It is a local seed path for the fixture-only
+        Discord Sync prototype.
+        """
+        data = DISCORD_FIXTURES
+        with self._conn:
+            self._conn.executemany(
+                """
+                INSERT INTO discord_accounts(id, label, account_type, approved_scope, created_at)
+                VALUES (:id, :label, :account_type, :approved_scope, :created_at)
+                ON CONFLICT(id) DO UPDATE SET
+                  label=excluded.label,
+                  account_type=excluded.account_type,
+                  approved_scope=excluded.approved_scope,
+                  created_at=excluded.created_at
+                """,
+                data["accounts"],
+            )
+            self._conn.executemany(
+                """
+                INSERT INTO discord_guilds(id, name, description, created_at)
+                VALUES (:id, :name, :description, :created_at)
+                ON CONFLICT(id) DO UPDATE SET
+                  name=excluded.name,
+                  description=excluded.description,
+                  created_at=excluded.created_at
+                """,
+                data["guilds"],
+            )
+            self._conn.executemany(
+                """
+                INSERT INTO discord_channels(id, guild_id, name, kind, topic)
+                VALUES (:id, :guild_id, :name, :kind, :topic)
+                ON CONFLICT(id) DO UPDATE SET
+                  guild_id=excluded.guild_id,
+                  name=excluded.name,
+                  kind=excluded.kind,
+                  topic=excluded.topic
+                """,
+                data["channels"],
+            )
+            self._conn.executemany(
+                """
+                INSERT INTO discord_users(id, username, display_name, profile_summary)
+                VALUES (:id, :username, :display_name, :profile_summary)
+                ON CONFLICT(id) DO UPDATE SET
+                  username=excluded.username,
+                  display_name=excluded.display_name,
+                  profile_summary=excluded.profile_summary
+                """,
+                data["users"],
+            )
+            self._conn.executemany(
+                """
+                INSERT INTO discord_members(guild_id, user_id, roles_json, joined_at)
+                VALUES (:guild_id, :user_id, :roles_json, :joined_at)
+                ON CONFLICT(guild_id, user_id) DO UPDATE SET
+                  roles_json=excluded.roles_json,
+                  joined_at=excluded.joined_at
+                """,
+                [
+                    {**member, "roles_json": json.dumps(member["roles"])}
+                    for member in data["members"]
+                ],
+            )
+            self._conn.executemany(
+                """
+                INSERT INTO discord_messages(
+                  id, account_id, guild_id, channel_id, author_user_id, content, sent_at, raw_json
+                ) VALUES (:id, :account_id, :guild_id, :channel_id, :author_user_id, :content, :sent_at, :raw_json)
+                ON CONFLICT(id) DO UPDATE SET
+                  account_id=excluded.account_id,
+                  guild_id=excluded.guild_id,
+                  channel_id=excluded.channel_id,
+                  author_user_id=excluded.author_user_id,
+                  content=excluded.content,
+                  sent_at=excluded.sent_at,
+                  raw_json=excluded.raw_json
+                """,
+                [
+                    {**message, "raw_json": json.dumps(message.get("raw") or {})}
+                    for message in data["messages"]
+                ],
+            )
+            self._conn.executemany(
+                """
+                INSERT INTO discord_lead_signals(
+                  id, account_id, guild_id, channel_id, message_id, keyword, topic, summary, evidence_json, created_at
+                ) VALUES (
+                  :id, :account_id, :guild_id, :channel_id, :message_id, :keyword, :topic, :summary, :evidence_json, :created_at
+                )
+                ON CONFLICT(id) DO UPDATE SET
+                  account_id=excluded.account_id,
+                  guild_id=excluded.guild_id,
+                  channel_id=excluded.channel_id,
+                  message_id=excluded.message_id,
+                  keyword=excluded.keyword,
+                  topic=excluded.topic,
+                  summary=excluded.summary,
+                  evidence_json=excluded.evidence_json,
+                  created_at=excluded.created_at
+                """,
+                [
+                    {**signal, "evidence_json": json.dumps(signal["evidence"])}
+                    for signal in data["lead_signals"]
+                ],
+            )
+        return self.discord_fixture_counts()
+
+    def discord_fixture_counts(self) -> dict[str, int]:
+        return {
+            key: int(self._conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+            for key, table in self._DISCORD_COUNT_TABLES.items()
+        }
+
+    def list_discord_accounts(self) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            """
+            SELECT a.*, COUNT(m.id) AS message_count
+            FROM discord_accounts a
+            LEFT JOIN discord_messages m ON m.account_id = a.id
+            GROUP BY a.id
+            ORDER BY a.label
+            """
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def list_discord_guilds(self) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            """
+            SELECT g.*, COUNT(DISTINCT c.id) AS channel_count, COUNT(m.id) AS message_count
+            FROM discord_guilds g
+            LEFT JOIN discord_channels c ON c.guild_id = g.id
+            LEFT JOIN discord_messages m ON m.guild_id = g.id
+            GROUP BY g.id
+            ORDER BY g.name
+            """
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def list_discord_channels(self, *, guild_id: str | None = None) -> list[dict[str, Any]]:
+        params: list[Any] = []
+        where = ""
+        if guild_id:
+            where = "WHERE c.guild_id = ?"
+            params.append(guild_id)
+        rows = self._conn.execute(
+            f"""
+            SELECT c.*, g.name AS guild_name, COUNT(m.id) AS message_count
+            FROM discord_channels c
+            JOIN discord_guilds g ON g.id = c.guild_id
+            LEFT JOIN discord_messages m ON m.channel_id = c.id
+            {where}
+            GROUP BY c.id
+            ORDER BY g.name, c.name
+            """,
+            params,
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def list_discord_users(self, *, guild_id: str | None = None) -> list[dict[str, Any]]:
+        if guild_id:
+            rows = self._conn.execute(
+                """
+                SELECT u.*, dm.guild_id, dm.roles_json
+                FROM discord_members dm
+                JOIN discord_users u ON u.id = dm.user_id
+                WHERE dm.guild_id = ?
+                ORDER BY u.display_name
+                """,
+                (guild_id,),
+            ).fetchall()
+        else:
+            rows = self._conn.execute("SELECT * FROM discord_users ORDER BY display_name").fetchall()
+        return [self._decode_discord_json_columns(dict(row)) for row in rows]
+
+    def list_discord_messages(
+        self,
+        *,
+        account_id: str | None = None,
+        guild_id: str | None = None,
+        channel_id: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        if limit < 1 or limit > 500:
+            raise ValueError("limit must be between 1 and 500")
+        clauses: list[str] = []
+        params: list[Any] = []
+        for column, value in (
+            ("m.account_id", account_id),
+            ("m.guild_id", guild_id),
+            ("m.channel_id", channel_id),
+        ):
+            if value:
+                clauses.append(f"{column} = ?")
+                params.append(value)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = self._conn.execute(
+            f"""
+            SELECT
+              m.id, m.account_id, a.label AS account_label,
+              m.guild_id, g.name AS guild_name,
+              m.channel_id, c.name AS channel_name,
+              m.author_user_id, u.display_name AS author_display_name, u.username AS author_username,
+              m.content, m.sent_at, m.raw_json
+            FROM discord_messages m
+            JOIN discord_accounts a ON a.id = m.account_id
+            JOIN discord_guilds g ON g.id = m.guild_id
+            JOIN discord_channels c ON c.id = m.channel_id
+            JOIN discord_users u ON u.id = m.author_user_id
+            {where}
+            ORDER BY m.sent_at ASC, m.id ASC
+            LIMIT ?
+            """,
+            [*params, limit],
+        ).fetchall()
+        return [self._decode_discord_json_columns(dict(row)) for row in rows]
+
+    def search_discord_messages(
+        self,
+        query: str,
+        *,
+        account_id: str | None = None,
+        guild_id: str | None = None,
+        channel_id: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        normalized = query.strip().lower()
+        if not normalized:
+            raise ValueError("query must be non-empty")
+        clauses = ["LOWER(m.content) LIKE ?"]
+        params: list[Any] = [f"%{normalized}%"]
+        for column, value in (
+            ("m.account_id", account_id),
+            ("m.guild_id", guild_id),
+            ("m.channel_id", channel_id),
+        ):
+            if value:
+                clauses.append(f"{column} = ?")
+                params.append(value)
+        rows = self._conn.execute(
+            f"""
+            SELECT
+              m.id, m.account_id, a.label AS account_label,
+              m.guild_id, g.name AS guild_name,
+              m.channel_id, c.name AS channel_name,
+              m.author_user_id, u.display_name AS author_display_name, u.username AS author_username,
+              m.content, m.sent_at, m.raw_json
+            FROM discord_messages m
+            JOIN discord_accounts a ON a.id = m.account_id
+            JOIN discord_guilds g ON g.id = m.guild_id
+            JOIN discord_channels c ON c.id = m.channel_id
+            JOIN discord_users u ON u.id = m.author_user_id
+            WHERE {' AND '.join(clauses)}
+            ORDER BY m.sent_at ASC, m.id ASC
+            LIMIT ?
+            """,
+            [*params, limit],
+        ).fetchall()
+        return [self._decode_discord_json_columns(dict(row)) for row in rows]
+
+    def list_discord_lead_signals(self) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            """
+            SELECT
+              s.*, a.label AS account_label, g.name AS guild_name, c.name AS channel_name,
+              m.content AS evidence_message
+            FROM discord_lead_signals s
+            JOIN discord_accounts a ON a.id = s.account_id
+            JOIN discord_guilds g ON g.id = s.guild_id
+            JOIN discord_channels c ON c.id = s.channel_id
+            JOIN discord_messages m ON m.id = s.message_id
+            ORDER BY s.created_at ASC, s.id ASC
+            """
+        ).fetchall()
+        return [self._decode_discord_json_columns(dict(row)) for row in rows]
+
+    def _decode_discord_json_columns(self, row: dict[str, Any]) -> dict[str, Any]:
+        if row.get("raw_json") is not None:
+            row["raw"] = json.loads(row.pop("raw_json") or "{}")
+        if row.get("roles_json") is not None:
+            row["roles"] = json.loads(row.pop("roles_json") or "[]")
+        if row.get("evidence_json") is not None:
+            row["evidence"] = json.loads(row.pop("evidence_json") or "[]")
+        return row

--- a/tests/test_discord_sync.py
+++ b/tests/test_discord_sync.py
@@ -1,0 +1,160 @@
+"""Discord Sync fixture prototype tests."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.cli import __main__ as cli_main
+from libs.core.storage import Storage
+
+
+@pytest.fixture
+def discord_db_path(tmp_path: Path) -> str:
+    return str(tmp_path / "discord-sync.sqlite")
+
+
+@pytest.fixture
+def discord_storage(discord_db_path: str) -> Storage:
+    storage = Storage(db_path=discord_db_path)
+    storage.migrate()
+    yield storage
+    storage.close()
+
+
+def test_discord_fixture_ingest_is_idempotent_and_persists_minimum_dataset(discord_storage: Storage) -> None:
+    first = discord_storage.ingest_discord_fixtures()
+    second = discord_storage.ingest_discord_fixtures()
+
+    assert first == {
+        "accounts": 2,
+        "guilds": 2,
+        "channels": 3,
+        "users": 5,
+        "members": 6,
+        "messages": 20,
+        "lead_signals": 3,
+    }
+    assert second == first
+
+    conn = sqlite3.connect(discord_storage.db_path)
+    counts = {
+        table: conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        for table in (
+            "discord_accounts",
+            "discord_guilds",
+            "discord_channels",
+            "discord_users",
+            "discord_members",
+            "discord_messages",
+            "discord_lead_signals",
+        )
+    }
+    conn.close()
+    assert counts == {
+        "discord_accounts": 2,
+        "discord_guilds": 2,
+        "discord_channels": 3,
+        "discord_users": 5,
+        "discord_members": 6,
+        "discord_messages": 20,
+        "discord_lead_signals": 3,
+    }
+
+
+def test_discord_message_list_and_search_filters_by_account_guild_channel(discord_storage: Storage) -> None:
+    discord_storage.ingest_discord_fixtures()
+
+    messages = discord_storage.list_discord_messages(
+        account_id="acct-growth", guild_id="guild-bittensor", channel_id="chan-alpha"
+    )
+    assert len(messages) == 8
+    assert messages[0]["account_label"] == "Growth research bot fixture"
+    assert messages[0]["guild_name"] == "Bittensor Builders"
+    assert messages[0]["channel_name"] == "alpha-research"
+
+    search = discord_storage.search_discord_messages("validator", guild_id="guild-bittensor")
+    assert search
+    assert all("validator" in (row["content"] or "").lower() for row in search)
+
+
+def test_discord_cli_ingest_list_search_and_show_commands(capsys: pytest.CaptureFixture[str], discord_db_path: str) -> None:
+    rc = cli_main.main(["discord", "fixture-ingest", "--db-path", discord_db_path])
+    assert rc == 0
+    ingest = json.loads(capsys.readouterr().out)
+    assert ingest["ok"] is True
+    assert ingest["counts"]["messages"] == 20
+
+    rc = cli_main.main(["discord", "list-messages", "--db-path", discord_db_path, "--channel-id", "chan-alpha"])
+    assert rc == 0
+    listed = json.loads(capsys.readouterr().out)
+    assert listed["ok"] is True
+    assert len(listed["messages"]) == 8
+
+    rc = cli_main.main(["discord", "search", "--db-path", discord_db_path, "--query", "lead"])
+    assert rc == 0
+    results = json.loads(capsys.readouterr().out)
+    assert results["ok"] is True
+    assert results["messages"]
+
+    rc = cli_main.main(["discord", "show-commands"])
+    assert rc == 0
+    commands = json.loads(capsys.readouterr().out)
+    assert commands["ok"] is True
+    assert "discord fixture-ingest" in commands["commands"]
+    assert "discord list-messages" in commands["commands"]
+    assert "discord search" in commands["commands"]
+    assert "discord show-commands" in commands["commands"]
+
+
+def test_discord_api_read_only_contract_and_no_live_sync_endpoint(discord_storage: Storage) -> None:
+    discord_storage.ingest_discord_fixtures()
+
+    import apps.api.main as api_mod
+
+    original_storage = api_mod.storage
+    api_mod.storage = discord_storage
+    try:
+        client = TestClient(api_mod.app)
+        accounts = client.get("/discord/accounts")
+        assert accounts.status_code == 200
+        assert len(accounts.json()["accounts"]) == 2
+
+        messages = client.get(
+            "/discord/messages",
+            params={"account_id": "acct-growth", "guild_id": "guild-bittensor", "channel_id": "chan-alpha"},
+        )
+        assert messages.status_code == 200
+        payload = messages.json()
+        assert payload["ok"] is True
+        assert len(payload["messages"]) == 8
+        assert {"account_label", "guild_name", "channel_name", "author_display_name"} <= set(payload["messages"][0])
+
+        signals = client.get("/discord/lead-signals")
+        assert signals.status_code == 200
+        assert len(signals.json()["lead_signals"]) == 3
+
+        commands = client.get("/discord/commands")
+        assert commands.status_code == 200
+        assert "discord fixture-ingest" in commands.json()["commands"]
+
+        rejected = client.post("/discord/sync", json={"token": "should-not-exist"})
+        assert rejected.status_code == 404
+    finally:
+        api_mod.storage = original_storage
+
+
+def test_discord_ui_static_assets_reference_commands_and_browser() -> None:
+    root = Path("apps/ui")
+    html = (root / "index.html").read_text()
+    js = (root / "app.js").read_text()
+
+    assert "Discord Sync" in html
+    assert "discord fixture-ingest" in html
+    assert "/discord/messages" in js
+    assert "account_id" in js
+    assert "guild_id" in js
+    assert "channel_id" in js

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -56,8 +56,8 @@ def test_schema_version_exists_after_migrate(storage):
 
 
 def test_schema_version_is_current_after_migrate(storage):
-    """Regression: migrate() leaves schema at current version (4 = browser_context)."""
-    assert storage._get_schema_version() == 4
+    """Regression: migrate() leaves schema at current version (5 = Discord fixtures)."""
+    assert storage._get_schema_version() == 5
 
 
 def test_migrate_idempotent(storage):
@@ -116,7 +116,7 @@ def test_migrate_upgrades_preexisting_baseline_db(tmp_path):
     s.migrate()
 
     # Verify schema_version is current.
-    assert s._get_schema_version() == 4
+    assert s._get_schema_version() == 5
 
     # Verify indexes exist.
     indexes = {r[0] for r in s._conn.execute(


### PR DESCRIPTION
## Problem
Giga needed the first runnable Discord Sync local prototype showing the Discrawl-like shape: fixture-only SQLite data, CLI commands, read-only API endpoints, and a small UI browser for accounts/guilds/channels/messages without any Discord credentials or live sync.

## Root cause
The repo only had the LinkedIn DMS storage/API/CLI paths. There were no Discord-specific tables, fixtures, read models, commands, routes, or UI assets yet.

## Fix
- Added synthetic fixture data and command metadata in `libs/core/discord_fixtures.py:12`, `libs/core/discord_fixtures.py:28`, `libs/core/discord_fixtures.py:147`, and `libs/core/discord_fixtures.py:161` with 2 accounts, 2 guilds, 3 channels, 5 users, 6 memberships, 20 messages, and 3 lead/keyword signals.
- Added SQLite Discord fixture schema migration in `libs/core/storage.py:80` plus idempotent fixture ingestion and read/search helpers in `libs/core/storage.py:568`, `libs/core/storage.py:747`, `libs/core/storage.py:789`, and `libs/core/storage.py:839`.
- Added fixture-only Discord CLI commands in `apps/cli/__main__.py:109` and handlers in `apps/cli/__main__.py:281`: `fixture-ingest`, `list-accounts`, `list-guilds`, `list-channels`, `list-messages`, `search`, and `show-commands`.
- Added read-only Discord API endpoints in `apps/api/main.py:506` through `apps/api/main.py:574`; no `/discord/sync` or credential-taking Discord route was added.
- Added a static UI prototype served from `apps/api/main.py:43` and `apps/api/main.py:577`, with browser/filter UI in `apps/ui/index.html:20`, API-backed message loading in `apps/ui/app.js:34`, and styling in `apps/ui/styles.css:1`.
- Updated storage schema version expectations in `tests/test_storage.py:58` and `tests/test_storage.py:119`.

## Validation
- Added `tests/test_discord_sync.py:28` for fixture ingest idempotency and persisted table counts.
- Added `tests/test_discord_sync.py:68` for account/guild/channel filtered message listing and search.
- Added `tests/test_discord_sync.py:84` for Discord CLI ingest/list/search/show-command behavior.
- Added `tests/test_discord_sync.py:113` for read-only API data contract and confirming `POST /discord/sync` is absent.
- Added `tests/test_discord_sync.py:150` for UI asset contract coverage.
- Ran `uv run pytest` → 430 passed.
- Ran `uv run python -m compileall apps libs` → passed.
- Committed changes: `4f8ac76 feat(#1673): add Discord Sync fixture prototype`.

## Known gaps/blockers
Fixture-only by design. The UI expects the local SQLite DB to be seeded with `python -m apps.cli discord fixture-ingest --db-path ...` before it has messages to show. No live Discord API/gateway/selfbot sync, no credential capture, no Growth export, and no outbound Discord sends are implemented.

## Production expectation
After merge, operators can seed synthetic Discord Sync data locally, inspect it via CLI/API/UI, and review the product shape safely. Any future real Discord sync, Growth handoff, or outbound campaign flow still requires explicit scoped human approval and anti-spam/safety controls.

---
Task: #1673 — Build Discord Sync fixture ingestion CLI/API/UI prototype
Opened automatically by mission-control dispatcher.